### PR TITLE
fix: persist theme choice to localStorage

### DIFF
--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -8,12 +8,32 @@ interface ThemeStore {
   toggleTheme: () => void;
 }
 
+function loadTheme(): Theme {
+  try {
+    const saved = localStorage.getItem("termcanvas-theme");
+    if (saved === "dark" || saved === "light") return saved;
+  } catch {
+    // localStorage unavailable — fall back to default
+  }
+  return "dark";
+}
+
+const initialTheme = loadTheme();
+if (initialTheme === "light") {
+  document.documentElement.setAttribute("data-theme", "light");
+}
+
 export const useThemeStore = create<ThemeStore>((set) => ({
-  theme: "dark",
+  theme: initialTheme,
   toggleTheme: () =>
     set((state) => {
       const next = state.theme === "dark" ? "light" : "dark";
       document.documentElement.setAttribute("data-theme", next);
+      try {
+        localStorage.setItem("termcanvas-theme", next);
+      } catch {
+        // localStorage unavailable — theme still works for this session
+      }
       return { theme: next };
     }),
 }));


### PR DESCRIPTION
## Summary

- The theme store (`themeStore.ts`) did not persist the user's theme choice. On app restart, it always defaulted to "dark" regardless of prior selection.
- Added `localStorage` read on store initialization (key: `termcanvas-theme`) and write on toggle, following the same pattern used by `localeStore.ts`.
- On init, applies `data-theme` attribute to `<html>` if the stored theme is "light", preventing a flash of wrong theme.
- localStorage errors are caught gracefully — the app falls back to "dark" without crashing.

## Test plan

- [ ] Toggle theme to light, refresh the page — theme should remain light
- [ ] Toggle theme to dark, refresh the page — theme should remain dark
- [ ] Clear `termcanvas-theme` from localStorage, refresh — should default to dark
- [ ] Set `termcanvas-theme` to an invalid value in localStorage, refresh — should default to dark
- [ ] Verify no flash of dark theme when light is persisted (check `data-theme` attribute on `<html>` at load)

Relates to #23