### PR TITLE
fix(usage): batch heatmap into single IPC call

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,7 +23,7 @@ import {
   createDefaultComposerSubmitDeps,
   submitComposerRequest,
 } from "./composer-submit";
-import { collectUsage } from "./usage-collector";
+import { collectUsage, collectHeatmapData } from "./usage-collector";
 import { setupAutoUpdater, stopAutoUpdater } from "./auto-updater";
 import type { ComposerSubmitRequest } from "../src/types";
 
@@ -571,6 +571,10 @@ function setupIpc() {
   // Usage statistics
   ipcMain.handle("usage:query", async (_event, dateStr: string) => {
     return await collectUsage(dateStr);
+  });
+
+  ipcMain.handle("usage:heatmap", async () => {
+    return await collectHeatmapData();
   });
 
   // Close flow

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -127,6 +127,8 @@ contextBridge.exposeInMainWorld("termcanvas", {
   usage: {
     query: (dateStr: string) =>
       ipcRenderer.invoke("usage:query", dateStr),
+    heatmap: () =>
+      ipcRenderer.invoke("usage:heatmap"),
   },
   app: {
     platform: process.platform as "darwin" | "win32" | "linux",

--- a/electron/usage-collector.ts
+++ b/electron/usage-collector.ts
@@ -342,6 +342,87 @@ function parseCodexSession(
   return { records: lastRecord ? [lastRecord] : [], projectPath };
 }
 
+// ── Heatmap API ─────────────────────────────────────────────────────────
+
+/**
+ * Collect heatmap data for the last 91 days in a single pass.
+ * Scans files once, reads each file once, buckets records by local date.
+ * Uses setImmediate chunking to avoid blocking the main thread.
+ */
+export async function collectHeatmapData(): Promise<Record<string, { tokens: number; cost: number }>> {
+  const HEATMAP_DAYS = 91;
+  const BATCH_SIZE = 20;
+  const tzOffsetHours = getLocalTzOffsetHours();
+
+  // Compute UTC range covering the full 91-day window in local time
+  const today = new Date();
+  const startLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate() - (HEATMAP_DAYS - 1));
+  const endLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1); // tomorrow midnight
+  const fmt = (ms: number) => new Date(ms).toISOString().replace("Z", "").split(".")[0];
+  const utcStart = fmt(startLocal.getTime());
+  const utcEnd = fmt(endLocal.getTime());
+  const startDateStr = `${startLocal.getFullYear()}-${String(startLocal.getMonth() + 1).padStart(2, "0")}-${String(startLocal.getDate()).padStart(2, "0")}`;
+
+  // Discover all files once
+  const claudeFiles = findClaudeJsonlFiles();
+  const codexFiles = findCodexJsonlFiles();
+
+  const result: Record<string, { tokens: number; cost: number }> = {};
+
+  const bucketRecord = (r: UsageRecord) => {
+    // Convert UTC timestamp to local date string
+    const utcMs = new Date(r.ts + "Z").getTime();
+    const localMs = utcMs + tzOffsetHours * 3600_000;
+    const localDate = new Date(localMs);
+    const dateStr = `${localDate.getUTCFullYear()}-${String(localDate.getUTCMonth() + 1).padStart(2, "0")}-${String(localDate.getUTCDate()).padStart(2, "0")}`;
+
+    const tokens = r.input + r.output + r.cacheRead + r.cacheCreate5m + r.cacheCreate1h;
+    const cost = computeCost(r.model, r.input, r.output, r.cacheRead, r.cacheCreate5m, r.cacheCreate1h);
+
+    if (!result[dateStr]) {
+      result[dateStr] = { tokens: 0, cost: 0 };
+    }
+    result[dateStr].tokens += tokens;
+    result[dateStr].cost += cost;
+  };
+
+  // Process Claude files in batches, yielding between batches
+  for (let i = 0; i < claudeFiles.length; i += BATCH_SIZE) {
+    if (i > 0) await new Promise<void>((r) => setImmediate(r));
+    const batch = claudeFiles.slice(i, i + BATCH_SIZE);
+    for (const f of batch) {
+      try {
+        const mtime = fs.statSync(f).mtimeMs;
+        const mtimeLocal = new Date(mtime + tzOffsetHours * 3600_000);
+        const mtimeDate = mtimeLocal.toISOString().split("T")[0];
+        if (mtimeDate < startDateStr) continue;
+      } catch { continue; }
+
+      const { records } = parseClaudeSession(f, utcStart, utcEnd);
+      for (const r of records) bucketRecord(r);
+    }
+  }
+
+  // Process Codex files in batches
+  for (let i = 0; i < codexFiles.length; i += BATCH_SIZE) {
+    if (i > 0) await new Promise<void>((r) => setImmediate(r));
+    const batch = codexFiles.slice(i, i + BATCH_SIZE);
+    for (const f of batch) {
+      try {
+        const mtime = fs.statSync(f).mtimeMs;
+        const mtimeLocal = new Date(mtime + tzOffsetHours * 3600_000);
+        const mtimeDate = mtimeLocal.toISOString().split("T")[0];
+        if (mtimeDate < startDateStr) continue;
+      } catch { continue; }
+
+      const { records } = parseCodexSession(f, utcStart, utcEnd);
+      for (const r of records) bucketRecord(r);
+    }
+  }
+
+  return result;
+}
+
 // ── Main API ───────────────────────────────────────────────────────────
 
 /**

--- a/src/stores/usageStore.ts
+++ b/src/stores/usageStore.ts
@@ -28,16 +28,6 @@ function todayStr(): string {
   return `${y}-${m}-${d}`;
 }
 
-function toDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-const HEATMAP_DAYS = 91;
-const HEATMAP_CONCURRENCY = 10;
-
 export const useUsageStore = create<UsageStore>((set, get) => ({
   summary: null,
   loading: false,
@@ -80,51 +70,20 @@ export const useUsageStore = create<UsageStore>((set, get) => ({
 
   fetchHeatmap: async () => {
     if (get().heatmapLoading) return;
-    // Skip if we already have data
     if (Object.keys(get().heatmapData).length > 0) return;
 
-    if (!window.termcanvas?.usage) {
+    if (!window.termcanvas?.usage?.heatmap) {
       set({ heatmapError: true });
       return;
     }
 
     set({ heatmapLoading: true, heatmapError: false });
 
-    const today = new Date();
-    const dates: string[] = [];
-    for (let i = 0; i < HEATMAP_DAYS; i++) {
-      const d = new Date(today);
-      d.setDate(d.getDate() - i);
-      dates.push(toDateStr(d));
-    }
-
-    const result: Record<string, HeatmapEntry> = {};
-    let failed = 0;
-
-    // Process in batches for throttling
-    for (let i = 0; i < dates.length; i += HEATMAP_CONCURRENCY) {
-      const batch = dates.slice(i, i + HEATMAP_CONCURRENCY);
-      const results = await Promise.allSettled(
-        batch.map((dateStr) => window.termcanvas!.usage.query(dateStr)),
-      );
-
-      for (let j = 0; j < results.length; j++) {
-        const r = results[j];
-        const dateStr = batch[j];
-        if (r.status === "fulfilled") {
-          const s = r.value;
-          const tokens = s.totalInput + s.totalOutput + s.totalCacheRead + s.totalCacheCreate5m + s.totalCacheCreate1h;
-          result[dateStr] = { tokens, cost: s.totalCost };
-        } else {
-          failed++;
-        }
-      }
-    }
-
-    if (failed === dates.length) {
+    try {
+      const data = await window.termcanvas.usage.heatmap();
+      set({ heatmapData: data, heatmapLoading: false });
+    } catch {
       set({ heatmapLoading: false, heatmapError: true });
-    } else {
-      set({ heatmapData: result, heatmapLoading: false });
     }
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,6 +236,7 @@ export interface TermCanvasAPI {
   };
   usage: {
     query: (dateStr: string) => Promise<UsageSummary>;
+    heatmap: () => Promise<Record<string, { tokens: number; cost: number }>>;
   };
   app: {
     platform: "darwin" | "win32" | "linux";


### PR DESCRIPTION
## Summary
- Add `collectHeatmapData()` in `electron/usage-collector.ts` that scans all JSONL files once and reads each file once, bucketing records by local date for the last 91 days
- Uses `setImmediate` chunking (batches of 20 files) to avoid blocking the main thread
- Expose via `usage:heatmap` IPC handler, replacing 91 individual `usage:query` calls with a single round-trip
- Simplify `fetchHeatmap()` in `usageStore.ts` to a single `window.termcanvas.usage.heatmap()` call

## Test plan
- [ ] Open the usage panel — verify it no longer freezes the app
- [ ] Verify heatmap calendar renders the same data as before
- [ ] Verify loading state shows while heatmap data is being fetched
- [ ] Verify error state surfaces if the heatmap call fails
- [ ] Run `npx tsc --noEmit` — passes with no errors