### PR TITLE
fix: prevent settings modal content overflow

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -322,7 +322,7 @@ export function SettingsModal({ onClose }: Props) {
         </div>
 
         {/* Content */}
-        <div className="px-6 py-5 min-h-[280px]">
+        <div className="px-6 py-5 min-h-[280px] max-h-[60vh] overflow-y-auto">
           {tab === "general" && (
             <div className="flex flex-col gap-5">
               {/* Language */}


### PR DESCRIPTION
## Summary

- Add `max-h-[60vh]` and `overflow-y-auto` to the settings modal content area so it scrolls when content (e.g. the 16-row keyboard shortcuts list) exceeds available height
- Pure CSS fix, no structural changes — applies equally to all settings tabs

## Test plan

- [ ] Open the settings modal on a small viewport (e.g. 768px height)
- [ ] Navigate to the Shortcuts tab and verify the list is scrollable within the modal
- [ ] Verify other tabs (General, Agents) still render correctly
- [ ] Confirm the modal itself does not overflow the screen

Relates to #16