### PR TITLE
fix: mark workspace dirty on terminal rename

### DIFF
--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -575,7 +575,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
       ),
     })),
 
-  updateTerminalCustomTitle: (projectId, worktreeId, terminalId, customTitle) =>
+  updateTerminalCustomTitle: (projectId, worktreeId, terminalId, customTitle) => {
     set((state) => ({
       projects: mapTerminals(
         state.projects,
@@ -584,7 +584,9 @@ export const useProjectStore = create<ProjectStore>((set) => ({
         terminalId,
         (t) => withUpdatedTerminalCustomTitle(t, customTitle),
       ),
-    })),
+    }));
+    markDirty();
+  },
 
   toggleTerminalStarred: (projectId, worktreeId, terminalId) => {
     set((state) => ({


### PR DESCRIPTION
## Summary

- `updateTerminalCustomTitle` in `projectStore.ts` was missing a `markDirty()` call after `set()`, meaning terminal renames did not mark the workspace as dirty. This could cause renamed terminals to be lost on crash since the workspace would not be auto-saved.
- Added the `markDirty()` call to match every other mutation in the store.

## Test plan

- [ ] Rename a terminal and verify the workspace is marked dirty (auto-save triggers)
- [ ] Confirm crash recovery preserves the renamed terminal title

Relates to #26