### PR TITLE
fix: handle Windows backslash paths in session-watcher

### DIFF
--- a/electron/session-watcher.ts
+++ b/electron/session-watcher.ts
@@ -88,7 +88,7 @@ function resolveSessionFile(
   const home = os.homedir();
 
   if (type === "claude") {
-    const projectKey = cwd.replaceAll(/[/.]/g, "-");
+    const projectKey = cwd.replaceAll(/[/\\.:-]/g, "-");
     return path.join(home, ".claude", "projects", projectKey, sessionId + ".jsonl");
   }
 


### PR DESCRIPTION
## Summary
- Update `projectKey` regex in `session-watcher.ts` to also replace `\` and `:` characters, which appear in Windows-style paths (e.g. `C:\Users\...`)
- Previous regex `[/.]` only handled forward slashes and dots, leaving backslashes and colons in the generated key

Related to #36

## Test plan
- [ ] Verify `projectKey` correctly normalizes a Windows path like `C:\Users\foo\project` into `C--Users-foo-project`
- [ ] Verify Unix paths (`/home/foo/project`) still normalize correctly
- [ ] Verify dots in paths are still replaced