### PR TITLE
fix: quote file paths with spaces on drag-and-drop

### DIFF
--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -379,7 +379,9 @@ export function ComposerBar() {
 
       // Handle non-image files — insert paths into draft
       if (nonImagePaths.length > 0) {
-        const pathText = nonImagePaths.join(" ");
+        const pathText = nonImagePaths
+          .map((p) => (/[\s"'\\$`!#&|;()<>]/.test(p) ? `"${p.replace(/"/g, '\\"')}"` : p))
+          .join(" ");
         const textarea = textareaRef.current;
         if (textarea) {
           const { selectionStart, selectionEnd } = textarea;


### PR DESCRIPTION
## Summary

- When dragging files with spaces or shell-special characters into the composer, paths are now wrapped in double quotes so they remain unambiguous
- Paths without special characters are left unquoted
- Internal double quotes within paths are escaped

## Test plan

- [ ] Drag a file with spaces in the path (e.g. `/Users/foo/my documents/file.txt`) into the composer and verify the path is quoted: `"/Users/foo/my documents/file.txt"`
- [ ] Drag a file without spaces (e.g. `/Users/foo/file.txt`) and verify it remains unquoted
- [ ] Drag multiple files (mix of spaced and non-spaced paths) and verify each is correctly handled
- [ ] Drag a file whose path contains a double quote and verify it is escaped within the quotes

Relates to #27