### PR TITLE
搭建 Hydra 评估框架，含 20 任务基线数据

### DIFF
--- a/eval/.gitignore
+++ b/eval/.gitignore
@@ -1,0 +1,22 @@
+node_modules/
+dist/
+
+# Downloaded datasets (regenerable via scripts/download-dataset.py)
+tasks/
+!tasks/.gitkeep
+
+# Evaluation results (regenerable by running evaluations)
+results/
+!results/.gitkeep
+
+# SWE-bench Docker logs (regenerable)
+logs/
+
+# SWE-bench report files
+*.json
+!package.json
+!package-lock.json
+!tsconfig.json
+
+# Parquet cache
+_cache_*

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,126 @@
+# Hydra Evaluation Framework
+
+Evaluation pipeline for measuring Hydra multi-agent orchestration effectiveness against single-agent baselines, using SWE-bench Docker test harness.
+
+## Overview
+
+This framework runs coding tasks from SWE-bench against different agent configurations, then validates results using SWE-bench's Docker harness (FAIL_TO_PASS test execution).
+
+```
+Supported modes:
+┌──────────────────────────────────────────────────┐
+│ single-claude  │ One Claude Code agent            │
+│ single-codex   │ One Codex agent                  │
+│ hydra          │ Hydra multi-agent orchestration   │
+└──────────────────────────────────────────────────┘
+```
+
+## Two-Phase Evaluation
+
+```
+Phase 1: Agent Run
+  eval run --mode single-claude --tasks tasks/swe-bench-multi-file.json
+  → Agent generates patches, saved to results/<run_id>/
+
+Phase 2: SWE-bench Docker Evaluation
+  python3 scripts/export-predictions.py <run_id>
+  DOCKER_HOST=... python3 -m swebench.harness.run_evaluation \
+    --predictions_path results/<run_id>/predictions.jsonl \
+    --dataset_name princeton-nlp/SWE-bench --run_id <run_id>
+  python3 scripts/update-results-with-swebench.py
+  → Real pass/fail from test execution updates results/
+```
+
+## Quick Start
+
+```bash
+cd eval
+npm install
+pip install swebench pyarrow
+
+# Download task set
+python3 scripts/download-dataset.py --min-files 3 --max-tasks 20
+
+# Phase 1: Run agents
+node --experimental-strip-types --no-warnings src/cli.ts run \
+  --mode single-claude \
+  --tasks tasks/swe-bench-multi-file.json \
+  --timeout 1800
+
+# Phase 2: Evaluate with SWE-bench Docker
+python3 scripts/export-predictions.py <run_id>
+DOCKER_HOST=unix:///path/to/docker.sock \
+  python3 -m swebench.harness.run_evaluation \
+  --dataset_name princeton-nlp/SWE-bench \
+  --predictions_path results/<run_id>/predictions.jsonl \
+  --max_workers 2 --run_id <run_id> --cache_level env
+python3 scripts/update-results-with-swebench.py
+
+# Compare runs
+node --experimental-strip-types --no-warnings src/cli.ts compare <run_a> <run_b>
+node --experimental-strip-types --no-warnings src/cli.ts list
+```
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--mode` | Agent mode: `single-claude`, `single-codex`, `hydra` | `single-claude` |
+| `--tasks` | Path to task JSON file | auto-download |
+| `--prompt-version` | Prompt version tag for tracking | `v1` |
+| `--run-id` | Custom run identifier | auto-generated |
+| `--timeout` | Per-task timeout in seconds | `600` |
+| `--max-tasks` | Limit number of tasks to run | all |
+| `--max-workers` | Parallel task execution | `1` |
+| `--orchestrator` | Hydra orchestrator model | `claude` |
+| `--sub-agents` | Hydra sub-agent types (comma-separated) | `claude,codex` |
+
+## Task Sets
+
+Task files are not checked into the repo — generate them with `scripts/download-dataset.py`:
+
+```bash
+# SWE-bench Pro (recommended — multi-file, multi-language, pollution-resistant)
+python3 scripts/download-dataset.py --dataset swe-bench-pro --max-tasks 50 --output pro-50
+
+# SWE-bench Full, stratified sample of multi-file tasks
+python3 scripts/download-dataset.py --dataset swe-bench --min-files 3 --max-tasks 30 --output multi-file-30
+
+# SWE-bench Verified (deprecated by OpenAI, not recommended)
+python3 scripts/download-dataset.py --dataset swe-bench-verified --max-tasks 50 --output verified-50
+```
+
+Available datasets: `swe-bench`, `swe-bench-verified`, `swe-bench-pro`
+
+## Architecture
+
+```
+eval/
+  src/
+    cli.ts              CLI entry point
+    runner.ts           Orchestrates evaluation runs (Phase 1)
+    types.ts            Type definitions
+    dataset.ts          SWE-bench task loading and filtering
+    evaluator.ts        SWE-bench Docker integration
+    results.ts          Result storage and loading
+    compare.ts          Cross-run comparison
+    agents/
+      single.ts         Claude Code / Codex single-agent runner
+      hydra.ts          Hydra multi-agent runner (direct + TermCanvas)
+  scripts/
+    download-dataset.py         Download SWE-bench from HuggingFace
+    export-predictions.py       Convert results to SWE-bench JSONL
+    run-swebench-eval.py        Run SWE-bench Docker evaluation
+    update-results-with-swebench.py  Merge Docker verdicts into results
+    select-tasks.py             Select balanced task subsets
+  tasks/                Task definitions (JSON)
+  results/              Run results (JSON, updated with Docker verdicts)
+  logs/                 SWE-bench Docker evaluation logs + reports
+```
+
+## Development
+
+```bash
+npm run typecheck
+node --experimental-strip-types --no-warnings --test tests/*.test.ts
+```

--- a/eval/package-lock.json
+++ b/eval/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@termcanvas/eval",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@termcanvas/eval",
+      "version": "0.1.0",
+      "bin": {
+        "eval": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/eval/package.json
+++ b/eval/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@termcanvas/eval",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "eval": "node --experimental-strip-types --no-warnings src/cli.ts",
+    "test": "node --experimental-strip-types --no-warnings --test tests/*.test.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/eval/scripts/download-dataset.py
+++ b/eval/scripts/download-dataset.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Download SWE-bench dataset and filter for multi-file tasks."""
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+TASKS_DIR = Path(__file__).parent.parent / "tasks"
+TASKS_DIR.mkdir(exist_ok=True)
+
+DATASETS = {
+    "swe-bench": {
+        "url": "https://huggingface.co/api/datasets/princeton-nlp/SWE-bench/parquet/default/test",
+    },
+    "swe-bench-lite": {
+        "url": "https://huggingface.co/api/datasets/SWE-bench/SWE-bench_Lite/parquet/default/test",
+    },
+    "swe-bench-verified": {
+        "url": "https://huggingface.co/api/datasets/SWE-bench/SWE-bench_Verified/parquet/default/test",
+    },
+    "swe-bench-pro": {
+        "url": "https://huggingface.co/api/datasets/ScaleAI/SWE-bench_Pro/parquet/default/test",
+    },
+}
+
+
+def count_files_in_patch(patch: str) -> list[str]:
+    """Extract file paths from a unified diff patch."""
+    files = []
+    for line in patch.split("\n"):
+        if line.startswith("diff --git"):
+            parts = line.split(" b/", 1)
+            if len(parts) == 2:
+                files.append(parts[1])
+    return files
+
+
+def count_lines_in_patch(patch: str) -> int:
+    """Count added/removed lines in a patch."""
+    count = 0
+    for line in patch.split("\n"):
+        if (line.startswith("+") or line.startswith("-")) and \
+           not line.startswith("+++") and not line.startswith("---"):
+            count += 1
+    return count
+
+
+def download_parquet(dataset_name: str) -> list[dict]:
+    """Download parquet files and return as list of dicts."""
+    config = DATASETS.get(dataset_name)
+    if not config:
+        print(f"Unknown dataset: {dataset_name}")
+        sys.exit(1)
+
+    print(f"Fetching parquet URLs for {dataset_name}...")
+    with urllib.request.urlopen(config["url"]) as resp:
+        urls = json.loads(resp.read())
+
+    print(f"Found {len(urls)} parquet file(s)")
+
+    all_rows = []
+    for i, url in enumerate(urls):
+        cache_path = TASKS_DIR / f"_cache_{dataset_name}_{i}.parquet"
+        if not cache_path.exists():
+            print(f"Downloading parquet {i+1}/{len(urls)}...")
+            urllib.request.urlretrieve(url, cache_path)
+
+        table = pq.read_table(cache_path)
+        rows = table.to_pylist()
+        all_rows.extend(rows)
+        print(f"  Loaded {len(rows)} rows from file {i+1}")
+
+    return all_rows
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Download and filter SWE-bench tasks")
+    parser.add_argument("--dataset", default="swe-bench", choices=DATASETS.keys())
+    parser.add_argument("--min-files", type=int, default=2)
+    parser.add_argument("--max-tasks", type=int, default=30)
+    parser.add_argument("--output", default="swe-bench-multi-file")
+    parser.add_argument("--repos", nargs="*", help="Filter by repos")
+    args = parser.parse_args()
+
+    rows = download_parquet(args.dataset)
+    print(f"\nTotal tasks: {len(rows)}")
+
+    # Filter for multi-file tasks
+    filtered = []
+    for row in rows:
+        patch = row.get("patch", "")
+        files = count_files_in_patch(patch)
+        if len(files) >= args.min_files:
+            if args.repos and row.get("repo") not in args.repos:
+                continue
+            filtered.append(row)
+
+    print(f"Multi-file tasks (>={args.min_files} files): {len(filtered)}")
+
+    # Stratified sample across difficulty range (not just the hardest)
+    filtered.sort(key=lambda r: len(count_files_in_patch(r.get("patch", ""))))
+    if len(filtered) > args.max_tasks:
+        step = len(filtered) / args.max_tasks
+        selected = [filtered[int(i * step)] for i in range(args.max_tasks)]
+    else:
+        selected = filtered
+    print(f"Selected: {len(selected)} tasks")
+
+    # Show summary
+    print("\nSelected tasks:")
+    for i, task in enumerate(selected):
+        files = count_files_in_patch(task.get("patch", ""))
+        lines = count_lines_in_patch(task.get("patch", ""))
+        print(f"  {i+1:3d}. {task['instance_id']:50s} files={len(files):2d} lines={lines:4d} repo={task['repo']}")
+
+    # Save
+    output_path = TASKS_DIR / f"{args.output}.json"
+    with open(output_path, "w") as f:
+        json.dump(selected, f, indent=2, default=str)
+    print(f"\nSaved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/scripts/export-predictions.py
+++ b/eval/scripts/export-predictions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Export eval results as SWE-bench prediction JSONL files."""
+
+import json
+import sys
+from pathlib import Path
+
+RESULTS_DIR = Path(__file__).parent.parent / "results"
+
+def export(run_id: str):
+    result_path = RESULTS_DIR / run_id / "result.json"
+    with open(result_path) as f:
+        result = json.load(f)
+
+    model_name = f"termcanvas-eval-{result['config']['mode']}"
+    predictions = []
+    for task in result["tasks"]:
+        patch = task.get("model_patch", "")
+        if patch.strip():
+            predictions.append({
+                "instance_id": task["task_id"],
+                "model_name_or_path": model_name,
+                "model_patch": patch,
+            })
+
+    output_path = RESULTS_DIR / run_id / "predictions.jsonl"
+    with open(output_path, "w") as f:
+        for p in predictions:
+            f.write(json.dumps(p) + "\n")
+
+    print(f"{run_id}: {len(predictions)} predictions -> {output_path}")
+    return str(output_path)
+
+if __name__ == "__main__":
+    run_ids = sys.argv[1:] if len(sys.argv) > 1 else [
+        d.name for d in sorted(RESULTS_DIR.iterdir())
+        if d.is_dir() and (d / "result.json").exists()
+    ]
+    for run_id in run_ids:
+        export(run_id)

--- a/eval/scripts/run-swebench-eval.py
+++ b/eval/scripts/run-swebench-eval.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Run SWE-bench Docker evaluation on eval framework predictions.
+Converts our result.json to SWE-bench predictions format and runs the harness.
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+def load_run_result(run_id: str) -> dict:
+    """Load a run result from the eval results directory."""
+    result_path = Path(__file__).parent.parent / "results" / run_id / "result.json"
+    with open(result_path) as f:
+        return json.load(f)
+
+def to_predictions(result: dict, model_name: str) -> list[dict]:
+    """Convert run result to SWE-bench prediction format."""
+    predictions = []
+    for task in result["tasks"]:
+        patch = task.get("model_patch", "")
+        if patch.strip():
+            predictions.append({
+                "instance_id": task["task_id"],
+                "model_name_or_path": model_name,
+                "model_patch": patch,
+            })
+    return predictions
+
+def write_predictions_jsonl(predictions: list[dict], output_path: str):
+    """Write predictions to JSONL file."""
+    with open(output_path, "w") as f:
+        for pred in predictions:
+            f.write(json.dumps(pred) + "\n")
+    print(f"Wrote {len(predictions)} predictions to {output_path}")
+
+DATASET_MAP = {
+    "swe-bench": "princeton-nlp/SWE-bench",
+    "swe-bench-lite": "SWE-bench/SWE-bench_Lite",
+    "swe-bench-verified": "SWE-bench/SWE-bench_Verified",
+    "swe-bench-pro": "ScaleAI/SWE-bench_Pro",
+}
+
+def run_evaluation(predictions_path: str, run_id: str, benchmark: str = "swe-bench", max_workers: int = 4):
+    """Run SWE-bench evaluation."""
+    output_dir = Path(__file__).parent.parent / "results" / run_id / "swebench-eval"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_name = DATASET_MAP.get(benchmark, "princeton-nlp/SWE-bench")
+
+    print(f"\nRunning SWE-bench evaluation for {run_id}...")
+    print(f"Dataset: {dataset_name}")
+    print(f"Predictions: {predictions_path}")
+    print(f"Output: {output_dir}")
+    print(f"Workers: {max_workers}")
+    print()
+
+    import subprocess
+    cmd = [
+        "python3", "-m", "swebench.harness.run_evaluation",
+        "--dataset_name", dataset_name,
+        "--predictions_path", predictions_path,
+        "--max_workers", str(max_workers),
+        "--run_id", run_id,
+        "--cache_level", "env",
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.run(cmd, cwd=str(output_dir))
+
+def parse_results(run_id: str) -> dict:
+    """Parse SWE-bench evaluation results and update the run result."""
+    output_dir = Path(__file__).parent.parent / "results" / run_id / "swebench-eval"
+
+    # Look for results files
+    results = {}
+    for f in output_dir.glob("*.json"):
+        try:
+            with open(f) as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                for instance_id, detail in data.items():
+                    if isinstance(detail, dict) and "resolved" in detail:
+                        results[instance_id] = detail["resolved"]
+        except:
+            pass
+
+    # Also check for the log-based results
+    for log_dir in output_dir.glob("*/"):
+        if log_dir.is_dir():
+            for log_file in log_dir.glob("*.log"):
+                # Parse test results from logs
+                pass
+
+    return results
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: run-swebench-eval.py <run_id> [--max-workers N]")
+        print("\nAvailable runs:")
+        results_dir = Path(__file__).parent.parent / "results"
+        for d in sorted(results_dir.iterdir()):
+            if d.is_dir() and (d / "result.json").exists():
+                with open(d / "result.json") as f:
+                    r = json.load(f)
+                tasks_with_patch = sum(1 for t in r["tasks"] if t.get("model_patch", "").strip())
+                print(f"  {d.name:30s} tasks={len(r['tasks']):2d}  with_patch={tasks_with_patch:2d}  mode={r['config']['mode']}")
+        sys.exit(1)
+
+    run_id = sys.argv[1]
+    max_workers = 4
+    if "--max-workers" in sys.argv:
+        idx = sys.argv.index("--max-workers")
+        max_workers = int(sys.argv[idx + 1])
+
+    # Load and convert
+    result = load_run_result(run_id)
+    model_name = f"termcanvas-eval-{result['config']['mode']}"
+    predictions = to_predictions(result, model_name)
+
+    if not predictions:
+        print(f"No predictions with patches found in {run_id}")
+        sys.exit(1)
+
+    print(f"Run: {run_id}")
+    print(f"Mode: {result['config']['mode']}")
+    print(f"Tasks with patches: {len(predictions)}/{len(result['tasks'])}")
+
+    # Write predictions
+    pred_path = str(Path(__file__).parent.parent / "results" / run_id / "predictions.jsonl")
+    write_predictions_jsonl(predictions, pred_path)
+
+    # Run evaluation
+    benchmark = result.get("config", {}).get("benchmark", "swe-bench")
+    run_evaluation(pred_path, run_id, benchmark, max_workers)
+
+    print("\nDone. Check results in:")
+    print(f"  {Path(__file__).parent.parent / 'results' / run_id / 'swebench-eval'}")
+
+if __name__ == "__main__":
+    main()

