### PR TITLE
fix: internationalize update modal UI strings

### DIFF
--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useRef } from "react";
 import { marked } from "marked";
 import { useUpdaterStore } from "../stores/updaterStore";
+import { useT } from "../i18n/useT";
 
 interface Props {
   onClose: () => void;
 }
 
 export function UpdateModal({ onClose }: Props) {
+  const t = useT();
   const { status, info, downloadPercent, errorMessage } = useUpdaterStore();
   const backdropRef = useRef<HTMLDivElement>(null);
 
@@ -42,7 +44,7 @@ export function UpdateModal({ onClose }: Props) {
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)]">
           <div>
             <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">
-              {status === "ready" ? "Update Ready" : "Update"}
+              {status === "ready" ? t.update_modal_title_ready : t.update_modal_title}
             </h2>
             {info && (
               <p className="mt-0.5 text-[12px] text-[var(--text-secondary)]">
@@ -80,7 +82,7 @@ export function UpdateModal({ onClose }: Props) {
               />
             </div>
             <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-              Downloading... {Math.round(downloadPercent)}%
+              {t.update_modal_downloading(downloadPercent)}
             </p>
           </div>
         )}
@@ -89,7 +91,7 @@ export function UpdateModal({ onClose }: Props) {
         {status === "error" && (
           <div className="px-5 py-3">
             <p className="text-[12px] text-red-400">
-              {errorMessage || "Download failed"}
+              {errorMessage || t.update_modal_download_failed}
             </p>
           </div>
         )}
@@ -100,14 +102,14 @@ export function UpdateModal({ onClose }: Props) {
             onClick={onClose}
             className="px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
           >
-            Later
+            {t.update_modal_later}
           </button>
           {status === "error" && (
             <button
               onClick={handleRetry}
               className="px-4 py-1.5 text-[12px] font-medium text-white bg-[var(--accent)] rounded-lg hover:brightness-110 transition-all"
             >
-              Retry
+              {t.update_modal_retry}
             </button>
           )}
           {status === "ready" && (
@@ -115,7 +117,7 @@ export function UpdateModal({ onClose }: Props) {
               onClick={handleInstall}
               className="px-4 py-1.5 text-[12px] font-medium text-white bg-[var(--accent)] rounded-lg hover:brightness-110 transition-all"
             >
-              Restart & Update
+              {t.update_modal_restart}
             </button>
           )}
         </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -147,6 +147,15 @@ export const en = {
   update_ready: "Update ready, click to view",
   update_error: "Update error",
 
+  // UpdateModal
+  update_modal_title_ready: "Update Ready",
+  update_modal_title: "Update",
+  update_modal_downloading: (percent: number) => `Downloading... ${Math.round(percent)}%`,
+  update_modal_download_failed: "Download failed",
+  update_modal_later: "Later",
+  update_modal_retry: "Retry",
+  update_modal_restart: "Restart & Update",
+
   // CLI
   cli_label: "Command line interface",
   cli_registered: "Registered",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -145,6 +145,15 @@ export const zh = {
   update_ready: "更新已就绪，点击查看",
   update_error: "更新出错",
 
+  // UpdateModal
+  update_modal_title_ready: "更新就绪",
+  update_modal_title: "更新",
+  update_modal_downloading: (percent: number) => `下载中... ${Math.round(percent)}%`,
+  update_modal_download_failed: "下载失败",
+  update_modal_later: "稍后",
+  update_modal_retry: "重试",
+  update_modal_restart: "重启并更新",
+
   // CLI
   cli_label: "命令行工具",
   cli_registered: "已注册",


### PR DESCRIPTION
## Summary
- Add 7 new i18n keys for the update modal to both `en.ts` and `zh.ts` translation files
- Replace all hardcoded English strings in `UpdateModal.tsx` with `useT()` hook calls
- Covers: modal title, downloading progress, error fallback, and all button labels

## Test plan
- [ ] Switch language to Chinese and open the update modal — verify all strings display in Chinese
- [ ] Switch back to English — verify strings display correctly in English
- [ ] Verify the downloading progress percentage still renders correctly
- [ ] Verify error fallback text appears when `errorMessage` is null

Relates to #25