### PR TITLE
fix: internationalize empty canvas onboarding text

### DIFF
--- a/src/canvas/Canvas.tsx
+++ b/src/canvas/Canvas.tsx
@@ -13,8 +13,10 @@ import { DrawingLayer } from "./DrawingLayer";
 import { ConnectionOverlay } from "./ConnectionOverlay";
 import { FamilyTreeOverlay } from "../components/FamilyTreeOverlay";
 import { BoxSelectOverlay } from "./BoxSelectOverlay";
+import { useT } from "../i18n/useT";
 
 export function Canvas() {
+  const t = useT();
   const { viewport, isAnimating } = useCanvasStore();
   const animationBlur = usePreferencesStore((s) => s.animationBlur);
   const { projects } = useProjectStore();
@@ -84,12 +86,12 @@ export function Canvas() {
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <div className="text-center">
             <div className="text-[var(--text-muted)] text-lg font-light mb-2">
-              No projects yet
+              {t.canvas_empty_title}
             </div>
             <div className="text-[var(--text-faint)] text-sm">
-              Click{" "}
-              <span className="text-[var(--text-secondary)]">Add Project</span>{" "}
-              in the toolbar to get started
+              {t.canvas_empty_click}{" "}
+              <span className="text-[var(--text-secondary)]">{t.canvas_empty_action}</span>{" "}
+              {t.canvas_empty_suffix}
             </div>
           </div>
         </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -290,6 +290,12 @@ export const en = {
   welcome_github: "GitHub:",
   welcome_dismiss: "Press Enter to start the interactive tutorial, or Escape to skip.",
 
+  // Canvas empty state
+  canvas_empty_title: "No projects yet",
+  canvas_empty_click: "Click",
+  canvas_empty_action: "Add Project",
+  canvas_empty_suffix: "in the toolbar to get started",
+
   // Onboarding tutorial
   onboarding_dblclick_prompt: "Double-click a terminal title bar to focus it",
   onboarding_focus_prompt: "Press {shortcut} to focus a terminal",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -288,6 +288,12 @@ export const zh = {
   welcome_github: "GitHub:",
   welcome_dismiss: "按 Enter 进入交互教程，按 Escape 跳过。",
 
+  // Canvas empty state
+  canvas_empty_title: "还没有项目",
+  canvas_empty_click: "点击工具栏的",
+  canvas_empty_action: "添加项目",
+  canvas_empty_suffix: "来开始使用",
+
   // Onboarding tutorial
   onboarding_dblclick_prompt: "双击终端标题栏聚焦",
   onboarding_focus_prompt: "按 {shortcut} 聚焦终端",


### PR DESCRIPTION
## Summary

- Add i18n keys (`canvas_empty_title`, `canvas_empty_click`, `canvas_empty_action`, `canvas_empty_suffix`) to both `en.ts` and `zh.ts`
- Replace hardcoded English strings in the empty canvas state (`Canvas.tsx`) with translated `useT()` values

## Test plan

- [ ] Switch language to Chinese and verify the empty canvas state shows "还没有项目" / "点击工具栏的 添加项目 来开始使用"
- [ ] Switch language to English and verify the empty canvas state shows "No projects yet" / "Click Add Project in the toolbar to get started"
- [ ] Verify "Add Project" text retains its distinct styling (`--text-secondary`) in both languages

Relates to #24