### PR TITLE
fix: use junction symlinks on Windows for Hydra skill

### DIFF
--- a/electron/hydra-skill.ts
+++ b/electron/hydra-skill.ts
@@ -33,7 +33,7 @@ export function installHydraSkillLinks({
       } catch {
         // ignore missing stale links
       }
-      fs.symlinkSync(sourceDir, link);
+      fs.symlinkSync(sourceDir, link, process.platform === 'win32' ? 'junction' : undefined);
     }
     return true;
   } catch {
@@ -65,7 +65,7 @@ export function ensureHydraSkillLinks({
       } catch {
         // ignore missing stale links
       }
-      fs.symlinkSync(sourceDir, link);
+      fs.symlinkSync(sourceDir, link, process.platform === 'win32' ? 'junction' : undefined);
     }
     return true;
   } catch {


### PR DESCRIPTION
## Summary
- Pass `'junction'` as the third argument to `fs.symlinkSync` on Windows in both `installHydraSkillLinks` and `ensureHydraSkillLinks`
- Directory symlinks on Windows require admin privileges, but junctions do not — this removes that requirement

Related to #35

## Test plan
- [ ] Verify Hydra skill install works on Windows without running as administrator
- [ ] Verify Hydra skill install still works on macOS/Linux (third argument is `undefined`, no behavior change)