### PR TITLE
fix(session-watcher): normalize Claude project keys on Windows

### DIFF
--- a/electron/session-watcher.ts
+++ b/electron/session-watcher.ts
@@ -77,6 +77,10 @@ export function checkTurnComplete(
   return { completed: false };
 }
 
+export function toClaudeProjectKey(cwd: string): string {
+  return cwd.replaceAll(/[/\\.:]/g, "-");
+}
+
 /**
  * Resolve the JSONL file path for a session.
  */
@@ -88,7 +92,7 @@ function resolveSessionFile(
   const home = os.homedir();
 
   if (type === "claude") {
-    const projectKey = cwd.replaceAll(/[/\\.:-]/g, "-");
+    const projectKey = toClaudeProjectKey(cwd);
     return path.join(home, ".claude", "projects", projectKey, sessionId + ".jsonl");
   }
 

--- a/tests/session-watcher.test.ts
+++ b/tests/session-watcher.test.ts
@@ -4,7 +4,10 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { checkTurnComplete } from "../electron/session-watcher.ts";
+import {
+  checkTurnComplete,
+  toClaudeProjectKey,
+} from "../electron/session-watcher.ts";
 
 function withTempFile(content: string, fn: (filePath: string) => void) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-watcher-"));
@@ -135,4 +138,18 @@ test("claude: detects completion with mixed valid/invalid lines at tail", () => 
     const result = checkTurnComplete(filePath, "claude");
     assert.equal(result.completed, true);
   });
+});
+
+test("claude project key normalizes POSIX paths", () => {
+  assert.equal(
+    toClaudeProjectKey("/Users/foo/my.app"),
+    "-Users-foo-my-app",
+  );
+});
+
+test("claude project key normalizes Windows paths", () => {
+  assert.equal(
+    toClaudeProjectKey("C:\\Users\\foo\\project"),
+    "C--Users-foo-project",
+  );
 });


### PR DESCRIPTION
## Summary
- normalize Claude project keys derived from Windows `cwd` values before resolving session JSONL paths
- preserve the existing POSIX behavior while handling drive letters and backslashes correctly

## Changes
- extract `toClaudeProjectKey()` in `electron/session-watcher.ts`
- replace `/`, `\`, `.`, and `:` with `-` when building Claude project keys
- add regression coverage for both POSIX and Windows-style paths in `tests/session-watcher.test.ts`

## Testing
- `node --experimental-strip-types --test tests/session-watcher.test.ts`

Closes #36