### PR TITLE
feat(composer): add slash command autocomplete

### DIFF
--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -1,15 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useProjectStore } from "../stores/projectStore";
 import { useComposerStore } from "../stores/composerStore";
 import { useNotificationStore } from "../stores/notificationStore";
 import { useCanvasStore } from "../stores/canvasStore";
 import { getComposerAdapter } from "../terminal/cliConfig";
+import { filterSlashCommands } from "../terminal/slashCommands";
 import { shouldSubmitComposerFromKeyEvent } from "./composerInputBehavior";
 import {
   getComposerTargetState,
   getSupportedTerminals,
   resolveComposerTarget,
 } from "./composerTarget";
+import { SlashCommandMenu } from "./SlashCommandMenu";
 import { useT } from "../i18n/useT";
 import type {
   ComposerImageAttachment,
@@ -143,6 +145,42 @@ export function ComposerBar() {
     ? getComposerAdapter(targetTerminal.type)
     : null;
   const isTargetReady = targetState === "ready";
+
+  // Slash command autocomplete state
+  const [slashMenuOpen, setSlashMenuOpen] = useState(false);
+  const [slashSelectedIndex, setSlashSelectedIndex] = useState(0);
+
+  const slashCommands = useMemo(() => {
+    if (!slashMenuOpen || !targetTerminal) return [];
+    // Extract the query after "/"
+    const query = draft.startsWith("/") ? draft.slice(1) : "";
+    return filterSlashCommands(targetTerminal.type, query);
+  }, [slashMenuOpen, targetTerminal, draft]);
+
+  // Open/close menu based on draft content
+  useEffect(() => {
+    if (draft.startsWith("/") && targetTerminal) {
+      const commands = filterSlashCommands(
+        targetTerminal.type,
+        draft.slice(1),
+      );
+      if (commands.length > 0) {
+        setSlashMenuOpen(true);
+        setSlashSelectedIndex(0);
+        return;
+      }
+    }
+    setSlashMenuOpen(false);
+  }, [draft, targetTerminal]);
+
+  const handleSlashSelect = useCallback(
+    (command: string) => {
+      setDraft(command);
+      setSlashMenuOpen(false);
+      textareaRef.current?.focus();
+    },
+    [setDraft],
+  );
 
   // Auto-focus Composer when target terminal changes so the user can
   // start typing immediately without an extra click.
@@ -377,12 +415,48 @@ export function ComposerBar() {
         {/* Input area */}
         <div className="px-3 py-2">
           <div className="relative">
+            {slashMenuOpen && slashCommands.length > 0 && (
+              <SlashCommandMenu
+                commands={slashCommands}
+                selectedIndex={slashSelectedIndex}
+                onSelect={handleSlashSelect}
+                onClose={() => setSlashMenuOpen(false)}
+              />
+            )}
             <textarea
               ref={textareaRef}
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
               onPaste={handleImagePaste}
               onKeyDown={(event) => {
+                // Slash command menu keyboard navigation
+                if (slashMenuOpen && slashCommands.length > 0) {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setSlashSelectedIndex((i) =>
+                      i < slashCommands.length - 1 ? i + 1 : 0,
+                    );
+                    return;
+                  }
+                  if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setSlashSelectedIndex((i) =>
+                      i > 0 ? i - 1 : slashCommands.length - 1,
+                    );
+                    return;
+                  }
+                  if (event.key === "Enter" || event.key === "Tab") {
+                    event.preventDefault();
+                    handleSlashSelect(slashCommands[slashSelectedIndex].command);
+                    return;
+                  }
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setSlashMenuOpen(false);
+                    return;
+                  }
+                }
+
                 if (targetTerminal) {
                   const seq = getPassthroughSequence(event, draft, images.length > 0);
                   if (seq !== null) {

--- a/src/components/SlashCommandMenu.tsx
+++ b/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from "react";
+import type { SlashCommand } from "../terminal/slashCommands";
+
+interface Props {
+  commands: readonly SlashCommand[];
+  selectedIndex: number;
+  onSelect: (command: string) => void;
+  onClose: () => void;
+}
+
+export function SlashCommandMenu({
+  commands,
+  selectedIndex,
+  onSelect,
+  onClose,
+}: Props) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll the selected item into view
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    window.addEventListener("mousedown", handler);
+    return () => window.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  if (commands.length === 0) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute bottom-full left-0 right-0 mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-[0_-8px_24px_rgba(0,0,0,0.2)] z-10"
+    >
+      <div className="py-1">
+        {commands.map((cmd, index) => {
+          const isSelected = index === selectedIndex;
+          return (
+            <button
+              key={cmd.command}
+              ref={isSelected ? selectedRef : undefined}
+              className={`w-full flex items-center gap-3 px-3 py-1.5 text-left transition-colors duration-75 ${
+                isSelected
+                  ? "bg-[var(--accent)]/15 text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--border)]/50 hover:text-[var(--text-primary)]"
+              }`}
+              style={{ fontFamily: '"Geist Mono", monospace' }}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(cmd.command);
+              }}
+              onMouseEnter={() => {
+                // Let parent handle index via mouse — not needed since
+                // we highlight on hover via CSS, but selection on click
+                // uses the command directly.
+              }}
+            >
+              <span
+                className={`text-[12px] font-medium shrink-0 ${
+                  isSelected ? "text-[var(--accent)]" : ""
+                }`}
+              >
+                {cmd.command}
+              </span>
+              <span className="text-[11px] text-[var(--text-muted)] truncate">
+                {cmd.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/terminal/slashCommands.ts
+++ b/src/terminal/slashCommands.ts
@@ -1,0 +1,64 @@
+import type { TerminalType } from "../types";
+
+export interface SlashCommand {
+  command: string;
+  description: string;
+}
+
+const CLAUDE_COMMANDS: readonly SlashCommand[] = [
+  { command: "/help", description: "Show help and available commands" },
+  { command: "/config", description: "View or update configuration" },
+  { command: "/cost", description: "Show token usage and cost" },
+  { command: "/compact", description: "Compact conversation history" },
+  { command: "/clear", description: "Clear conversation" },
+  { command: "/doctor", description: "Check for common issues" },
+  { command: "/init", description: "Initialize project configuration" },
+  { command: "/login", description: "Sign in to your account" },
+  { command: "/logout", description: "Sign out" },
+  { command: "/mcp", description: "Manage MCP servers" },
+  { command: "/memory", description: "Edit CLAUDE.md memory files" },
+  { command: "/model", description: "Switch AI model" },
+  { command: "/permissions", description: "View or update permissions" },
+  { command: "/review", description: "Review a pull request" },
+  { command: "/status", description: "Show status information" },
+  { command: "/terminal-setup", description: "Set up terminal integration" },
+  { command: "/vim", description: "Toggle vim mode" },
+] as const;
+
+const CODEX_COMMANDS: readonly SlashCommand[] = [
+  { command: "/help", description: "Show help" },
+  { command: "/model", description: "Switch model" },
+  { command: "/approval", description: "Set approval mode" },
+  { command: "/provider", description: "Switch provider" },
+  { command: "/history", description: "Show conversation history" },
+  { command: "/compact", description: "Compact conversation" },
+  { command: "/clear", description: "Clear conversation" },
+] as const;
+
+const NO_COMMANDS: readonly SlashCommand[] = [];
+
+const COMMANDS_BY_TYPE: Record<TerminalType, readonly SlashCommand[]> = {
+  claude: CLAUDE_COMMANDS,
+  codex: CODEX_COMMANDS,
+  shell: NO_COMMANDS,
+  kimi: NO_COMMANDS,
+  gemini: NO_COMMANDS,
+  opencode: NO_COMMANDS,
+  lazygit: NO_COMMANDS,
+  tmux: NO_COMMANDS,
+};
+
+export function getSlashCommands(type: TerminalType): readonly SlashCommand[] {
+  return COMMANDS_BY_TYPE[type];
+}
+
+export function filterSlashCommands(
+  type: TerminalType,
+  query: string,
+): readonly SlashCommand[] {
+  const commands = COMMANDS_BY_TYPE[type];
+  if (query.length === 0) return commands;
+
+  const lower = query.toLowerCase();
+  return commands.filter((cmd) => cmd.command.toLowerCase().includes(lower));
+}


### PR DESCRIPTION
## Summary

- Typing `/` in the ComposerBar now shows a dropdown of available slash commands for the focused terminal's agent type
- Claude terminals show 17 commands (`/help`, `/compact`, `/model`, `/config`, etc.) and Codex terminals show 7 commands (`/help`, `/model`, `/approval`, etc.)
- Other terminal types (shell, lazygit, tmux, etc.) have no slash commands and won't trigger the menu
- Commands filter as you type (e.g. `/co` shows `/compact`, `/config`, `/cost`)

## How it works

1. **Registry** (`src/terminal/slashCommands.ts`): Static mapping of `TerminalType → SlashCommand[]` with command name and description
2. **Menu component** (`src/components/SlashCommandMenu.tsx`): Dropdown rendered above the composer input with keyboard navigation and mouse selection
3. **ComposerBar integration**: Watches the draft for a `/` prefix, opens the menu, intercepts Up/Down/Enter/Tab/Escape keys when the menu is active

### Keyboard navigation
- **Up/Down** — cycle through filtered commands
- **Enter/Tab** — insert the selected command into the input
- **Escape** — dismiss the menu
- Clicking a command also selects it

## Test plan

- [ ] Focus a Claude terminal, type `/` — verify all 17 commands appear
- [ ] Type `/co` — verify only `/compact`, `/config`, `/cost` are shown
- [ ] Use Up/Down arrows to navigate, Enter to select — verify command is inserted
- [ ] Press Tab to select — verify same behavior as Enter
- [ ] Press Escape — verify menu closes
- [ ] Click a command — verify it's inserted
- [ ] Focus a Codex terminal, type `/` — verify 7 Codex commands appear
- [ ] Focus a shell terminal, type `/` — verify no menu appears
- [ ] Type a non-`/` prefix — verify no menu appears
- [ ] Select a command, then submit — verify it sends to terminal as normal text