### PR TITLE
fix(process-detector): support Windows process enumeration and path parsing

### DIFF
--- a/electron/process-detector.ts
+++ b/electron/process-detector.ts
@@ -20,10 +20,21 @@ const CLI_PATTERNS: [RegExp, string][] = [
 // Wrappers that delegate to another binary — check subsequent args for the real CLI
 const WRAPPER_NAMES = new Set(["node", "bun", "npx", "bunx"]);
 
+function normalizeProcessName(token: string): string {
+  const trimmed = token.replace(/^"|"$/g, "");
+  const baseName = trimmed.split(/[\\/]/).pop() ?? "";
+  return baseName.replace(/\.(exe|cmd|bat)$/i, "").toLowerCase();
+}
+
+function extractFirstToken(args: string): string {
+  const match = args.match(/^"([^"]+)"|^(\S+)/);
+  return match?.[1] ?? match?.[2] ?? "";
+}
+
 function matchCli(args: string): string | null {
   // Extract the process name (first token)
-  const firstToken = args.split(/\s+/)[0];
-  const baseName = firstToken.split("/").pop() ?? "";
+  const firstToken = extractFirstToken(args);
+  const baseName = normalizeProcessName(firstToken);
 
   // If the process is a wrapper (node, bun, npx, bunx), match against the full args string
   // to catch patterns like `node /usr/local/bin/claude` or `npx codex`
@@ -43,29 +54,10 @@ function matchCli(args: string): string | null {
   return null;
 }
 
-/**
- * Parse `ps -eo pid,ppid,args` output and find CLI processes
- * among all descendants (not just direct children) of the given shell PIDs.
- * Uses BFS so shallower matches appear first in results.
- */
-export function parsePsOutput(psOutput: string, shellPids: number[]): DetectedCli[] {
-  const processes: { pid: number; ppid: number; args: string }[] = [];
-  const lines = psOutput.split("\n");
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("PID")) continue;
-
-    // Format: "  PID  PPID ARGS..."
-    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.+)$/);
-    if (!match) continue;
-
-    processes.push({
-      pid: parseInt(match[1], 10),
-      ppid: parseInt(match[2], 10),
-      args: match[3],
-    });
-  }
-
+function collectDetectedClis(
+  processes: { pid: number; ppid: number; args: string }[],
+  shellPids: number[],
+): DetectedCli[] {
   // Build parent → children map
   const childrenOf = new Map<number, number[]>();
   for (const p of processes) {
@@ -93,7 +85,6 @@ export function parsePsOutput(psOutput: string, shellPids: number[]): DetectedCl
   }
 
   // Match CLIs among descendants in BFS order (shallowest first).
-  // `queue` was populated by BFS so its order reflects tree depth.
   const processMap = new Map(processes.map((p) => [p.pid, p]));
   const results: DetectedCli[] = [];
   for (const pid of queue.slice(shellPids.length)) {
@@ -109,20 +100,111 @@ export function parsePsOutput(psOutput: string, shellPids: number[]): DetectedCl
 }
 
 /**
+ * Parse `ps -eo pid,ppid,args` output and find CLI processes
+ * among all descendants (not just direct children) of the given shell PIDs.
+ * Uses BFS so shallower matches appear first in results.
+ */
+export function parsePsOutput(psOutput: string, shellPids: number[]): DetectedCli[] {
+  const processes: { pid: number; ppid: number; args: string }[] = [];
+  const lines = psOutput.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("PID")) continue;
+
+    // Format: "  PID  PPID ARGS..."
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) continue;
+
+    processes.push({
+      pid: parseInt(match[1], 10),
+      ppid: parseInt(match[2], 10),
+      args: match[3],
+    });
+  }
+
+  return collectDetectedClis(processes, shellPids);
+}
+
+export function parseWindowsProcessListOutput(
+  processJson: string,
+  shellPids: number[],
+): DetectedCli[] {
+  if (!processJson.trim()) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(processJson);
+  } catch {
+    return [];
+  }
+
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  const processes: { pid: number; ppid: number; args: string }[] = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const row = entry as {
+      ProcessId?: unknown;
+      ParentProcessId?: unknown;
+      CommandLine?: unknown;
+    };
+    if (
+      typeof row.ProcessId !== "number" ||
+      typeof row.ParentProcessId !== "number" ||
+      typeof row.CommandLine !== "string" ||
+      row.CommandLine.trim().length === 0
+    ) {
+      continue;
+    }
+
+    processes.push({
+      pid: row.ProcessId,
+      ppid: row.ParentProcessId,
+      args: row.CommandLine,
+    });
+  }
+
+  return collectDetectedClis(processes, shellPids);
+}
+
+export function getProcessListCommand(
+  platform = process.platform,
+): { command: string; args: string[] } {
+  if (platform === "win32") {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-Command",
+        "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
+      ],
+    };
+  }
+
+  return {
+    command: "ps",
+    args: ["-eo", "pid,ppid,args"],
+  };
+}
+
+/**
  * Detect a CLI tool running as a descendant of the given shell PID.
  * Returns the CLI type and optional session name (for tmux).
  */
 export async function detectCli(
   shellPid: number,
 ): Promise<{ cliType: string; pid?: number; sessionName?: string } | null> {
-  const psOutput = await new Promise<string>((resolve, reject) => {
-    execFile("ps", ["-eo", "pid,ppid,args"], (err, stdout) => {
+  const processListCommand = getProcessListCommand();
+  const processOutput = await new Promise<string>((resolve, reject) => {
+    execFile(processListCommand.command, processListCommand.args, (err, stdout) => {
       if (err) return reject(err);
       resolve(stdout);
     });
   });
 
-  const results = parsePsOutput(psOutput, [shellPid]);
+  const results = process.platform === "win32"
+    ? parseWindowsProcessListOutput(processOutput, [shellPid])
+    : parsePsOutput(processOutput, [shellPid]);
   if (results.length === 0) return null;
 
   const first = results[0];

--- a/tests/process-detector.test.ts
+++ b/tests/process-detector.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { parsePsOutput } from "../electron/process-detector.ts";
+import {
+  getProcessListCommand,
+  parsePsOutput,
+  parseWindowsProcessListOutput,
+} from "../electron/process-detector.ts";
 
 const HEADER = "  PID  PPID ARGS\n";
 
@@ -184,4 +188,42 @@ test("node without CLI arg is not detected", () => {
 
   const results = parsePsOutput(ps, [100]);
   assert.equal(results.length, 0);
+});
+
+test("getProcessListCommand uses PowerShell on Windows", () => {
+  assert.deepEqual(getProcessListCommand("win32"), {
+    command: "powershell.exe",
+    args: [
+      "-NoProfile",
+      "-Command",
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
+    ],
+  });
+});
+
+test("parseWindowsProcessListOutput detects node.exe wrapper paths", () => {
+  const processes = JSON.stringify([
+    { ProcessId: 100, ParentProcessId: 1, CommandLine: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" },
+    {
+      ProcessId: 200,
+      ParentProcessId: 100,
+      CommandLine: "\"C:\\Program Files\\nodejs\\node.exe\" C:\\Users\\foo\\AppData\\Roaming\\npm\\claude",
+    },
+  ]);
+
+  const results = parseWindowsProcessListOutput(processes, [100]);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].cliType, "claude");
+});
+
+test("parseWindowsProcessListOutput handles single-object JSON output", () => {
+  const processJson = JSON.stringify({
+    ProcessId: 200,
+    ParentProcessId: 100,
+    CommandLine: "C:\\Users\\foo\\bin\\codex.exe --help",
+  });
+
+  const results = parseWindowsProcessListOutput(processJson, [100]);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].cliType, "codex");
 });


### PR DESCRIPTION
## Summary
- make CLI process detection work on Windows by replacing Unix-only assumptions in both process enumeration and executable-name parsing

## Changes
- add `getProcessListCommand()` to use PowerShell `Get-CimInstance Win32_Process` on Windows
- add `parseWindowsProcessListOutput()` and share descendant traversal logic across platforms
- normalize executable names for backslashes, quoted paths, spaces, and `.exe`/`.cmd`/`.bat` suffixes
- preserve the existing `ps -eo pid,ppid,args` flow on non-Windows platforms
- add regression tests for Windows wrapper paths and single-object PowerShell JSON output

## Testing
- `node --experimental-strip-types --test tests/process-detector.test.ts`

Closes #31