### PR TITLE
fix(composer): prevent slash command selection from resetting on keystroke

### DIFF
--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -165,8 +165,18 @@ export function ComposerBar() {
         draft.slice(1),
       );
       if (commands.length > 0) {
-        setSlashMenuOpen(true);
-        setSlashSelectedIndex(0);
+        setSlashMenuOpen((wasOpen) => {
+          if (!wasOpen) {
+            // Menu is opening for the first time — reset to top
+            setSlashSelectedIndex(0);
+          } else {
+            // Menu was already open — clamp index to new list bounds
+            setSlashSelectedIndex((prev) =>
+              Math.min(prev, commands.length - 1),
+            );
+          }
+          return true;
+        });
         return;
       }
     }


### PR DESCRIPTION
## Summary

- Slash command menu selection index was reset to 0 on every keystroke because the `useEffect` unconditionally called `setSlashSelectedIndex(0)` whenever `draft` changed.
- Now the index only resets when the menu first opens (closed→open transition). When already open and the filtered list changes, the index is clamped to the new list bounds via `Math.min(prev, commands.length - 1)`.

## Test plan

- [ ] Type `/` to open slash command menu, arrow down to select a non-first item, then continue typing — selection should stay on the current item or clamp to last item, not jump to top
- [ ] Delete characters to widen the filter — selection should remain stable
- [ ] Type a query that narrows results below current index — selection should clamp to last available item
- [ ] Close and reopen menu — selection should reset to first item