--- a/eval/scripts/select-tasks.py
+++ b/eval/scripts/select-tasks.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Select a balanced subset of tasks for baseline evaluation."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def count_files(patch: str) -> int:
+    return patch.count("diff --git")
+
+
+def count_lines(patch: str) -> int:
+    count = 0
+    for line in patch.split("\n"):
+        if (line.startswith("+") or line.startswith("-")) and \
+           not line.startswith("+++") and not line.startswith("---"):
+            count += 1
+    return count
+
+
+def main():
+    input_file = sys.argv[1] if len(sys.argv) > 1 else "tasks/swe-bench-all-multi.json"
+    output_file = sys.argv[2] if len(sys.argv) > 2 else "tasks/eval-baseline-5.json"
+    n_tasks = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+
+    with open(input_file) as f:
+        tasks = json.load(f)
+
+    # Filter for moderate complexity: 3-8 files, 30-200 lines
+    candidates = []
+    for t in tasks:
+        nf = count_files(t["patch"])
+        nl = count_lines(t["patch"])
+        if 3 <= nf <= 8 and 30 <= nl <= 200:
+            candidates.append((t, nf, nl))
+
+    # Sort by lines (ascending) for faster eval
+    candidates.sort(key=lambda x: x[2])
+
+    # Select diverse repos
+    selected = []
+    seen_repos = set()
+    for task, nf, nl in candidates:
+        repo = task["repo"]
+        if repo not in seen_repos or len(selected) >= len(candidates) // 2:
+            selected.append(task)
+            seen_repos.add(repo)
+        if len(selected) >= n_tasks:
+            break
+
+    # If not enough, fill from remaining
+    if len(selected) < n_tasks:
+        for task, nf, nl in candidates:
+            if task not in selected:
+                selected.append(task)
+            if len(selected) >= n_tasks:
+                break
+
+    print(f"Selected {len(selected)} tasks:")
+    for i, t in enumerate(selected):
+        nf = count_files(t["patch"])
+        nl = count_lines(t["patch"])
+        ps = t["problem_statement"][:80].replace("\n", " ")
+        print(f"  {i+1}. {t['instance_id']:50s} files={nf:2d} lines={nl:3d} ({ps}...)")
+
+    with open(output_file, "w") as f:
+        json.dump(selected, f, indent=2, default=str)
+    print(f"\nSaved to {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/scripts/update-results-with-swebench.py
+++ b/eval/scripts/update-results-with-swebench.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Update result.json files with real SWE-bench Docker test verdicts."""
+
+import json
+from pathlib import Path
+
+RESULTS_DIR = Path(__file__).parent.parent / "results"
+LOGS_DIR = Path(__file__).parent.parent / "logs" / "run_evaluation"
+
+def get_docker_verdicts(run_id: str) -> dict[str, dict]:
+    """Read all report.json files for a run and return per-task verdicts."""
+    verdicts = {}
+    run_log_dirs = [
+        LOGS_DIR / run_id,
+        RESULTS_DIR / run_id / "swebench-eval" / "logs" / "run_evaluation" / run_id,
+    ]
+
+    for run_log_dir in run_log_dirs:
+        if not run_log_dir.exists():
+            continue
+
+        for model_dir in run_log_dir.iterdir():
+            if not model_dir.is_dir():
+                continue
+            for task_dir in model_dir.iterdir():
+                report = task_dir / "report.json"
+                if report.exists():
+                    with open(report) as f:
+                        data = json.load(f)
+                    for task_id, detail in data.items():
+                        verdicts[task_id] = {
+                            "resolved": detail.get("resolved", False),
+                            "patch_applied": detail.get("patch_successfully_applied", False),
+                            "patch_exists": detail.get("patch_exists", False),
+                        }
+    return verdicts
+
+def update_run(run_id: str):
+    """Update a run's result.json with Docker verdicts."""
+    result_path = RESULTS_DIR / run_id / "result.json"
+    if not result_path.exists():
+        return
+
+    verdicts = get_docker_verdicts(run_id)
+    if not verdicts:
+        print(f"{run_id}: no Docker verdicts found, skipping")
+        return
+
+    with open(result_path) as f:
+        result = json.load(f)
+
+    evaluated = 0
+    resolved = 0
+    docker_errors = 0
+
+    for task in result["tasks"]:
+        tid = task["task_id"]
+        if tid in verdicts:
+            v = verdicts[tid]
+            task["pass"] = v["resolved"]
+            task["eval_detail"] = {
+                "applied": v["patch_applied"],
+                "tests_passed": v["resolved"],
+                "eval_method": "swebench-docker",
+            }
+            evaluated += 1
+            if v["resolved"]:
+                resolved += 1
+        else:
+            # No Docker verdict — mark as not evaluated (Docker build failed)
+            task["pass"] = False
+            task["eval_detail"] = {
+                "applied": False,
+                "tests_passed": False,
+                "eval_method": "docker-build-failed",
+            }
+            docker_errors += 1
+
+    # Recompute summary
+    total = len(result["tasks"])
+    result["summary"]["total"] = total
+    result["summary"]["resolved"] = resolved
+    result["summary"]["pass_rate"] = resolved / evaluated if evaluated > 0 else 0
+    result["summary"]["evaluated"] = evaluated
+    result["summary"]["docker_errors"] = docker_errors
+
+    with open(result_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    # Also update per-task files
+    tasks_dir = RESULTS_DIR / run_id / "tasks"
+    if tasks_dir.exists():
+        for task in result["tasks"]:
+            task_file = tasks_dir / f"{task['task_id']}.json"
+            if task_file.exists():
+                with open(task_file, "w") as f:
+                    json.dump(task, f, indent=2)
+
+    # Update summary.json
+    summary_path = RESULTS_DIR / run_id / "summary.json"
+    if summary_path.exists():
+        with open(summary_path, "w") as f:
+            json.dump({
+                "run_id": result["run_id"],
+                "config": result["config"],
+                "summary": result["summary"],
+                "started_at": result["started_at"],
+                "completed_at": result["completed_at"],
+            }, f, indent=2)
+
+    print(f"{run_id}: {resolved}/{evaluated} resolved ({docker_errors} Docker errors, {total} total)")
+
+if __name__ == "__main__":
+    for run_dir in sorted(RESULTS_DIR.iterdir()):
+        if run_dir.is_dir() and (run_dir / "result.json").exists():
+            update_run(run_dir.name)

--- a/eval/src/agents/hydra.ts
+++ b/eval/src/agents/hydra.ts
@@ -1,0 +1,497 @@
+import { execFile, spawn as spawnChild } from "node:child_process";
+import { readFile, writeFile, mkdir, access } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+  AgentRunner,
+  AgentRunResult,
+  EvalConfig,
+  TaskDefinition,
+} from "../types.ts";
+
+const DEFAULT_TIMEOUT_S = 1200;
+const POLL_INTERVAL_MS = 15_000;
+
+/** Run a command and return stdout */
+function exec(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      {
+        cwd: options.cwd,
+        timeout: (options.timeout ?? DEFAULT_TIMEOUT_S) * 1000,
+        maxBuffer: 50 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error && !stdout) {
+          reject(error);
+        } else {
+          resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
+        }
+      },
+    );
+  });
+}
+
+/** Run a command with stdin */
+function execWithStdin(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number; stdin?: string },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnChild(cmd, args, {
+      cwd: options.cwd,
+      timeout: (options.timeout ?? DEFAULT_TIMEOUT_S) * 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    child.stderr?.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0 && !stdout) {
+        reject(new Error(`Process exited with code ${code}: ${stderr.slice(0, 500)}`));
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+
+    child.on("error", reject);
+
+    if (options.stdin) {
+      child.stdin?.write(options.stdin);
+      child.stdin?.end();
+    }
+  });
+}
+
+/** Capture the git diff produced by the agent */
+async function capturePatch(
+  workDir: string,
+  baseCommit: string,
+): Promise<string> {
+  const { stdout: committedPatch } = await exec(
+    "git",
+    ["diff", baseCommit, "HEAD"],
+    { cwd: workDir },
+  );
+  if (committedPatch.trim()) return committedPatch;
+  const { stdout: patch } = await exec("git", ["diff"], { cwd: workDir });
+  return patch;
+}
+
+/**
+ * Direct Hydra runner — multi-agent orchestration without TermCanvas.
+ *
+ * Flow:
+ * 1. Orchestrator (Claude) analyzes the problem and produces a plan with sub-tasks
+ * 2. Each sub-task is assigned to a sub-agent (Claude or Codex) in a git worktree
+ * 3. Sub-agents work in parallel
+ * 4. Results are merged back
+ */
+export class HydraRunner implements AgentRunner {
+  async run(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<AgentRunResult> {
+    const timeoutS = config.timeout_per_task_s ?? DEFAULT_TIMEOUT_S;
+    const startTime = Date.now();
+    const subAgentTypes = config.sub_agent_types ?? ["claude", "codex"];
+
+    try {
+      // Phase 1: Orchestrator analyzes and decomposes the task
+      console.log(`    [hydra] Phase 1: Orchestrator analyzing task...`);
+      const plan = await this.decompose(task, workDir, config);
+
+      if (plan.subtasks.length === 0) {
+        // Orchestrator decided task is not decomposable — run as single agent
+        console.log(`    [hydra] Not decomposable, falling back to single agent`);
+        return this.runSingleFallback(task, workDir, config, startTime);
+      }
+
+      console.log(`    [hydra] Decomposed into ${plan.subtasks.length} sub-tasks`);
+
+      // Phase 2: Create worktrees and spawn sub-agents
+      console.log(`    [hydra] Phase 2: Spawning ${plan.subtasks.length} sub-agents...`);
+      const subResults = await Promise.all(
+        plan.subtasks.map((subtask, i) => {
+          const agentType = subAgentTypes[i % subAgentTypes.length];
+          return this.runSubAgent(
+            subtask,
+            task,
+            workDir,
+            agentType,
+            config,
+            i,
+            timeoutS,
+          );
+        }),
+      );
+
+      // Phase 3: Merge all sub-agent changes
+      console.log(`    [hydra] Phase 3: Merging results...`);
+      let mergeFailures = 0;
+      for (const sub of subResults) {
+        if (sub.branch && !sub.error) {
+          const merged = await exec("git", ["merge", sub.branch, "--no-edit"], {
+            cwd: workDir,
+            timeout: 30,
+          }).then(() => true).catch(() => {
+            console.log(`    [hydra] Merge conflict on ${sub.branch}, trying theirs strategy`);
+            return exec(
+              "git",
+              ["merge", sub.branch!, "--no-edit", "-X", "theirs"],
+              { cwd: workDir, timeout: 30 },
+            ).then(() => true).catch(() => {
+              return exec("git", ["merge", "--abort"], {
+                cwd: workDir,
+                timeout: 10,
+              }).catch(() => {}).then(() => false);
+            });
+          });
+          if (!merged) {
+            mergeFailures++;
+          }
+        }
+      }
+
+      // Cleanup worktrees
+      for (const sub of subResults) {
+        if (sub.worktreePath) {
+          await exec("git", ["worktree", "remove", sub.worktreePath, "--force"], {
+            cwd: workDir,
+            timeout: 30,
+          }).catch(() => {});
+          if (sub.branch) {
+            await exec("git", ["branch", "-D", sub.branch], {
+              cwd: workDir,
+              timeout: 10,
+            }).catch(() => {});
+          }
+        }
+      }
+
+      const duration = (Date.now() - startTime) / 1000;
+      const modelPatch = await capturePatch(workDir, task.base_commit);
+
+      return {
+        model_patch: modelPatch,
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        sub_agents: plan.subtasks.length,
+        merge_failures: mergeFailures,
+      };
+    } catch (error) {
+      const duration = (Date.now() - startTime) / 1000;
+      return {
+        model_patch: "",
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /** Use orchestrator to decompose the task into sub-tasks */
+  private async decompose(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<{ subtasks: string[] }> {
+    const orchestratorModel = config.models.hydra_orchestrator_model;
+    const normalizedModel = orchestratorModel.toLowerCase();
+
+    const prompt = [
+      "You are a task decomposition engine. Analyze this issue and break it into independent sub-tasks.",
+      "Each sub-task should be independently implementable in a separate git branch.",
+      "",
+      "IMPORTANT: Respond ONLY with a JSON array of strings, each being a sub-task description.",
+      "If the task cannot be meaningfully decomposed (e.g., it's a single logical change), respond with an empty array [].",
+      "Do NOT include test-writing tasks. Only include code changes.",
+      "Keep sub-tasks to 2-4 maximum.",
+      "",
+      `## Repository: ${task.repo}`,
+      "",
+      "## Issue",
+      "",
+      task.problem_statement,
+    ].join("\n");
+
+    try {
+      if (
+        normalizedModel.startsWith("gpt") ||
+        normalizedModel.includes("codex")
+      ) {
+        const { stdout } = await execWithStdin(
+          "codex",
+          [
+            "exec",
+            "--full-auto",
+            "--json",
+            ...(normalizedModel === "codex" ? [] : ["-m", orchestratorModel]),
+          ],
+          { cwd: workDir, timeout: 120, stdin: prompt },
+        );
+        return this.parseDecomposition(stdout);
+      }
+
+      const { stdout } = await execWithStdin(
+        "claude",
+        ["-p", "--output-format", "text", "--dangerously-skip-permissions", "--model", config.models.hydra_orchestrator_model],
+        { cwd: workDir, timeout: 120, stdin: prompt },
+      );
+      return this.parseDecomposition(stdout);
+    } catch {
+      return { subtasks: [] };
+    }
+  }
+
+  /** Parse the orchestrator's decomposition output */
+  private parseDecomposition(output: string): { subtasks: string[] } {
+    // Try to extract JSON array from the output
+    const jsonMatch = output.match(/\[[\s\S]*?\]/);
+    if (!jsonMatch) return { subtasks: [] };
+
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+        return { subtasks: parsed.slice(0, 4) }; // Cap at 4
+      }
+    } catch {}
+
+    return { subtasks: [] };
+  }
+
+  /** Run a sub-agent in an isolated worktree */
+  private async runSubAgent(
+    subtask: string,
+    task: TaskDefinition,
+    mainWorkDir: string,
+    agentType: string,
+    config: EvalConfig,
+    index: number,
+    timeoutS: number,
+  ): Promise<{ branch: string | null; worktreePath: string | null; error?: string }> {
+    const safeInstanceId = task.instance_id.replace(/[^a-zA-Z0-9_-]/g, "_");
+    const branchName = `hydra-eval-sub-${safeInstanceId}-${index}`;
+    const worktreePath = join(
+      mainWorkDir,
+      `..`,
+      `.hydra-wt-${safeInstanceId}-${index}`,
+    );
+
+    try {
+      // Create worktree
+      await exec(
+        "git",
+        ["worktree", "add", "-b", branchName, worktreePath, "HEAD"],
+        { cwd: mainWorkDir, timeout: 30 },
+      );
+
+      const prompt = [
+        `You are working on a sub-task for the ${task.repo} repository.`,
+        "Make minimal, targeted changes. Do not modify test files.",
+        "Commit your changes when done.",
+        "",
+        "## Sub-task",
+        "",
+        subtask,
+        "",
+        "## Context (original issue)",
+        "",
+        task.problem_statement.slice(0, 2000),
+      ].join("\n");
+
+      console.log(`    [hydra] Sub-agent ${index} (${agentType}): starting...`);
+
+      if (agentType === "codex") {
+        await execWithStdin(
+          "codex",
+          [
+            "exec",
+            "--full-auto",
+            ...(config.models.hydra_sub_codex_model ? ["-m", config.models.hydra_sub_codex_model] : []),
+          ],
+          { cwd: worktreePath, timeout: timeoutS, stdin: prompt },
+        );
+      } else {
+        await execWithStdin(
+          "claude",
+          ["-p", "--output-format", "text", "--dangerously-skip-permissions", "--model", config.models.hydra_sub_claude_model],
+          { cwd: worktreePath, timeout: timeoutS, stdin: prompt },
+        );
+      }
+
+      console.log(`    [hydra] Sub-agent ${index} (${agentType}): done`);
+      return { branch: branchName, worktreePath };
+    } catch (error) {
+      console.log(`    [hydra] Sub-agent ${index} (${agentType}): failed - ${error instanceof Error ? error.message : String(error)}`);
+      return {
+        branch: branchName,
+        worktreePath,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /** Fallback: run as a single agent when decomposition isn't possible */
+  private async runSingleFallback(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+    startTime: number,
+  ): Promise<AgentRunResult> {
+    const timeoutS = config.timeout_per_task_s ?? DEFAULT_TIMEOUT_S;
+    const prompt = [
+      `Fix this issue in the ${task.repo} repository.`,
+      "Make minimal, targeted changes. Do not modify test files.",
+      "Commit your changes.",
+      "",
+      "## Issue",
+      "",
+      task.problem_statement,
+      task.hints_text ? `\n## Hints\n\n${task.hints_text}` : "",
+    ].join("\n");
+
+    try {
+      await execWithStdin(
+        "claude",
+        ["-p", "--output-format", "text", "--dangerously-skip-permissions", "--model", config.models.hydra_sub_claude_model],
+        { cwd: workDir, timeout: timeoutS, stdin: prompt },
+      );
+
+      const duration = (Date.now() - startTime) / 1000;
+      const modelPatch = await capturePatch(workDir, task.base_commit);
+
+      return {
+        model_patch: modelPatch,
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        sub_agents: 1,
+      };
+    } catch (error) {
+      const duration = (Date.now() - startTime) / 1000;
+      return {
+        model_patch: "",
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+/** Original TermCanvas-based Hydra runner (for use within TermCanvas projects) */
+export class TermCanvasHydraRunner implements AgentRunner {
+  async run(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<AgentRunResult> {
+    const taskDesc = [
+      `Fix this issue in the ${task.repo} repository.`,
+      "Analyze the problem, break it into sub-tasks if beneficial, and fix it.",
+      "Make minimal, targeted changes. Do not modify test files.",
+      "Commit all changes before finishing.",
+      "",
+      "## Issue",
+      "",
+      task.problem_statement,
+      task.hints_text ? `\n## Hints\n\n${task.hints_text}` : "",
+    ].join("\n");
+
+    const timeoutS = config.timeout_per_task_s ?? DEFAULT_TIMEOUT_S;
+    const startTime = Date.now();
+
+    try {
+      const agentType = config.models.hydra_orchestrator_model;
+      const { stdout: spawnOutput } = await exec(
+        "hydra",
+        [
+          "spawn",
+          "--task", taskDesc,
+          "--type", agentType,
+          "--repo", workDir,
+          "--auto-approve",
+        ],
+        { cwd: workDir, timeout: 60 },
+      );
+
+      const spawnResult = JSON.parse(spawnOutput) as {
+        agentId: string;
+        resultFile: string;
+        worktreePath: string;
+        branch: string;
+      };
+
+      // Poll for result file
+      const deadline = Date.now() + timeoutS * 1000;
+      while (Date.now() < deadline) {
+        try {
+          await access(spawnResult.resultFile);
+          break;
+        } catch {
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        }
+      }
+
+      const duration = (Date.now() - startTime) / 1000;
+
+      const { stdout: patch } = await exec(
+        "git",
+        ["diff", task.base_commit, "HEAD"],
+        { cwd: spawnResult.worktreePath },
+      ).catch(() => ({ stdout: "", stderr: "" }));
+
+      if (patch) {
+        await exec("git", ["merge", spawnResult.branch, "--no-edit"], {
+          cwd: workDir,
+          timeout: 30,
+        }).catch(() => {});
+      }
+
+      await exec("hydra", ["cleanup", spawnResult.agentId, "--force"], {
+        cwd: workDir,
+        timeout: 30,
+      }).catch(() => {});
+
+      return {
+        model_patch: patch,
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        sub_agents: 1,
+      };
+    } catch (error) {
+      const duration = (Date.now() - startTime) / 1000;
+      return {
+        model_patch: "",
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}

--- a/eval/src/agents/single.ts
+++ b/eval/src/agents/single.ts
@@ -1,0 +1,248 @@
+import { execFile, spawn as spawnChild } from "node:child_process";
+import { join } from "node:path";
+import type {
+  AgentRunner,
+  AgentRunResult,
+  EvalConfig,
+  TaskDefinition,
+} from "../types.ts";
+
+const COST_PER_1K_INPUT_TOKENS = 0.015;
+const COST_PER_1K_OUTPUT_TOKENS = 0.075;
+const DEFAULT_TIMEOUT_S = 600;
+
+/** Build the prompt for the agent */
+function buildPrompt(task: TaskDefinition): string {
+  return [
+    "You are a senior software engineer. Fix the following issue in this repository.",
+    "Make minimal, targeted changes. Do not modify test files.",
+    "After making your changes, commit them with a descriptive message.",
+    "",
+    `## Repository: ${task.repo}`,
+    "",
+    "## Issue",
+    "",
+    task.problem_statement,
+    task.hints_text ? `\n## Hints\n\n${task.hints_text}` : "",
+  ].join("\n");
+}
+
+/** Run a command with stdin support, return stdout */
+function execWithStdin(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number; stdin?: string },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnChild(cmd, args, {
+      cwd: options.cwd,
+      timeout: (options.timeout ?? DEFAULT_TIMEOUT_S) * 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    child.stderr?.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0 && !stdout) {
+        reject(new Error(`Process exited with code ${code}: ${stderr}`));
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+
+    child.on("error", reject);
+
+    if (options.stdin) {
+      child.stdin?.write(options.stdin);
+      child.stdin?.end();
+    }
+  });
+}
+
+/** Run an exec command and return stdout */
+function exec(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      {
+        cwd: options.cwd,
+        timeout: (options.timeout ?? DEFAULT_TIMEOUT_S) * 1000,
+        maxBuffer: 50 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error && !stdout) {
+          reject(error);
+        } else {
+          resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
+        }
+      },
+    );
+  });
+}
+
+/** Parse Claude Code JSON output for token usage and cost */
+function parseClaudeJsonOutput(output: string): {
+  tokens: number;
+  cost: number;
+} {
+  try {
+    const data = JSON.parse(output);
+    const inputTokens = data.usage?.input_tokens ?? 0;
+    const outputTokens = data.usage?.output_tokens ?? 0;
+    const totalCost = data.cost_usd ?? estimateCost(inputTokens + outputTokens);
+    return { tokens: inputTokens + outputTokens, cost: totalCost };
+  } catch {
+    return { tokens: 0, cost: 0 };
+  }
+}
+
+/** Estimate cost from tokens (rough approximation) */
+function estimateCost(tokens: number): number {
+  const inputTokens = tokens * 0.7;
+  const outputTokens = tokens * 0.3;
+  return (
+    (inputTokens / 1000) * COST_PER_1K_INPUT_TOKENS +
+    (outputTokens / 1000) * COST_PER_1K_OUTPUT_TOKENS
+  );
+}
+
+/** Capture the git diff produced by the agent */
+async function capturePatch(
+  workDir: string,
+  baseCommit: string,
+): Promise<string> {
+  // Check for committed changes first
+  const { stdout: committedPatch } = await exec(
+    "git",
+    ["diff", baseCommit, "HEAD"],
+    { cwd: workDir },
+  );
+  if (committedPatch.trim()) return committedPatch;
+
+  // Fall back to uncommitted changes
+  const { stdout: patch } = await exec("git", ["diff"], { cwd: workDir });
+  return patch;
+}
+
+/** Single Claude Code agent runner */
+export class SingleClaudeRunner implements AgentRunner {
+  async run(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<AgentRunResult> {
+    const prompt = buildPrompt(task);
+    const timeoutS = config.timeout_per_task_s ?? DEFAULT_TIMEOUT_S;
+    const startTime = Date.now();
+
+    try {
+      // Use stdin for prompt to avoid arg length limits (E2BIG)
+      const { stdout, stderr } = await execWithStdin(
+        "claude",
+        [
+          "-p",
+          "--output-format",
+          "json",
+          "--dangerously-skip-permissions",
+          "--model",
+          config.models.claude_model,
+        ],
+        { cwd: workDir, timeout: timeoutS, stdin: prompt },
+      );
+
+      const duration = (Date.now() - startTime) / 1000;
+      const modelPatch = await capturePatch(workDir, task.base_commit);
+      const { tokens, cost } = parseClaudeJsonOutput(stdout);
+
+      return {
+        model_patch: modelPatch,
+        tokens,
+        duration_s: Math.round(duration),
+        cost_usd: cost,
+      };
+    } catch (error) {
+      const duration = (Date.now() - startTime) / 1000;
+      return {
+        model_patch: "",
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+/** Single Codex agent runner */
+export class SingleCodexRunner implements AgentRunner {
+  async run(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<AgentRunResult> {
+    const prompt = buildPrompt(task);
+    const timeoutS = config.timeout_per_task_s ?? DEFAULT_TIMEOUT_S;
+    const startTime = Date.now();
+
+    try {
+      // Codex exec mode with full-auto for non-interactive
+      const { stdout, stderr } = await execWithStdin(
+        "codex",
+        [
+          "exec",
+          "--full-auto",
+          "--json",
+          ...(config.models.codex_model ? ["-m", config.models.codex_model] : []),
+        ],
+        { cwd: workDir, timeout: timeoutS, stdin: prompt },
+      );
+
+      const duration = (Date.now() - startTime) / 1000;
+      const modelPatch = await capturePatch(workDir, task.base_commit);
+
+      // Parse codex JSON output for cost info
+      let cost = 0;
+      try {
+        const lines = stdout
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean);
+        const data = JSON.parse(lines[lines.length - 1]);
+        cost = data.cost_usd ?? 0;
+      } catch {}
+
+      return {
+        model_patch: modelPatch,
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: cost,
+      };
+    } catch (error) {
+      const duration = (Date.now() - startTime) / 1000;
+      return {
+        model_patch: "",
+        tokens: 0,
+        duration_s: Math.round(duration),
+        cost_usd: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}

--- a/eval/src/cli.ts
+++ b/eval/src/cli.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+import { loadTasksFromFile, loadDefaultTasks, downloadAndFilter, taskMeta } from "./dataset.ts";
+import { runEvaluation } from "./runner.ts";
+import { listRuns, loadRunResult, generateRunId } from "./results.ts";
+import { compareRuns, formatComparison } from "./compare.ts";
+import type { EvalConfig, AgentMode, ModelConfig } from "./types.ts";
+import { DEFAULT_MODELS } from "./types.ts";
+
+const USAGE = `
+eval - Hydra evaluation framework
+
+Usage:
+  eval run [options]       Run an evaluation
+  eval compare <a> <b>     Compare two runs
+  eval list                List all runs
+  eval report <run_id>     Show run report
+  eval download [options]  Download task set
+  eval tasks <file>        Show task metadata
+
+Run Options:
+  --mode <mode>            Agent mode: single-claude, single-codex, hydra (default: single-claude)
+  --tasks <file>           Task file path (default: auto-download SWE-bench multi-file)
+  --prompt-version <ver>   Prompt version tag (default: v1)
+  --run-id <id>            Custom run ID (default: auto-generated)
+  --sub-agents <types>     Hydra sub-agent types, comma-separated (default: claude,codex)
+  --timeout <seconds>      Per-task timeout (default: 600)
+  --max-tasks <n>          Max tasks to run (for quick tests)
+  --swebench-eval          Run SWE-bench Docker evaluation
+  --benchmark <name>       Benchmark name (default: swe-bench)
+
+Model Options:
+  --claude-model <model>   Claude model for single-claude mode (default: sonnet)
+  --codex-model <model>    Codex model for single-codex mode (default: codex config.toml)
+  --orchestrator-model <m> Hydra orchestrator model (default: sonnet)
+  --sub-claude-model <m>   Hydra sub-agent Claude model (default: sonnet)
+  --sub-codex-model <m>    Hydra sub-agent Codex model (default: codex config.toml)
+
+Download Options:
+  --dataset <id>           HuggingFace dataset ID (default: princeton-nlp/SWE-bench)
+  --split <split>          Dataset split (default: test)
+  --min-files <n>          Minimum files changed (default: 2)
+  --max-tasks <n>          Maximum tasks to download (default: 50)
+  --output <name>          Output file name (without extension)
+
+Examples:
+  eval run --mode single-claude --max-tasks 5
+  eval run --mode hydra --orchestrator claude --prompt-version v2
+  eval compare run-20260322-001 run-20260322-002
+  eval download --min-files 3 --max-tasks 20 --output swe-bench-complex
+`;
+
+const VALID_MODES: AgentMode[] = ["single-claude", "single-codex", "hydra"];
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (!command || command === "--help" || command === "-h") {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const rest = args.slice(1);
+
+  switch (command) {
+    case "run":
+      await handleRun(rest);
+      break;
+    case "compare":
+      await handleCompare(rest);
+      break;
+    case "list":
+      await handleList();
+      break;
+    case "report":
+      await handleReport(rest);
+      break;
+    case "download":
+      await handleDownload(rest);
+      break;
+    case "tasks":
+      await handleTasks(rest);
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.log(USAGE);
+      process.exit(1);
+  }
+}
+
+async function handleRun(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      mode: { type: "string", default: "single-claude" },
+      tasks: { type: "string" },
+      "prompt-version": { type: "string", default: "v1" },
+      "run-id": { type: "string" },
+      "sub-agents": { type: "string", default: "claude,codex" },
+      timeout: { type: "string", default: "600" },
+      "max-tasks": { type: "string" },
+      "max-workers": { type: "string", default: "1" },
+      "swebench-eval": { type: "boolean", default: false },
+      benchmark: { type: "string", default: "swe-bench" },
+      // Model options
+      "claude-model": { type: "string" },
+      "codex-model": { type: "string" },
+      "orchestrator-model": { type: "string" },
+      "sub-claude-model": { type: "string" },
+      "sub-codex-model": { type: "string" },
+    },
+  });
+
+  const mode = values.mode as AgentMode;
+  if (!VALID_MODES.includes(mode)) {
+    console.error(
+      `Invalid mode: ${mode}. Must be one of: ${VALID_MODES.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  // Load tasks
+  let tasks;
+  if (values.tasks) {
+    tasks = await loadTasksFromFile(values.tasks);
+  } else {
+    tasks = await loadDefaultTasks();
+  }
+
+  const maxTasks = values["max-tasks"]
+    ? parseInt(values["max-tasks"], 10)
+    : undefined;
+  if (maxTasks !== undefined) {
+    tasks = tasks.slice(0, maxTasks);
+  }
+
+  if (tasks.length === 0) {
+    console.error("No tasks to run. Use --tasks or download a task set first.");
+    process.exit(1);
+  }
+
+  const models: ModelConfig = {
+    ...DEFAULT_MODELS,
+    ...(values["claude-model"] && { claude_model: values["claude-model"] }),
+    ...(values["codex-model"] && { codex_model: values["codex-model"] }),
+    ...(values["orchestrator-model"] && { hydra_orchestrator_model: values["orchestrator-model"] }),
+    ...(values["sub-claude-model"] && { hydra_sub_claude_model: values["sub-claude-model"] }),
+    ...(values["sub-codex-model"] && { hydra_sub_codex_model: values["sub-codex-model"] }),
+  };
+
+  const config: EvalConfig = {
+    run_id: values["run-id"] ?? generateRunId(),
+    mode,
+    models,
+    sub_agent_types:
+      mode === "hydra" ? values["sub-agents"]?.split(",") : undefined,
+    prompt_version: values["prompt-version"] ?? "v1",
+    benchmark: values.benchmark ?? "swe-bench",
+    timeout_per_task_s: parseInt(values.timeout ?? "600", 10),
+    max_workers: parseInt(values["max-workers"] ?? "1", 10),
+    run_swebench_eval: values["swebench-eval"],
+  };
+
+  await runEvaluation(tasks, config);
+}
+
+async function handleCompare(args: string[]): Promise<void> {
+  const [runA, runB] = args;
+  if (!runA || !runB) {
+    console.error("Usage: eval compare <run_id_a> <run_id_b>");
+    process.exit(1);
+  }
+
+  const comparison = await compareRuns(runA, runB);
+  console.log(formatComparison(comparison));
+}
+
+async function handleList(): Promise<void> {
+  const runs = await listRuns();
+  if (runs.length === 0) {
+    console.log("No evaluation runs found.");
+    return;
+  }
+
+  console.log("Available runs:\n");
+  for (const runId of runs) {
+    try {
+      const result = await loadRunResult(runId);
+      const { summary, config } = result;
+      console.log(
+        `  ${runId}  mode=${config.mode}  prompt=${config.prompt_version}  ` +
+          `pass=${(summary.pass_rate * 100).toFixed(0)}%  ` +
+          `tasks=${summary.total}  cost=$${summary.total_cost_usd.toFixed(2)}`,
+      );
+    } catch {
+      console.log(`  ${runId}  (error loading result)`);
+    }
+  }
+}
+
+async function handleReport(args: string[]): Promise<void> {
+  const runId = args[0];
+  if (!runId) {
+    console.error("Usage: eval report <run_id>");
+    process.exit(1);
+  }
+
+  const result = await loadRunResult(runId);
+  const { config, summary, tasks } = result;
+
+  console.log(`# Evaluation Report: ${result.run_id}`);
+  console.log();
+  console.log("## Configuration");
+  console.log(`- Mode: ${config.mode}`);
+  console.log(`- Prompt Version: ${config.prompt_version}`);
+  console.log(`- Benchmark: ${config.benchmark}`);
+  if (config.mode === "hydra") {
+    console.log(`- Orchestrator: ${config.models.hydra_orchestrator_model}`);
+  }
+  if (config.sub_agent_types) {
+    console.log(`- Sub-agents: ${config.sub_agent_types.join(", ")}`);
+  }
+  console.log(`- Started: ${result.started_at}`);
+  console.log(`- Completed: ${result.completed_at}`);
+  console.log();
+  console.log("## Summary");
+  console.log(`- Total Tasks: ${summary.total}`);
+  console.log(`- Resolved: ${summary.resolved}`);
+  console.log(`- Pass Rate: ${(summary.pass_rate * 100).toFixed(1)}%`);
+  console.log(`- Total Tokens: ${summary.total_tokens.toLocaleString()}`);
+  console.log(`- Total Cost: $${summary.total_cost_usd.toFixed(2)}`);
+  console.log(`- Avg Duration: ${summary.avg_duration_s}s`);
+  console.log();
+  console.log("## Tasks");
+  console.log();
+  console.log("| Task | Pass | Tokens | Duration | Cost |");
+  console.log("|------|------|--------|----------|------|");
+  for (const task of tasks) {
+    console.log(
+      `| ${task.task_id} | ${task.pass ? "PASS" : "FAIL"} | ${task.tokens.toLocaleString()} | ${task.duration_s}s | $${task.cost_usd.toFixed(2)} |`,
+    );
+    if (task.error) {
+      console.log(`| | Error: ${task.error.slice(0, 80)} | | | |`);
+    }
+  }
+}
+
+async function handleDownload(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      dataset: { type: "string", default: "princeton-nlp/SWE-bench" },
+      split: { type: "string", default: "test" },
+      "min-files": { type: "string", default: "2" },
+      "max-tasks": { type: "string", default: "50" },
+      output: { type: "string", default: "swe-bench-multi-file" },
+    },
+  });
+
+  await downloadAndFilter({
+    dataset: values.dataset ?? "princeton-nlp/SWE-bench",
+    split: values.split ?? "test",
+    minFiles: parseInt(values["min-files"] ?? "2", 10),
+    maxTasks: parseInt(values["max-tasks"] ?? "50", 10),
+    outputName: values.output ?? "swe-bench-multi-file",
+  });
+}
+
+async function handleTasks(args: string[]): Promise<void> {
+  const filePath = args[0];
+  if (!filePath) {
+    console.error("Usage: eval tasks <file>");
+    process.exit(1);
+  }
+
+  const tasks = await loadTasksFromFile(filePath);
+  console.log(`Tasks in ${filePath}: ${tasks.length}\n`);
+  console.log("| # | Instance ID | Repo | Files | Lines |");
+  console.log("|---|-------------|------|-------|-------|");
+
+  for (let i = 0; i < tasks.length; i++) {
+    const meta = taskMeta(tasks[i]);
+    console.log(
+      `| ${i + 1} | ${meta.instance_id} | ${meta.repo} | ${meta.num_files} | ${meta.num_lines} |`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/eval/src/compare.ts
+++ b/eval/src/compare.ts
@@ -1,0 +1,185 @@
+import type {
+  RunResult,
+  RunComparison,
+  TaskDiff,
+  EvalConfig,
+} from "./types.ts";
+import { loadRunResult } from "./results.ts";
+
+/** Compare two evaluation runs */
+export async function compareRuns(
+  runIdA: string,
+  runIdB: string,
+): Promise<RunComparison> {
+  const [resultA, resultB] = await Promise.all([
+    loadRunResult(runIdA),
+    loadRunResult(runIdB),
+  ]);
+
+  return compareResults(resultA, resultB);
+}
+
+/** Compare two run results directly */
+export function compareResults(
+  resultA: RunResult,
+  resultB: RunResult,
+): RunComparison {
+  // Find config differences
+  const configDiff: Record<string, { a: unknown; b: unknown }> = {};
+  const configKeys = new Set([
+    ...Object.keys(resultA.config),
+    ...Object.keys(resultB.config),
+  ]);
+
+  for (const key of configKeys) {
+    const aVal = (resultA.config as unknown as Record<string, unknown>)[key];
+    const bVal = (resultB.config as unknown as Record<string, unknown>)[key];
+    if (JSON.stringify(aVal) !== JSON.stringify(bVal)) {
+      configDiff[key] = { a: aVal, b: bVal };
+    }
+  }
+
+  // Compare per-task results
+  const taskMapA = new Map(resultA.tasks.map((t) => [t.task_id, t]));
+  const taskMapB = new Map(resultB.tasks.map((t) => [t.task_id, t]));
+  const allTaskIds = new Set([...taskMapA.keys(), ...taskMapB.keys()]);
+
+  const taskDiffs: TaskDiff[] = [];
+  for (const taskId of allTaskIds) {
+    const a = taskMapA.get(taskId);
+    const b = taskMapB.get(taskId);
+
+    const passA = a?.pass ?? false;
+    const passB = b?.pass ?? false;
+
+    let status: TaskDiff["status"] = "unchanged";
+    if (!passA && passB) status = "improved";
+    else if (passA && !passB) status = "regressed";
+
+    taskDiffs.push({
+      task_id: taskId,
+      pass: { a: passA, b: passB },
+      tokens: { a: a?.tokens ?? 0, b: b?.tokens ?? 0 },
+      duration_s: { a: a?.duration_s ?? 0, b: b?.duration_s ?? 0 },
+      status,
+    });
+  }
+
+  // Summary comparison
+  const sa = resultA.summary;
+  const sb = resultB.summary;
+
+  return {
+    run_a: resultA.run_id,
+    run_b: resultB.run_id,
+    config_diff: configDiff,
+    task_diffs: taskDiffs,
+    summary_diff: {
+      pass_rate: {
+        a: sa.pass_rate,
+        b: sb.pass_rate,
+        delta: sb.pass_rate - sa.pass_rate,
+      },
+      total_tokens: {
+        a: sa.total_tokens,
+        b: sb.total_tokens,
+        delta: sb.total_tokens - sa.total_tokens,
+      },
+      total_cost_usd: {
+        a: sa.total_cost_usd,
+        b: sb.total_cost_usd,
+        delta: sb.total_cost_usd - sa.total_cost_usd,
+      },
+      avg_duration_s: {
+        a: sa.avg_duration_s,
+        b: sb.avg_duration_s,
+        delta: sb.avg_duration_s - sa.avg_duration_s,
+      },
+    },
+  };
+}
+
+/** Format a comparison as a human-readable report */
+export function formatComparison(comparison: RunComparison): string {
+  const lines: string[] = [];
+
+  lines.push(`# Evaluation Comparison: ${comparison.run_a} vs ${comparison.run_b}`);
+  lines.push("");
+
+  // Config diff
+  if (Object.keys(comparison.config_diff).length > 0) {
+    lines.push("## Configuration Differences");
+    lines.push("");
+    lines.push("| Parameter | Run A | Run B |");
+    lines.push("|-----------|-------|-------|");
+    for (const [key, { a, b }] of Object.entries(comparison.config_diff)) {
+      lines.push(`| ${key} | ${JSON.stringify(a)} | ${JSON.stringify(b)} |`);
+    }
+    lines.push("");
+  }
+
+  // Summary comparison
+  const sd = comparison.summary_diff;
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Run A | Run B | Delta |");
+  lines.push("|--------|-------|-------|-------|");
+  lines.push(
+    `| Pass Rate | ${(sd.pass_rate.a * 100).toFixed(1)}% | ${(sd.pass_rate.b * 100).toFixed(1)}% | ${sd.pass_rate.delta > 0 ? "+" : ""}${(sd.pass_rate.delta * 100).toFixed(1)}% |`,
+  );
+  lines.push(
+    `| Total Tokens | ${sd.total_tokens.a.toLocaleString()} | ${sd.total_tokens.b.toLocaleString()} | ${sd.total_tokens.delta > 0 ? "+" : ""}${sd.total_tokens.delta.toLocaleString()} |`,
+  );
+  lines.push(
+    `| Total Cost | $${sd.total_cost_usd.a.toFixed(2)} | $${sd.total_cost_usd.b.toFixed(2)} | ${sd.total_cost_usd.delta > 0 ? "+" : ""}$${sd.total_cost_usd.delta.toFixed(2)} |`,
+  );
+  lines.push(
+    `| Avg Duration | ${sd.avg_duration_s.a}s | ${sd.avg_duration_s.b}s | ${sd.avg_duration_s.delta > 0 ? "+" : ""}${sd.avg_duration_s.delta}s |`,
+  );
+  lines.push("");
+
+  // Per-task comparison
+  const improved = comparison.task_diffs.filter(
+    (t) => t.status === "improved",
+  );
+  const regressed = comparison.task_diffs.filter(
+    (t) => t.status === "regressed",
+  );
+
+  if (improved.length > 0) {
+    lines.push(`## Improved Tasks (${improved.length})`);
+    lines.push("");
+    for (const t of improved) {
+      lines.push(`- **${t.task_id}**: FAIL -> PASS`);
+    }
+    lines.push("");
+  }
+
+  if (regressed.length > 0) {
+    lines.push(`## Regressed Tasks (${regressed.length})`);
+    lines.push("");
+    for (const t of regressed) {
+      lines.push(`- **${t.task_id}**: PASS -> FAIL`);
+    }
+    lines.push("");
+  }
+
+  // Full task table
+  lines.push("## All Tasks");
+  lines.push("");
+  lines.push("| Task | Run A | Run B | Status | Tokens A | Tokens B | Time A | Time B |");
+  lines.push("|------|-------|-------|--------|----------|----------|--------|--------|");
+  for (const t of comparison.task_diffs) {
+    const statusIcon =
+      t.status === "improved"
+        ? "UP"
+        : t.status === "regressed"
+          ? "DOWN"
+          : "-";
+    lines.push(
+      `| ${t.task_id} | ${t.pass.a ? "PASS" : "FAIL"} | ${t.pass.b ? "PASS" : "FAIL"} | ${statusIcon} | ${t.tokens.a} | ${t.tokens.b} | ${t.duration_s.a}s | ${t.duration_s.b}s |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/eval/src/dataset.ts
+++ b/eval/src/dataset.ts
@@ -1,0 +1,172 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { TaskDefinition, TaskMeta } from "./types.ts";
+
+const EVAL_ROOT = join(fileURLToPath(import.meta.url), "../..");
+const TASKS_DIR = join(EVAL_ROOT, "tasks");
+
+const HF_API_BASE = "https://datasets-server.huggingface.co";
+const PAGE_SIZE = 100;
+
+/** Count files changed in a unified diff patch */
+export function countPatchFiles(patch: string): string[] {
+  const files: string[] = [];
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("diff --git")) {
+      const match = line.match(/diff --git a\/(.+?) b\//);
+      if (match) {
+        files.push(match[1]);
+      }
+    }
+  }
+  return files;
+}
+
+/** Count total lines changed in a patch */
+export function countPatchLines(patch: string): number {
+  let lines = 0;
+  for (const line of patch.split("\n")) {
+    if (
+      (line.startsWith("+") || line.startsWith("-")) &&
+      !line.startsWith("+++") &&
+      !line.startsWith("---")
+    ) {
+      lines++;
+    }
+  }
+  return lines;
+}
+
+/** Derive task metadata from a task definition */
+export function taskMeta(task: TaskDefinition): TaskMeta {
+  const files = countPatchFiles(task.patch);
+  return {
+    instance_id: task.instance_id,
+    repo: task.repo,
+    num_files: files.length,
+    files_changed: files,
+    num_lines: countPatchLines(task.patch),
+  };
+}
+
+/** Load tasks from a local JSON file */
+export async function loadTasksFromFile(
+  filePath: string,
+): Promise<TaskDefinition[]> {
+  const raw = await readFile(filePath, "utf-8");
+  return JSON.parse(raw) as TaskDefinition[];
+}
+
+/** Fetch SWE-bench dataset from HuggingFace API */
+export async function fetchFromHuggingFace(
+  dataset: string,
+  split: string,
+  maxRows?: number,
+): Promise<TaskDefinition[]> {
+  const tasks: TaskDefinition[] = [];
+  let offset = 0;
+  const limit = maxRows ?? Infinity;
+
+  while (tasks.length < limit) {
+    const batchSize = Math.min(PAGE_SIZE, limit - tasks.length);
+    const url = `${HF_API_BASE}/rows?dataset=${encodeURIComponent(dataset)}&config=default&split=${split}&offset=${offset}&length=${batchSize}`;
+
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      throw new Error(
+        `HuggingFace API error: ${resp.status} ${resp.statusText}`,
+      );
+    }
+
+    const data = (await resp.json()) as {
+      rows: Array<{ row: TaskDefinition }>;
+    };
+    if (data.rows.length === 0) break;
+
+    for (const { row } of data.rows) {
+      tasks.push(row);
+    }
+
+    offset += data.rows.length;
+    if (data.rows.length < batchSize) break;
+  }
+
+  return tasks;
+}
+
+/** Filter tasks by minimum number of files changed */
+export function filterMultiFile(
+  tasks: TaskDefinition[],
+  minFiles: number = 2,
+): TaskDefinition[] {
+  return tasks.filter((t) => countPatchFiles(t.patch).length >= minFiles);
+}
+
+/** Filter tasks by repository */
+export function filterByRepo(
+  tasks: TaskDefinition[],
+  repo: string,
+): TaskDefinition[] {
+  return tasks.filter((t) => t.repo === repo);
+}
+
+/** Download and cache a filtered task set */
+export async function downloadAndFilter(options: {
+  dataset: string;
+  split: string;
+  minFiles?: number;
+  repos?: string[];
+  maxTasks?: number;
+  outputName: string;
+}): Promise<TaskDefinition[]> {
+  const { dataset, split, minFiles = 2, repos, maxTasks, outputName } = options;
+
+  const outputPath = join(TASKS_DIR, `${outputName}.json`);
+  if (existsSync(outputPath)) {
+    console.log(`Using cached task set: ${outputPath}`);
+    return loadTasksFromFile(outputPath);
+  }
+
+  console.log(`Fetching dataset: ${dataset} (split: ${split})`);
+  const allTasks = await fetchFromHuggingFace(dataset, split);
+  console.log(`Fetched ${allTasks.length} tasks`);
+
+  let filtered = filterMultiFile(allTasks, minFiles);
+  console.log(
+    `After multi-file filter (>=${minFiles} files): ${filtered.length} tasks`,
+  );
+
+  if (repos && repos.length > 0) {
+    filtered = filtered.filter((t) => repos.includes(t.repo));
+    console.log(
+      `After repo filter (${repos.join(", ")}): ${filtered.length} tasks`,
+    );
+  }
+
+  if (maxTasks && filtered.length > maxTasks) {
+    filtered = filtered.slice(0, maxTasks);
+  }
+
+  await writeFile(outputPath, JSON.stringify(filtered, null, 2));
+  console.log(`Saved ${filtered.length} tasks to ${outputPath}`);
+
+  return filtered;
+}
+
+/** Load the default multi-file task set (download if needed) */
+export async function loadDefaultTasks(): Promise<TaskDefinition[]> {
+  const defaultPath = join(TASKS_DIR, "swe-bench-multi-file.json");
+  if (existsSync(defaultPath)) {
+    return loadTasksFromFile(defaultPath);
+  }
+
+  return downloadAndFilter({
+    dataset: "princeton-nlp/SWE-bench",
+    split: "test",
+    minFiles: 2,
+    maxTasks: 50,
+    outputName: "swe-bench-multi-file",
+  });
+}

--- a/eval/src/evaluator.ts
+++ b/eval/src/evaluator.ts
@@ -1,0 +1,240 @@
+import { execFile } from "node:child_process";
+import { writeFile, readFile, mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import type { TaskDefinition, SWEBenchPrediction } from "./types.ts";
+
+const EVAL_ROOT = join(fileURLToPath(import.meta.url), "../..");
+const REPO_CACHE_DIR = join(tmpdir(), "eval-repo-cache");
+
+/** Run a command and return stdout */
+function exec(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      {
+        cwd: options.cwd,
+        timeout: (options.timeout ?? 600) * 1000,
+        maxBuffer: 50 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error && !stdout) {
+          reject(error);
+        } else {
+          resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
+        }
+      },
+    );
+  });
+}
+
+/** Write predictions to JSONL for SWE-bench evaluation */
+export async function writePredictions(
+  predictions: SWEBenchPrediction[],
+  outputPath: string,
+): Promise<void> {
+  const lines = predictions.map((p) => JSON.stringify(p)).join("\n") + "\n";
+  await writeFile(outputPath, lines);
+}
+
+/** Run SWE-bench Docker evaluation on predictions */
+export async function runSWEBenchEval(options: {
+  predictionsPath: string;
+  dataset: string;
+  runId: string;
+  maxWorkers?: number;
+}): Promise<Map<string, boolean>> {
+  const { predictionsPath, dataset, runId, maxWorkers = 4 } = options;
+
+  const outputDir = join(EVAL_ROOT, "results", runId, "swebench-eval");
+  await mkdir(outputDir, { recursive: true });
+
+  try {
+    const { stdout, stderr } = await exec(
+      "python3",
+      [
+        "-m",
+        "swebench.harness.run_evaluation",
+        "--dataset_name",
+        dataset,
+        "--predictions_path",
+        predictionsPath,
+        "--max_workers",
+        String(maxWorkers),
+        "--run_id",
+        runId,
+        "--cache_level",
+        "env",
+      ],
+      { cwd: outputDir, timeout: 3600 },
+    );
+
+    console.log("SWE-bench evaluation output:", stdout);
+    if (stderr) console.error("SWE-bench stderr:", stderr);
+
+    return parseSWEBenchResults(outputDir, runId);
+  } catch (error) {
+    console.error("SWE-bench evaluation failed:", error);
+    console.log("Falling back to patch-based evaluation");
+    return new Map();
+  }
+}
+
+/** Parse SWE-bench evaluation results from output directory */
+async function parseSWEBenchResults(
+  outputDir: string,
+  runId: string,
+): Promise<Map<string, boolean>> {
+  const results = new Map<string, boolean>();
+
+  const resultsFile = (await readdir(outputDir)).find((file) =>
+    file.endsWith(`.${runId}.json`),
+  );
+  if (resultsFile) {
+    const resultsPath = join(outputDir, resultsFile);
+    const raw = await readFile(resultsPath, "utf-8");
+    const data = JSON.parse(raw) as Record<string, { resolved: boolean }>;
+    for (const [instanceId, result] of Object.entries(data)) {
+      results.set(instanceId, result.resolved);
+    }
+  }
+
+  return results;
+}
+
+/** Simple patch-based evaluation (fallback when SWE-bench Docker not available) */
+export function evaluatePatchSimple(
+  modelPatch: string,
+  goldPatch: string,
+): { applied: boolean; similarity: number } {
+  if (!modelPatch.trim()) {
+    return { applied: false, similarity: 0 };
+  }
+
+  const modelFiles = extractPatchFiles(modelPatch);
+  const goldFiles = extractPatchFiles(goldPatch);
+
+  const modelFileSet = new Set(modelFiles);
+  const goldFileSet = new Set(goldFiles);
+  const intersection = new Set(
+    [...modelFileSet].filter((f) => goldFileSet.has(f)),
+  );
+
+  const fileOverlap =
+    goldFileSet.size > 0 ? intersection.size / goldFileSet.size : 0;
+
+  const modelLines = extractChangedLines(modelPatch);
+  const goldLines = extractChangedLines(goldPatch);
+  const lineOverlap = computeLineOverlap(modelLines, goldLines);
+
+  const similarity = fileOverlap * 0.4 + lineOverlap * 0.6;
+
+  return {
+    applied: modelPatch.trim().length > 0,
+    similarity,
+  };
+}
+
+/** Extract file paths from a unified diff */
+function extractPatchFiles(patch: string): string[] {
+  const files: string[] = [];
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("diff --git")) {
+      const match = line.match(/diff --git a\/(.+?) b\//);
+      if (match) files.push(match[1]);
+    }
+  }
+  return files;
+}
+
+/** Extract added/removed lines from a patch */
+function extractChangedLines(patch: string): Set<string> {
+  const lines = new Set<string>();
+  for (const line of patch.split("\n")) {
+    if (
+      (line.startsWith("+") || line.startsWith("-")) &&
+      !line.startsWith("+++") &&
+      !line.startsWith("---") &&
+      !line.startsWith("diff ")
+    ) {
+      lines.add(line.slice(1).trim());
+    }
+  }
+  return lines;
+}
+
+/** Compute overlap between two sets of lines */
+function computeLineOverlap(a: Set<string>, b: Set<string>): number {
+  if (b.size === 0) return 0;
+  const intersection = new Set([...a].filter((line) => b.has(line)));
+  return intersection.size / b.size;
+}
+
+/** Get or create a cached bare clone of a repository */
+async function getRepoCachePath(repo: string): Promise<string> {
+  await mkdir(REPO_CACHE_DIR, { recursive: true });
+  const safeRepo = repo.replace(/\//g, "__");
+  const cachePath = join(REPO_CACHE_DIR, safeRepo);
+
+  if (existsSync(cachePath)) {
+    // Update the cache
+    console.log(`  Using cached repo: ${repo}`);
+    await exec("git", ["fetch", "--all"], {
+      cwd: cachePath,
+      timeout: 120,
+    }).catch(() => {});
+    return cachePath;
+  }
+
+  console.log(`  Cloning repo (first time): ${repo}`);
+  const repoUrl = `https://github.com/${repo}.git`;
+  await exec("git", ["clone", "--bare", repoUrl, cachePath], {
+    timeout: 600,
+  });
+
+  return cachePath;
+}
+
+/** Setup a task's working directory using repo cache */
+export async function setupTaskWorkdir(
+  task: TaskDefinition,
+  baseDir: string,
+): Promise<string> {
+  const safeId = task.instance_id.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const workDir = join(baseDir, safeId);
+
+  if (existsSync(workDir)) {
+    // Reset to base commit
+    await exec("git", ["checkout", "-f", task.base_commit], {
+      cwd: workDir,
+      timeout: 60,
+    });
+    await exec("git", ["clean", "-fd"], { cwd: workDir, timeout: 30 });
+    return workDir;
+  }
+
+  // Clone from cache
+  const cachePath = await getRepoCachePath(task.repo);
+  await exec("git", ["clone", cachePath, workDir], { timeout: 300 });
+
+  // Add the original remote for proper diff headers
+  await exec(
+    "git",
+    ["remote", "set-url", "origin", `https://github.com/${task.repo}.git`],
+    { cwd: workDir, timeout: 10 },
+  );
+
+  await exec("git", ["checkout", "-f", task.base_commit], {
+    cwd: workDir,
+    timeout: 60,
+  });
+
+  return workDir;
+}

--- a/eval/src/results.ts
+++ b/eval/src/results.ts
@@ -1,0 +1,110 @@
+import { readFile, writeFile, readdir, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type {
+  RunResult,
+  TaskResult,
+  EvalConfig,
+  RunSummary,
+} from "./types.ts";
+
+const EVAL_ROOT = join(fileURLToPath(import.meta.url), "../..");
+const RESULTS_DIR = join(EVAL_ROOT, "results");
+
+/** Compute summary statistics from task results */
+export function computeSummary(tasks: TaskResult[]): RunSummary {
+  const resolved = tasks.filter((t) => t.pass).length;
+  const totalTokens = tasks.reduce((sum, t) => sum + t.tokens, 0);
+  const totalCost = tasks.reduce((sum, t) => sum + t.cost_usd, 0);
+  const avgDuration =
+    tasks.length > 0
+      ? tasks.reduce((sum, t) => sum + t.duration_s, 0) / tasks.length
+      : 0;
+
+  return {
+    total: tasks.length,
+    resolved,
+    pass_rate: tasks.length > 0 ? resolved / tasks.length : 0,
+    total_tokens: totalTokens,
+    total_cost_usd: Math.round(totalCost * 100) / 100,
+    avg_duration_s: Math.round(avgDuration),
+  };
+}
+
+/** Save a run result to disk */
+export async function saveRunResult(result: RunResult): Promise<string> {
+  const runDir = join(RESULTS_DIR, result.run_id);
+  await mkdir(runDir, { recursive: true });
+
+  const resultPath = join(runDir, "result.json");
+  await writeFile(resultPath, JSON.stringify(result, null, 2));
+
+  // Also save individual task results for easy inspection
+  const tasksDir = join(runDir, "tasks");
+  await mkdir(tasksDir, { recursive: true });
+  for (const task of result.tasks) {
+    const taskPath = join(tasksDir, `${task.task_id}.json`);
+    await writeFile(taskPath, JSON.stringify(task, null, 2));
+  }
+
+  // Save a summary for quick reference
+  const summaryPath = join(runDir, "summary.json");
+  await writeFile(
+    summaryPath,
+    JSON.stringify(
+      {
+        run_id: result.run_id,
+        config: result.config,
+        summary: result.summary,
+        started_at: result.started_at,
+        completed_at: result.completed_at,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return resultPath;
+}
+
+/** Load a run result from disk */
+export async function loadRunResult(runId: string): Promise<RunResult> {
+  const resultPath = join(RESULTS_DIR, runId, "result.json");
+  const raw = await readFile(resultPath, "utf-8");
+  return JSON.parse(raw) as RunResult;
+}
+
+/** List all available run IDs */
+export async function listRuns(): Promise<string[]> {
+  if (!existsSync(RESULTS_DIR)) return [];
+
+  const entries = await readdir(RESULTS_DIR, { withFileTypes: true });
+  const runs: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const resultPath = join(RESULTS_DIR, entry.name, "result.json");
+      if (existsSync(resultPath)) {
+        runs.push(entry.name);
+      }
+    }
+  }
+
+  return runs.sort();
+}
+
+/** Load all run results */
+export async function loadAllRuns(): Promise<RunResult[]> {
+  const runIds = await listRuns();
+  return Promise.all(runIds.map(loadRunResult));
+}
+
+/** Generate a unique run ID */
+export function generateRunId(): string {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10).replace(/-/g, "");
+  const time = now.toISOString().slice(11, 19).replace(/:/g, "");
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `run-${date}-${time}-${rand}`;
+}

--- a/eval/src/runner.ts
+++ b/eval/src/runner.ts
@@ -1,0 +1,264 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type {
+  EvalConfig,
+  TaskDefinition,
+  TaskResult,
+  RunResult,
+  AgentRunner,
+  SWEBenchPrediction,
+} from "./types.ts";
+import { SingleClaudeRunner, SingleCodexRunner } from "./agents/single.ts";
+import { HydraRunner } from "./agents/hydra.ts";
+import {
+  setupTaskWorkdir,
+  writePredictions,
+  runSWEBenchEval,
+} from "./evaluator.ts";
+import { computeSummary, saveRunResult, generateRunId } from "./results.ts";
+
+/** Create the appropriate agent runner for the config */
+function createRunner(config: EvalConfig): AgentRunner {
+  switch (config.mode) {
+    case "single-claude":
+      return new SingleClaudeRunner();
+    case "single-codex":
+      return new SingleCodexRunner();
+    case "hydra":
+      return new HydraRunner();
+    default:
+      throw new Error(`Unknown mode: ${config.mode}`);
+  }
+}
+
+/** Run a single task and return the result */
+async function runTask(
+  task: TaskDefinition,
+  runner: AgentRunner,
+  config: EvalConfig,
+  workBaseDir: string,
+  taskIndex: number,
+  totalTasks: number,
+): Promise<TaskResult> {
+  console.log(`\n--- [${taskIndex + 1}/${totalTasks}] ${task.instance_id} ---`);
+  console.log(`  Repo: ${task.repo}`);
+
+  try {
+    console.log(`  Setting up workdir...`);
+    const workDir = await setupTaskWorkdir(task, workBaseDir);
+
+    console.log(`  Running agent (mode: ${config.mode})...`);
+    const agentResult = await runner.run(task, workDir, config);
+
+    if (agentResult.error) {
+      console.log(`  Error: ${agentResult.error}`);
+      return {
+        task_id: task.instance_id,
+        pass: false,
+        model_patch: agentResult.model_patch,
+        tokens: agentResult.tokens,
+        duration_s: agentResult.duration_s,
+        cost_usd: agentResult.cost_usd,
+        sub_agents: agentResult.sub_agents,
+        merge_failures: agentResult.merge_failures,
+        error: agentResult.error,
+      };
+    }
+
+    const hasPatch = agentResult.model_patch.trim().length > 0;
+    console.log(
+      `  [${taskIndex + 1}/${totalTasks}] ${task.instance_id}: patch_generated=${hasPatch}`,
+    );
+
+    // pass/fail is determined later by SWE-bench Docker evaluation
+    // (run scripts/run-swebench-eval.py after the run completes)
+    return {
+      task_id: task.instance_id,
+      pass: false, // placeholder — real verdict from SWE-bench Docker
+      model_patch: agentResult.model_patch,
+      tokens: agentResult.tokens,
+      duration_s: agentResult.duration_s,
+      cost_usd: agentResult.cost_usd,
+      sub_agents: agentResult.sub_agents,
+      merge_failures: agentResult.merge_failures,
+      eval_detail: {
+        applied: hasPatch,
+        tests_passed: false, // set by update-results-with-swebench.py
+        eval_method: "pending-docker-eval",
+      },
+    };
+  } catch (error) {
+    console.error(
+      `  [${taskIndex + 1}/${totalTasks}] ${task.instance_id}: FAILED - ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return {
+      task_id: task.instance_id,
+      pass: false,
+      model_patch: "",
+      tokens: 0,
+      duration_s: 0,
+      cost_usd: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/** Run tasks with concurrency limit */
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<unknown>,
+): Promise<void> {
+  const queue = items.map((item, i) => ({ item, index: i }));
+  const active: Promise<void>[] = [];
+
+  for (const { item, index } of queue) {
+    const task = fn(item, index)
+      .catch((err) => {
+        console.error(`Task ${index} failed unexpectedly:`, err);
+      })
+      .then(() => {
+        active.splice(active.indexOf(task), 1);
+      });
+    active.push(task);
+    if (active.length >= concurrency) {
+      await Promise.race(active);
+    }
+  }
+
+  await Promise.all(active);
+}
+
+/** Main evaluation runner */
+export async function runEvaluation(
+  tasks: TaskDefinition[],
+  config: EvalConfig,
+): Promise<RunResult> {
+  const runId = config.run_id ?? generateRunId();
+  const updatedConfig = { ...config, run_id: runId };
+  const maxWorkers = config.max_workers ?? 1;
+
+  console.log(`\n========================================`);
+  console.log(`Evaluation Run: ${runId}`);
+  console.log(`Mode: ${config.mode}`);
+  console.log(`Prompt Version: ${config.prompt_version}`);
+  console.log(`Tasks: ${tasks.length}`);
+  console.log(`Workers: ${maxWorkers}`);
+  if (config.mode === "single-claude") {
+    console.log(`Model: ${config.models.claude_model}`);
+  } else if (config.mode === "single-codex") {
+    console.log(`Model: ${config.models.codex_model ?? "(codex default)"}`);
+  } else if (config.mode === "hydra") {
+    console.log(`Orchestrator: ${config.models.hydra_orchestrator_model}`);
+    console.log(`Sub-agents: claude=${config.models.hydra_sub_claude_model}, codex=${config.models.hydra_sub_codex_model ?? "(default)"}`);
+  }
+  console.log(`========================================\n`);
+
+  const runner = createRunner(config);
+  const workBaseDir = join(tmpdir(), "eval-workdirs", runId);
+  await mkdir(workBaseDir, { recursive: true });
+
+  const startedAt = new Date().toISOString();
+  const taskResults: TaskResult[] = new Array(tasks.length);
+
+  if (maxWorkers <= 1) {
+    // Sequential execution
+    for (let i = 0; i < tasks.length; i++) {
+      const result = await runTask(
+        tasks[i],
+        runner,
+        updatedConfig,
+        workBaseDir,
+        i,
+        tasks.length,
+      );
+      taskResults[i] = result;
+
+      const completed = taskResults.filter(Boolean);
+      const resolved = completed.filter((t) => t.pass).length;
+      console.log(
+        `  Progress: ${resolved}/${completed.length} resolved (${((resolved / completed.length) * 100).toFixed(0)}%)`,
+      );
+    }
+  } else {
+    // Parallel execution with concurrency limit
+    console.log(`Running ${tasks.length} tasks with ${maxWorkers} workers...\n`);
+    await runWithConcurrency(tasks, maxWorkers, async (task, index) => {
+      const result = await runTask(
+        task,
+        runner,
+        updatedConfig,
+        workBaseDir,
+        index,
+        tasks.length,
+      );
+      taskResults[index] = result;
+    });
+  }
+
+  const completedAt = new Date().toISOString();
+
+  // Optionally run SWE-bench Docker evaluation
+  if (config.run_swebench_eval) {
+    console.log("\nRunning SWE-bench Docker evaluation...");
+
+    const predictions: SWEBenchPrediction[] = taskResults
+      .filter((t) => t.model_patch)
+      .map((t) => ({
+        instance_id: t.task_id,
+        model_name_or_path: `termcanvas-eval-${config.mode}`,
+        model_patch: t.model_patch,
+      }));
+
+    const predictionsPath = join(workBaseDir, "predictions.jsonl");
+    await writePredictions(predictions, predictionsPath);
+
+    const swebenchResults = await runSWEBenchEval({
+      predictionsPath,
+      dataset:
+        config.benchmark === "swe-bench-lite"
+          ? "SWE-bench/SWE-bench_Lite"
+          : config.benchmark === "swe-bench-pro"
+            ? "ScaleAI/SWE-bench_Pro"
+            : config.benchmark === "swe-bench-verified"
+              ? "SWE-bench/SWE-bench_Verified"
+              : "princeton-nlp/SWE-bench",
+      runId,
+    });
+
+    for (const task of taskResults) {
+      const swebenchPass = swebenchResults.get(task.task_id);
+      if (swebenchPass !== undefined) {
+        task.pass = swebenchPass;
+        if (task.eval_detail) {
+          task.eval_detail.tests_passed = swebenchPass;
+        }
+      }
+    }
+  }
+
+  const result: RunResult = {
+    run_id: runId,
+    config: updatedConfig,
+    started_at: startedAt,
+    completed_at: completedAt,
+    tasks: taskResults,
+    summary: computeSummary(taskResults),
+  };
+
+  const savedPath = await saveRunResult(result);
+  console.log(`\n========================================`);
+  console.log(`Run complete: ${runId}`);
+  console.log(`Results saved to: ${savedPath}`);
+  console.log(`Summary:`);
+  console.log(`  Total: ${result.summary.total}`);
+  console.log(`  Resolved: ${result.summary.resolved}`);
+  console.log(`  Pass Rate: ${(result.summary.pass_rate * 100).toFixed(1)}%`);
+  console.log(`  Total Tokens: ${result.summary.total_tokens.toLocaleString()}`);
+  console.log(`  Total Cost: $${result.summary.total_cost_usd.toFixed(2)}`);
+  console.log(`  Avg Duration: ${result.summary.avg_duration_s}s`);
+  console.log(`========================================\n`);
+
+  return result;
+}

--- a/eval/src/types.ts
+++ b/eval/src/types.ts
@@ -1,0 +1,166 @@
+/** Agent execution mode */
+export type AgentMode = "single-claude" | "single-codex" | "hydra";
+
+/** Model configuration for all agent roles */
+export interface ModelConfig {
+  /** Claude model for single-claude mode (e.g. "sonnet", "opus") */
+  claude_model: string;
+  /** Codex model for single-codex mode (e.g. "gpt-5.4", "o3") */
+  codex_model?: string;
+  /** Model for Hydra orchestrator — the most critical role */
+  hydra_orchestrator_model: string;
+  /** Claude model for Hydra sub-agents */
+  hydra_sub_claude_model: string;
+  /** Codex model for Hydra sub-agents */
+  hydra_sub_codex_model?: string;
+}
+
+/** Default model configuration */
+export const DEFAULT_MODELS: ModelConfig = {
+  claude_model: "sonnet",
+  codex_model: undefined, // uses codex config.toml default
+  hydra_orchestrator_model: "sonnet", // NOT haiku — orchestrator needs strong reasoning
+  hydra_sub_claude_model: "sonnet",
+  hydra_sub_codex_model: undefined,
+};
+
+/** Configuration for a single evaluation run */
+export interface EvalConfig {
+  /** Unique run identifier, e.g. "run-20260322-001" */
+  run_id: string;
+  /** Agent mode */
+  mode: AgentMode;
+  /** Model configuration */
+  models: ModelConfig;
+  /** For Hydra: sub-agent type combination */
+  sub_agent_types?: string[];
+  /** Prompt version tag for tracking prompt iterations */
+  prompt_version: string;
+  /** Benchmark name, e.g. "swe-bench" */
+  benchmark: string;
+  /** Task filter tag, e.g. "multi-file" */
+  task_filter?: string;
+  /** Max concurrent tasks */
+  max_workers?: number;
+  /** Timeout per task in seconds */
+  timeout_per_task_s?: number;
+  /** Whether to run SWE-bench Docker evaluation */
+  run_swebench_eval?: boolean;
+}
+
+/** A single SWE-bench task definition */
+export interface TaskDefinition {
+  instance_id: string;
+  repo: string;
+  base_commit: string;
+  problem_statement: string;
+  hints_text: string;
+  patch: string;
+  test_patch: string;
+  FAIL_TO_PASS: string;
+  PASS_TO_PASS: string;
+  version: string;
+  environment_setup_commit: string;
+  created_at: string;
+}
+
+/** Metadata about a task (derived from TaskDefinition) */
+export interface TaskMeta {
+  instance_id: string;
+  repo: string;
+  num_files: number;
+  files_changed: string[];
+  num_lines: number;
+}
+
+/** Result of a single task execution */
+export interface TaskResult {
+  task_id: string;
+  pass: boolean;
+  model_patch: string;
+  tokens: number;
+  duration_s: number;
+  cost_usd: number;
+  sub_agents?: number;
+  merge_failures?: number;
+  error?: string;
+  /** Detailed evaluation breakdown */
+  eval_detail?: {
+    applied: boolean;
+    tests_passed: boolean;
+    eval_method?: string;
+    fail_to_pass_results?: Record<string, boolean>;
+  };
+}
+
+/** Summary statistics for a run */
+export interface RunSummary {
+  total: number;
+  resolved: number;
+  pass_rate: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  avg_duration_s: number;
+}
+
+/** Complete result of an evaluation run */
+export interface RunResult {
+  run_id: string;
+  config: EvalConfig;
+  started_at: string;
+  completed_at: string;
+  tasks: TaskResult[];
+  summary: RunSummary;
+}
+
+/** Prediction entry for SWE-bench evaluation */
+export interface SWEBenchPrediction {
+  instance_id: string;
+  model_name_or_path: string;
+  model_patch: string;
+}
+
+/** Comparison between two runs */
+export interface RunComparison {
+  run_a: string;
+  run_b: string;
+  config_diff: Record<string, { a: unknown; b: unknown }>;
+  task_diffs: TaskDiff[];
+  summary_diff: {
+    pass_rate: { a: number; b: number; delta: number };
+    total_tokens: { a: number; b: number; delta: number };
+    total_cost_usd: { a: number; b: number; delta: number };
+    avg_duration_s: { a: number; b: number; delta: number };
+  };
+}
+
+/** Per-task comparison */
+export interface TaskDiff {
+  task_id: string;
+  pass: { a: boolean; b: boolean };
+  tokens: { a: number; b: number };
+  duration_s: { a: number; b: number };
+  /** "improved" | "regressed" | "unchanged" */
+  status: "improved" | "regressed" | "unchanged";
+}
+
+/** Agent runner interface */
+export interface AgentRunner {
+  /** Run a single task and return the model patch */
+  run(
+    task: TaskDefinition,
+    workDir: string,
+    config: EvalConfig,
+  ): Promise<AgentRunResult>;
+}
+
+/** Result from an agent run (before evaluation) */
+export interface AgentRunResult {
+  model_patch: string;
+  tokens: number;
+  duration_s: number;
+  cost_usd: number;
+  sub_agents?: number;
+  merge_failures?: number;
+  error?: string;
+}

--- a/eval/tests/compare.test.ts
+++ b/eval/tests/compare.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import { strict as a } from "node:assert";
+import { compareResults, formatComparison } from "../src/compare.ts";
+import type { RunResult } from "../src/types.ts";
+
+function makeResult(overrides: Partial<RunResult>): RunResult {
+  return {
+    run_id: "test-run",
+    config: {
+      run_id: "test-run",
+      mode: "single-claude",
+      prompt_version: "v1",
+      benchmark: "swe-bench",
+    },
+    started_at: "2026-03-22T00:00:00Z",
+    completed_at: "2026-03-22T01:00:00Z",
+    tasks: [],
+    summary: {
+      total: 0,
+      resolved: 0,
+      pass_rate: 0,
+      total_tokens: 0,
+      total_cost_usd: 0,
+      avg_duration_s: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("compareResults", () => {
+  it("detects improved and regressed tasks", () => {
+    const runA = makeResult({
+      run_id: "run-a",
+      config: { run_id: "run-a", mode: "single-claude", prompt_version: "v1", benchmark: "swe-bench" },
+      tasks: [
+        { task_id: "t1", pass: true, model_patch: "", tokens: 100, duration_s: 10, cost_usd: 0.1 },
+        { task_id: "t2", pass: false, model_patch: "", tokens: 200, duration_s: 20, cost_usd: 0.2 },
+      ],
+      summary: { total: 2, resolved: 1, pass_rate: 0.5, total_tokens: 300, total_cost_usd: 0.3, avg_duration_s: 15 },
+    });
+
+    const runB = makeResult({
+      run_id: "run-b",
+      config: { run_id: "run-b", mode: "single-codex", prompt_version: "v1", benchmark: "swe-bench" },
+      tasks: [
+        { task_id: "t1", pass: false, model_patch: "", tokens: 50, duration_s: 5, cost_usd: 0.05 },
+        { task_id: "t2", pass: true, model_patch: "", tokens: 150, duration_s: 15, cost_usd: 0.15 },
+      ],
+      summary: { total: 2, resolved: 1, pass_rate: 0.5, total_tokens: 200, total_cost_usd: 0.2, avg_duration_s: 10 },
+    });
+
+    const comparison = compareResults(runA, runB);
+
+    a.equal(comparison.run_a, "run-a");
+    a.equal(comparison.run_b, "run-b");
+
+    const t1 = comparison.task_diffs.find((t) => t.task_id === "t1");
+    const t2 = comparison.task_diffs.find((t) => t.task_id === "t2");
+    a.equal(t1?.status, "regressed");
+    a.equal(t2?.status, "improved");
+
+    a.ok("mode" in comparison.config_diff);
+  });
+
+  it("formats comparison as readable report", () => {
+    const runA = makeResult({
+      run_id: "run-a",
+      tasks: [
+        { task_id: "t1", pass: true, model_patch: "", tokens: 100, duration_s: 10, cost_usd: 0.1 },
+      ],
+      summary: { total: 1, resolved: 1, pass_rate: 1, total_tokens: 100, total_cost_usd: 0.1, avg_duration_s: 10 },
+    });
+
+    const runB = makeResult({
+      run_id: "run-b",
+      tasks: [
+        { task_id: "t1", pass: false, model_patch: "", tokens: 200, duration_s: 20, cost_usd: 0.2 },
+      ],
+      summary: { total: 1, resolved: 0, pass_rate: 0, total_tokens: 200, total_cost_usd: 0.2, avg_duration_s: 20 },
+    });
+
+    const comparison = compareResults(runA, runB);
+    const report = formatComparison(comparison);
+
+    a.ok(report.includes("run-a"));
+    a.ok(report.includes("run-b"));
+    a.ok(report.includes("Pass Rate"));
+    a.ok(report.includes("Regressed"));
+  });
+});

--- a/eval/tests/dataset.test.ts
+++ b/eval/tests/dataset.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, assert } from "node:test";
+import { strict as a } from "node:assert";
+import { countPatchFiles, countPatchLines, taskMeta } from "../src/dataset.ts";
+import type { TaskDefinition } from "../src/types.ts";
+
+const SAMPLE_PATCH = `diff --git a/django/contrib/admin/options.py b/django/contrib/admin/options.py
+--- a/django/contrib/admin/options.py
++++ b/django/contrib/admin/options.py
+@@ -100,6 +100,7 @@
+ class ModelAdmin:
+     pass
++    new_line = True
+
+diff --git a/django/contrib/admin/sites.py b/django/contrib/admin/sites.py
+--- a/django/contrib/admin/sites.py
++++ b/django/contrib/admin/sites.py
+@@ -50,7 +50,8 @@
+-old_line = False
++new_line = True
++another_line = True
+
+diff --git a/tests/admin/test_options.py b/tests/admin/test_options.py
+--- a/tests/admin/test_options.py
++++ b/tests/admin/test_options.py
+@@ -10,6 +10,10 @@
++def test_new():
++    pass
++
++def test_another():
++    pass
+`;
+
+describe("countPatchFiles", () => {
+  it("counts files in a multi-file patch", () => {
+    const files = countPatchFiles(SAMPLE_PATCH);
+    a.equal(files.length, 3);
+    a.deepEqual(files, [
+      "django/contrib/admin/options.py",
+      "django/contrib/admin/sites.py",
+      "tests/admin/test_options.py",
+    ]);
+  });
+
+  it("returns empty for empty patch", () => {
+    a.deepEqual(countPatchFiles(""), []);
+  });
+
+  it("handles single file patch", () => {
+    const patch = `diff --git a/foo.py b/foo.py
+--- a/foo.py
++++ b/foo.py
+@@ -1 +1,2 @@
++new_line`;
+    a.equal(countPatchFiles(patch).length, 1);
+  });
+});
+
+describe("countPatchLines", () => {
+  it("counts added and removed lines", () => {
+    const lines = countPatchLines(SAMPLE_PATCH);
+    a.equal(lines, 9);
+  });
+
+  it("returns 0 for empty patch", () => {
+    a.equal(countPatchLines(""), 0);
+  });
+});
+
+describe("taskMeta", () => {
+  it("derives metadata from task definition", () => {
+    const task: TaskDefinition = {
+      instance_id: "django__django-12345",
+      repo: "django/django",
+      base_commit: "abc123",
+      problem_statement: "Fix the bug",
+      hints_text: "",
+      patch: SAMPLE_PATCH,
+      test_patch: "",
+      FAIL_TO_PASS: "[]",
+      PASS_TO_PASS: "[]",
+      version: "3.2",
+      environment_setup_commit: "def456",
+      created_at: "2023-01-01",
+    };
+
+    const meta = taskMeta(task);
+    a.equal(meta.instance_id, "django__django-12345");
+    a.equal(meta.repo, "django/django");
+    a.equal(meta.num_files, 3);
+    a.equal(meta.num_lines, 9);
+    a.equal(meta.files_changed.length, 3);
+  });
+});

--- a/eval/tests/evaluator.test.ts
+++ b/eval/tests/evaluator.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import { strict as a } from "node:assert";
+import { evaluatePatchSimple } from "../src/evaluator.ts";
+
+const GOLD_PATCH = `diff --git a/django/cache/backends/base.py b/django/cache/backends/base.py
+--- a/django/cache/backends/base.py
++++ b/django/cache/backends/base.py
+@@ -100,6 +100,8 @@
+     def delete(self, key):
+-        pass
++        result = self._delete(key)
++        return result
+
+diff --git a/django/cache/backends/db.py b/django/cache/backends/db.py
+--- a/django/cache/backends/db.py
++++ b/django/cache/backends/db.py
+@@ -50,6 +50,8 @@
+     def _delete(self, key):
+-        pass
++        cursor.execute("DELETE FROM %s WHERE key = %s", [self._table, key])
++        return cursor.rowcount > 0
+`;
+
+describe("evaluatePatchSimple", () => {
+  it("returns similarity=0 for empty model patch", () => {
+    const result = evaluatePatchSimple("", GOLD_PATCH);
+    a.equal(result.applied, false);
+    a.equal(result.similarity, 0);
+  });
+
+  it("returns high similarity for identical patch", () => {
+    const result = evaluatePatchSimple(GOLD_PATCH, GOLD_PATCH);
+    a.equal(result.applied, true);
+    a.equal(result.similarity, 1.0);
+  });
+
+  it("returns partial similarity for overlapping files", () => {
+    const modelPatch = `diff --git a/django/cache/backends/base.py b/django/cache/backends/base.py
+--- a/django/cache/backends/base.py
++++ b/django/cache/backends/base.py
+@@ -100,6 +100,8 @@
+     def delete(self, key):
+-        pass
++        return self._delete(key)
+`;
+    const result = evaluatePatchSimple(modelPatch, GOLD_PATCH);
+    a.equal(result.applied, true);
+    // 1/2 file overlap (0.5 * 0.4) + some line overlap
+    a.ok(result.similarity > 0);
+    a.ok(result.similarity < 1);
+  });
+
+  it("returns 0 similarity for completely different patch", () => {
+    const modelPatch = `diff --git a/unrelated/file.py b/unrelated/file.py
+--- a/unrelated/file.py
++++ b/unrelated/file.py
+@@ -1 +1,2 @@
++completely_different_change = True
+`;
+    const result = evaluatePatchSimple(modelPatch, GOLD_PATCH);
+    a.equal(result.applied, true);
+    a.equal(result.similarity, 0);
+  });
+});

--- a/eval/tests/regressions.test.ts
+++ b/eval/tests/regressions.test.ts
@@ -1,0 +1,633 @@
+import { describe, it } from "node:test";
+import { strict as a } from "node:assert";
+import { promisify } from "node:util";
+import { execFile, spawn } from "node:child_process";
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  readFile,
+  chmod,
+  access,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runSWEBenchEval } from "../src/evaluator.ts";
+import { runEvaluation } from "../src/runner.ts";
+import { SingleCodexRunner } from "../src/agents/single.ts";
+import { HydraRunner } from "../src/agents/hydra.ts";
+import { DEFAULT_MODELS, type EvalConfig, type TaskDefinition } from "../src/types.ts";
+
+const execFileAsync = promisify(execFile);
+const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
+const EVAL_ROOT = resolve(TESTS_DIR, "..");
+const REPO_ROOT = resolve(EVAL_ROOT, "..");
+const RESULTS_DIR = join(EVAL_ROOT, "results");
+
+function makeTask(overrides: Partial<TaskDefinition> = {}): TaskDefinition {
+  return {
+    instance_id: "task-1",
+    repo: "owner/repo",
+    base_commit: "",
+    problem_statement: "Fix the bug",
+    hints_text: "",
+    patch: "",
+    test_patch: "",
+    FAIL_TO_PASS: "[]",
+    PASS_TO_PASS: "[]",
+    version: "1",
+    environment_setup_commit: "",
+    created_at: "2026-03-22T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<EvalConfig> = {}): EvalConfig {
+  return {
+    run_id: "run-test",
+    mode: "single-codex",
+    models: { ...DEFAULT_MODELS },
+    prompt_version: "v1",
+    benchmark: "swe-bench",
+    max_workers: 1,
+    ...overrides,
+  };
+}
+
+async function makeExecutable(
+  dir: string,
+  name: string,
+  contents: string,
+): Promise<string> {
+  const path = join(dir, name);
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+  return path;
+}
+
+async function initGitRepo(dir: string): Promise<string> {
+  await mkdir(dir, { recursive: true });
+  await execFileAsync("git", ["init", "-b", "main"], { cwd: dir });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], {
+    cwd: dir,
+  });
+  await execFileAsync("git", ["config", "user.name", "Test User"], {
+    cwd: dir,
+  });
+  await writeFile(join(dir, "base.txt"), "base\n");
+  await execFileAsync("git", ["add", "base.txt"], { cwd: dir });
+  await execFileAsync("git", ["commit", "-m", "init"], { cwd: dir });
+  const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+    cwd: dir,
+  });
+  return stdout.trim();
+}
+
+async function runProcess(
+  cmd: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolvePromise({ code, stdout, stderr });
+    });
+  });
+}
+
+async function withPath<T>(binDir: string, fn: () => Promise<T>): Promise<T> {
+  const originalPath = process.env.PATH ?? "";
+  process.env.PATH = `${binDir}:${originalPath}`;
+  try {
+    return await fn();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+}
+
+describe("eval regressions", () => {
+  it("parses SWE-bench result files named with model and run id", async (t) => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const binDir = join(tempDir, "bin");
+    const runId = `parse-${Date.now()}`;
+    const predictionsPath = join(tempDir, "predictions.jsonl");
+    const runDir = join(RESULTS_DIR, runId);
+
+    t.after(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+      await rm(runDir, { recursive: true, force: true });
+    });
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(predictionsPath, "");
+    await makeExecutable(
+      binDir,
+      "python3",
+      `#!/bin/sh
+run_id=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--run_id" ]; then
+    run_id="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+printf '{"task-parse":{"resolved":true}}' > "fake-model.\${run_id}.json"
+`,
+    );
+
+    const results = await withPath(binDir, async () =>
+      runSWEBenchEval({
+        predictionsPath,
+        dataset: "SWE-bench/SWE-bench_Verified",
+        runId,
+        maxWorkers: 1,
+      }),
+    );
+
+    a.equal(results.get("task-parse"), true);
+  });
+
+  it("maps swe-bench variants to the correct dataset names", async (t) => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const binDir = join(tempDir, "bin");
+    const captureFile = join(tempDir, "python-args.txt");
+    const runIds = [`dataset-pro-${Date.now()}`, `dataset-verified-${Date.now()}`];
+
+    t.after(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+      for (const runId of runIds) {
+        await rm(join(RESULTS_DIR, runId), { recursive: true, force: true });
+      }
+    });
+
+    await mkdir(binDir, { recursive: true });
+    await makeExecutable(
+      binDir,
+      "python3",
+      `#!/bin/sh
+printf '%s\n' "$@" > "$CAPTURE_ARGS_FILE"
+run_id=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--run_id" ]; then
+    run_id="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+printf '{}' > "fake.\${run_id}.json"
+`,
+    );
+
+    async function captureDataset(benchmark: string, runId: string): Promise<string> {
+      return withPath(binDir, async () => {
+        const originalCapture = process.env.CAPTURE_ARGS_FILE;
+        process.env.CAPTURE_ARGS_FILE = captureFile;
+        try {
+          await runEvaluation(
+            [],
+            makeConfig({
+              run_id: runId,
+              benchmark,
+              run_swebench_eval: true,
+            }),
+          );
+        } finally {
+          if (originalCapture === undefined) {
+            delete process.env.CAPTURE_ARGS_FILE;
+          } else {
+            process.env.CAPTURE_ARGS_FILE = originalCapture;
+          }
+        }
+
+        const args = (await readFile(captureFile, "utf-8")).trim().split("\n");
+        const datasetIndex = args.indexOf("--dataset_name");
+        return args[datasetIndex + 1];
+      });
+    }
+
+    a.equal(
+      await captureDataset("swe-bench-pro", runIds[0]),
+      "ScaleAI/SWE-bench_Pro",
+    );
+    a.equal(
+      await captureDataset("swe-bench-verified", runIds[1]),
+      "SWE-bench/SWE-bench_Verified",
+    );
+  });
+
+  it("treats --max-tasks 0 as an empty selection", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const tasksPath = join(tempDir, "tasks.json");
+
+    try {
+      await writeFile(
+        tasksPath,
+        JSON.stringify([makeTask()], null, 2),
+      );
+
+      const result = await runProcess(
+        "node",
+        [
+          "--experimental-strip-types",
+          "--no-warnings",
+          join(EVAL_ROOT, "src", "cli.ts"),
+          "run",
+          "--tasks",
+          tasksPath,
+          "--max-tasks",
+          "0",
+        ],
+        { cwd: REPO_ROOT, env: process.env },
+      );
+
+      a.equal(result.code, 1);
+      a.match(result.stderr, /No tasks to run/);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses cost from the last line of codex JSONL output", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const binDir = join(tempDir, "bin");
+    const repoDir = join(tempDir, "repo");
+
+    try {
+      await mkdir(binDir, { recursive: true });
+      await makeExecutable(
+        binDir,
+        "codex",
+        `#!/bin/sh
+printf '{"event":"start"}\n'
+printf '{"cost_usd":1.75}\n'
+`,
+      );
+      const baseCommit = await initGitRepo(repoDir);
+      const runner = new SingleCodexRunner();
+      const result = await withPath(binDir, async () =>
+        runner.run(
+          makeTask({ base_commit: baseCommit }),
+          repoDir,
+          makeConfig({ mode: "single-codex" }),
+        ),
+      );
+
+      a.equal(result.cost_usd, 1.75);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("routes gpt orchestrator models through codex", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const binDir = join(tempDir, "bin");
+    const codexLog = join(tempDir, "codex.log");
+    const claudeLog = join(tempDir, "claude.log");
+    const runner = new HydraRunner() as any;
+
+    try {
+      await mkdir(binDir, { recursive: true });
+      await makeExecutable(
+        binDir,
+        "codex",
+        `#!/bin/sh
+printf '%s\n' "$@" > "$CODEX_LOG"
+printf '["subtask"]\n'
+`,
+      );
+      await makeExecutable(
+        binDir,
+        "claude",
+        `#!/bin/sh
+printf '%s\n' "$@" > "$CLAUDE_LOG"
+printf '["subtask"]\n'
+`,
+      );
+
+      await withPath(binDir, async () => {
+        const originalCodexLog = process.env.CODEX_LOG;
+        const originalClaudeLog = process.env.CLAUDE_LOG;
+        process.env.CODEX_LOG = codexLog;
+        process.env.CLAUDE_LOG = claudeLog;
+        try {
+          const plan = await runner.decompose(
+            makeTask(),
+            tempDir,
+            makeConfig({
+              mode: "hydra",
+              models: {
+                ...DEFAULT_MODELS,
+                hydra_orchestrator_model: "gpt-5.4",
+              },
+            }),
+          );
+
+          a.deepEqual(plan, { subtasks: ["subtask"] });
+        } finally {
+          if (originalCodexLog === undefined) {
+            delete process.env.CODEX_LOG;
+          } else {
+            process.env.CODEX_LOG = originalCodexLog;
+          }
+          if (originalClaudeLog === undefined) {
+            delete process.env.CLAUDE_LOG;
+          } else {
+            process.env.CLAUDE_LOG = originalClaudeLog;
+          }
+        }
+      });
+
+      a.equal((await readFile(codexLog, "utf-8")).includes("-m"), true);
+      await a.rejects(access(claudeLog));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses task-specific worktree paths and branch names for hydra sub-agents", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const binDir = join(tempDir, "bin");
+    const repoA = join(tempDir, "task-a");
+    const repoB = join(tempDir, "task-b");
+    const runner = new HydraRunner() as any;
+    let subA:
+      | { branch: string | null; worktreePath: string | null; error?: string }
+      | undefined;
+    let subB:
+      | { branch: string | null; worktreePath: string | null; error?: string }
+      | undefined;
+
+    try {
+      await mkdir(binDir, { recursive: true });
+      await makeExecutable(binDir, "codex", "#!/bin/sh\n");
+      const baseA = await initGitRepo(repoA);
+      const baseB = await initGitRepo(repoB);
+
+      subA = await withPath(binDir, async () =>
+        runner.runSubAgent(
+          "subtask",
+          makeTask({ instance_id: "task-a", base_commit: baseA }),
+          repoA,
+          "codex",
+          makeConfig({ mode: "hydra" }),
+          0,
+          30,
+        ),
+      );
+      subB = await withPath(binDir, async () =>
+        runner.runSubAgent(
+          "subtask",
+          makeTask({ instance_id: "task-b", base_commit: baseB }),
+          repoB,
+          "codex",
+          makeConfig({ mode: "hydra" }),
+          0,
+          30,
+        ),
+      );
+
+      a.equal(subA.error, undefined);
+      a.equal(subB.error, undefined);
+      a.notEqual(subA.worktreePath, subB.worktreePath);
+      a.notEqual(subA.branch, subB.branch);
+      a.match(subA.worktreePath ?? "", /task-a/);
+      a.match(subB.worktreePath ?? "", /task-b/);
+    } finally {
+      if (subA?.worktreePath) {
+        await execFileAsync("git", ["worktree", "remove", subA.worktreePath, "--force"], {
+          cwd: repoA,
+        }).catch(() => {});
+      }
+      if (subA?.branch) {
+        await execFileAsync("git", ["branch", "-D", subA.branch], {
+          cwd: repoA,
+        }).catch(() => {});
+      }
+      if (subB?.worktreePath) {
+        await execFileAsync("git", ["worktree", "remove", subB.worktreePath, "--force"], {
+          cwd: repoB,
+        }).catch(() => {});
+      }
+      if (subB?.branch) {
+        await execFileAsync("git", ["branch", "-D", subB.branch], {
+          cwd: repoB,
+        }).catch(() => {});
+      }
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips failed hydra branches and reports merge failures", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const repoDir = join(tempDir, "repo");
+    const baseCommit = await initGitRepo(repoDir);
+    const runner = new HydraRunner() as any;
+
+    try {
+      await execFileAsync("git", ["checkout", "-b", "good-branch"], { cwd: repoDir });
+      await writeFile(join(repoDir, "good.txt"), "good\n");
+      await execFileAsync("git", ["add", "good.txt"], { cwd: repoDir });
+      await execFileAsync("git", ["commit", "-m", "good"], { cwd: repoDir });
+
+      await execFileAsync("git", ["checkout", "main"], { cwd: repoDir });
+      await execFileAsync("git", ["checkout", "-b", "bad-branch"], { cwd: repoDir });
+      await writeFile(join(repoDir, "bad.txt"), "bad\n");
+      await execFileAsync("git", ["add", "bad.txt"], { cwd: repoDir });
+      await execFileAsync("git", ["commit", "-m", "bad"], { cwd: repoDir });
+      await execFileAsync("git", ["checkout", "main"], { cwd: repoDir });
+
+      runner.decompose = async () => ({
+        subtasks: ["good", "bad", "missing"],
+      });
+      runner.runSubAgent = async (subtask: string) => {
+        if (subtask === "good") {
+          return { branch: "good-branch", worktreePath: null };
+        }
+        if (subtask === "bad") {
+          return {
+            branch: "bad-branch",
+            worktreePath: null,
+            error: "sub-agent failed",
+          };
+        }
+        return { branch: "missing-branch", worktreePath: null };
+      };
+
+      const result = await runner.run(
+        makeTask({ base_commit: baseCommit }),
+        repoDir,
+        makeConfig({ mode: "hydra" }),
+      );
+
+      a.equal(result.error, undefined);
+      a.match(result.model_patch, /good\.txt/);
+      a.doesNotMatch(result.model_patch, /bad\.txt/);
+      a.equal(result.merge_failures, 1);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("updates results from harness logs written under the run output directory", async (t) => {
+    const runId = `update-${Date.now()}`;
+    const runDir = join(RESULTS_DIR, runId);
+    const resultPath = join(runDir, "result.json");
+    const reportPath = join(
+      runDir,
+      "swebench-eval",
+      "logs",
+      "run_evaluation",
+      runId,
+      "fake-model",
+      "task-1",
+      "report.json",
+    );
+
+    t.after(async () => {
+      await rm(runDir, { recursive: true, force: true });
+    });
+
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(
+      resultPath,
+      JSON.stringify(
+        {
+          run_id: runId,
+          config: makeConfig({ run_id: runId }),
+          started_at: "2026-03-22T00:00:00Z",
+          completed_at: "2026-03-22T00:01:00Z",
+          tasks: [
+            {
+              task_id: "task-1",
+              pass: false,
+              model_patch: "patch",
+              tokens: 0,
+              duration_s: 0,
+              cost_usd: 0,
+            },
+          ],
+          summary: {
+            total: 1,
+            resolved: 0,
+            pass_rate: 0,
+            total_tokens: 0,
+            total_cost_usd: 0,
+            avg_duration_s: 0,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      reportPath,
+      JSON.stringify(
+        {
+          "task-1": {
+            resolved: true,
+            patch_successfully_applied: true,
+            patch_exists: true,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await runProcess(
+      "python3",
+      [join(EVAL_ROOT, "scripts", "update-results-with-swebench.py")],
+      { cwd: REPO_ROOT, env: process.env },
+    );
+
+    a.equal(result.code, 0);
+    const updated = JSON.parse(await readFile(resultPath, "utf-8"));
+    a.equal(updated.tasks[0].pass, true);
+    a.equal(updated.summary.resolved, 1);
+  });
+
+  it("runs SWE-bench evaluation only through the subprocess path", async (t) => {
+    const tempDir = await mkdtemp(join(tmpdir(), "eval-regression-"));
+    const runId = `script-${Date.now()}`;
+    const packageDir = join(tempDir, "swebench", "harness");
+    const directMarker = join(tempDir, "direct.txt");
+    const subprocessMarker = join(tempDir, "subprocess.txt");
+    const runDir = join(RESULTS_DIR, runId);
+
+    t.after(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+      await rm(runDir, { recursive: true, force: true });
+    });
+
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(join(tempDir, "swebench", "__init__.py"), "");
+    await writeFile(join(packageDir, "__init__.py"), "");
+    await writeFile(
+      join(packageDir, "run_evaluation.py"),
+      `from pathlib import Path
+import os
+
+def main(*args, **kwargs):
+    Path(os.environ["DIRECT_MARKER"]).write_text("direct")
+
+if __name__ == "__main__":
+    Path(os.environ["SUBPROCESS_MARKER"]).write_text("subprocess")
+`,
+    );
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "result.json"),
+      JSON.stringify(
+        {
+          run_id: runId,
+          config: { mode: "single-codex" },
+          tasks: [
+            {
+              task_id: "task-1",
+              model_patch: "diff --git a/a b/a\n",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await runProcess(
+      "python3",
+      [join(EVAL_ROOT, "scripts", "run-swebench-eval.py"), runId],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          PYTHONPATH: tempDir,
+          DIRECT_MARKER: directMarker,
+          SUBPROCESS_MARKER: subprocessMarker,
+        },
+      },
+    );
+
+    a.equal(result.code, 0);
+    await a.rejects(access(directMarker));
+    a.equal(await readFile(subprocessMarker, "utf-8"), "subprocess");
+  });
+});

--- a/eval/tests/results.test.ts
+++ b/eval/tests/results.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "node:test";
+import { strict as a } from "node:assert";
+import { computeSummary, generateRunId } from "../src/results.ts";
+import type { TaskResult } from "../src/types.ts";
+
+describe("computeSummary", () => {
+  it("computes correct summary for mixed results", () => {
+    const tasks: TaskResult[] = [
+      { task_id: "t1", pass: true, model_patch: "p", tokens: 10000, duration_s: 100, cost_usd: 0.5 },
+      { task_id: "t2", pass: false, model_patch: "", tokens: 5000, duration_s: 50, cost_usd: 0.2, error: "timeout" },
+      { task_id: "t3", pass: true, model_patch: "p", tokens: 15000, duration_s: 200, cost_usd: 0.8 },
+    ];
+
+    const summary = computeSummary(tasks);
+    a.equal(summary.total, 3);
+    a.equal(summary.resolved, 2);
+    a.ok(Math.abs(summary.pass_rate - 2 / 3) < 0.001);
+    a.equal(summary.total_tokens, 30000);
+    a.equal(summary.total_cost_usd, 1.5);
+    a.ok(Math.abs(summary.avg_duration_s - 117) < 1);
+  });
+
+  it("handles empty task list", () => {
+    const summary = computeSummary([]);
+    a.equal(summary.total, 0);
+    a.equal(summary.resolved, 0);
+    a.equal(summary.pass_rate, 0);
+    a.equal(summary.total_tokens, 0);
+    a.equal(summary.total_cost_usd, 0);
+    a.equal(summary.avg_duration_s, 0);
+  });
+});
+
+describe("generateRunId", () => {
+  it("generates unique IDs", () => {
+    const id1 = generateRunId();
+    const id2 = generateRunId();
+    a.notEqual(id1, id2);
+    a.ok(id1.startsWith("run-"));
+  });
+
+  it("includes date and time components", () => {
+    const id = generateRunId();
+    // Format: run-YYYYMMDD-HHMMSS-xxxx
+    const parts = id.split("-");
+    a.equal(parts[0], "run");
+    a.equal(parts[1].length, 8); // YYYYMMDD
+    a.equal(parts[2].length, 6); // HHMMSS
+    a.equal(parts[3].length, 4); // random suffix
+  });
+});

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

搭建 Hydra 评估框架，支持 SWE-bench Docker 测试验证。

### 框架

- TypeScript pipeline，支持 single-claude / single-codex / hydra 三种模式
- 所有模型通过 CLI 参数统一配置（`--claude-model`, `--orchestrator-model` 等），零硬编码
- 两阶段评估：agents 生成 patch → SWE-bench Docker 跑 FAIL_TO_PASS 测试验证
- Hydra runner：orchestrator 分解任务 → sub-agents 在 git worktree 中并行 → merge
- 支持 SWE-bench Full / Verified / **Pro** 数据集（推荐 Pro，多文件多语言）
- 任务下载采用分层抽样（跨难度均匀分布）
- 数据文件（tasks/, results/, logs/）全部 gitignore，可通过脚本再生
- 25 个测试（16 unit + 9 regression）

### 用法

```bash
# 下载评测集（推荐 SWE-bench Pro）
python3 scripts/download-dataset.py --dataset swe-bench-pro --max-tasks 50 --output pro-50

# 跑评测
eval run --mode hydra --orchestrator-model opus --sub-claude-model sonnet --timeout 1800

# SWE-bench Docker 验证
python3 scripts/export-predictions.py <run_id>
python3 -m swebench.harness.run_evaluation --predictions_path ...
python3 scripts/update-results-with-swebench.py

# 对比
eval compare <run_a> <run_b>
```

### 文件清单（24 files, 3834 lines）

```
eval/
  src/            框架核心（TypeScript）
  scripts/        数据下载、评估、结果合并（Python）
  tests/          25 个测试
  .gitignore      排除所有可再生数据
  README.md       完整使用文档
```

## Test plan

- [x] TypeScript typecheck 通过
- [x] 25 个测试通过（16 unit + 9 regression）
- [x] 模型配置可通过 CLI 参数控制
- [x] 支持 SWE-bench Full / Verified / Pro dataset 映射