### PR TITLE
fix: use hasPrimaryModifier for Ctrl+Arrow in Composer

### DIFF
--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -15,6 +15,7 @@ import {
   resolveComposerTarget,
 } from "./composerTarget";
 import { SlashCommandMenu } from "./SlashCommandMenu";
+import { hasPrimaryModifier } from "../hooks/shortcutTarget";
 import { useT } from "../i18n/useT";
 import type {
   ComposerImageAttachment,
@@ -109,7 +110,7 @@ function getPassthroughSequence(
   // Cmd+Arrow → always forward to terminal (history / cursor control)
   // Plain Arrow → forward only when Composer is empty
   const arrowSeq = ARROW_SEQUENCES[event.key];
-  if (arrowSeq && (event.metaKey || draft.trim().length === 0)) {
+  if (arrowSeq && (hasPrimaryModifier(event) || draft.trim().length === 0)) {
     return arrowSeq;
   }
   return null;


### PR DESCRIPTION
## Summary
- Replace `event.metaKey` with `hasPrimaryModifier(event)` in `getPassthroughSequence` so that Ctrl+Arrow keys are correctly forwarded to the terminal on Windows (where `metaKey` is always false).
- Import the existing `hasPrimaryModifier` helper from `src/hooks/shortcutTarget.ts`, which returns `metaKey` on macOS and `ctrlKey` on Windows/Linux.

Related to #37

## Test plan
- [ ] On macOS: verify Cmd+Arrow in ComposerBar still forwards arrow sequences to the terminal
- [ ] On Windows: verify Ctrl+Arrow in ComposerBar now forwards arrow sequences to the terminal (previously did nothing)
- [ ] Verify plain arrow keys still forward when composer draft is empty
- [ ] Verify arrow keys are handled by textarea when draft has content and no modifier is held