### PR TITLE
fix(cli): implement Windows CLI registration via the user PATH

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,6 +22,13 @@ import {
 } from "./hydra-skill";
 import { buildLaunchSpec } from "./pty-launch.js";
 import {
+  addWindowsPathEntry,
+  hasWindowsPathEntry,
+  readWindowsUserPath,
+  removeWindowsPathEntry,
+  writeWindowsUserPath,
+} from "./windows-cli-path";
+import {
   createDefaultComposerSubmitDeps,
   submitComposerRequest,
 } from "./composer-submit";
@@ -850,6 +857,14 @@ function getPathExportLine(): string {
 }
 
 function isCliRegistered(): boolean {
+  if (process.platform === "win32") {
+    try {
+      return hasWindowsPathEntry(readWindowsUserPath(), getCliDir());
+    } catch {
+      return false;
+    }
+  }
+
   if (process.platform === "darwin") {
     try {
       const content = fs.readFileSync(ZPROFILE_PATH, "utf-8");
@@ -884,6 +899,16 @@ function registerCli(): boolean {
   }
 
   let ok = false;
+
+  if (process.platform === "win32") {
+    try {
+      const nextPath = addWindowsPathEntry(readWindowsUserPath(), cliDir);
+      writeWindowsUserPath(nextPath);
+      ok = true;
+    } catch {
+      return false;
+    }
+  }
 
   if (process.platform === "darwin") {
     const line = getPathExportLine();
@@ -943,6 +968,16 @@ function registerCli(): boolean {
 function unregisterCli(): boolean {
   // Auto-uninstall hydra skill alongside CLI
   uninstallSkill();
+
+  if (process.platform === "win32") {
+    try {
+      const nextPath = removeWindowsPathEntry(readWindowsUserPath(), getCliDir());
+      writeWindowsUserPath(nextPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   if (process.platform === "darwin") {
     const line = getPathExportLine();

--- a/electron/windows-cli-path.ts
+++ b/electron/windows-cli-path.ts
@@ -1,0 +1,63 @@
+import { execFileSync } from "node:child_process";
+
+function escapePowerShellLiteral(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+function normalizeWindowsPathEntry(entry: string): string {
+  return entry
+    .trim()
+    .replaceAll("/", "\\")
+    .replace(/[\\]+$/, "")
+    .toLowerCase();
+}
+
+export function splitWindowsPathEntries(pathValue: string): string[] {
+  return pathValue
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function hasWindowsPathEntry(pathValue: string, entry: string): boolean {
+  const target = normalizeWindowsPathEntry(entry);
+  return splitWindowsPathEntries(pathValue).some(
+    (candidate) => normalizeWindowsPathEntry(candidate) === target,
+  );
+}
+
+export function addWindowsPathEntry(pathValue: string, entry: string): string {
+  if (hasWindowsPathEntry(pathValue, entry)) return pathValue;
+  return pathValue.trim().length > 0 ? `${pathValue};${entry}` : entry;
+}
+
+export function removeWindowsPathEntry(pathValue: string, entry: string): string {
+  const target = normalizeWindowsPathEntry(entry);
+  return splitWindowsPathEntries(pathValue)
+    .filter((candidate) => normalizeWindowsPathEntry(candidate) !== target)
+    .join(";");
+}
+
+export function readWindowsUserPath(): string {
+  return execFileSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-Command",
+      "[Environment]::GetEnvironmentVariable('Path', 'User')",
+    ],
+    { encoding: "utf-8" },
+  ).trim();
+}
+
+export function writeWindowsUserPath(pathValue: string): void {
+  execFileSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-Command",
+      `[Environment]::SetEnvironmentVariable('Path', '${escapePowerShellLiteral(pathValue)}', 'User')`,
+    ],
+    { stdio: "pipe" },
+  );
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:icons": "python3 scripts/generate-icons.py",
     "postinstall": "electron-builder install-app-deps",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts"
+    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/windows-cli-path.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts"
   },
   "keywords": [
     "terminal",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:icons": "python3 scripts/generate-icons.py",
     "postinstall": "electron-builder install-app-deps",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/windows-cli-path.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts"
+    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts"
   },
   "keywords": [
     "terminal",

--- a/tests/windows-cli-path.test.ts
+++ b/tests/windows-cli-path.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  addWindowsPathEntry,
+  hasWindowsPathEntry,
+  removeWindowsPathEntry,
+} from "../electron/windows-cli-path.ts";
+
+test("hasWindowsPathEntry ignores case and slash style", () => {
+  assert.equal(
+    hasWindowsPathEntry(
+      "C:\\Windows\\System32;C:\\Users\\Foo\\AppData\\Local\\termcanvas\\bin",
+      "c:/users/foo/appdata/local/termcanvas/bin/",
+    ),
+    true,
+  );
+});
+
+test("addWindowsPathEntry appends missing entries once", () => {
+  assert.equal(
+    addWindowsPathEntry("C:\\Windows\\System32", "C:\\termcanvas\\bin"),
+    "C:\\Windows\\System32;C:\\termcanvas\\bin",
+  );
+  assert.equal(
+    addWindowsPathEntry(
+      "C:\\Windows\\System32;C:\\termcanvas\\bin",
+      "c:/termcanvas/bin/",
+    ),
+    "C:\\Windows\\System32;C:\\termcanvas\\bin",
+  );
+});
+
+test("removeWindowsPathEntry removes only the target entry", () => {
+  assert.equal(
+    removeWindowsPathEntry(
+      "C:\\Windows\\System32;C:\\termcanvas\\bin;C:\\Other",
+      "c:/termcanvas/bin",
+    ),
+    "C:\\Windows\\System32;C:\\Other",
+  );
+});


### PR DESCRIPTION
## Summary
- implement CLI registration and unregistration on Windows by updating the user-scoped `Path` environment variable

## Changes
- add `electron/windows-cli-path.ts` helpers for PATH parsing, normalization, deduplication, and removal
- implement Windows branches in `isCliRegistered()`, `registerCli()`, and `unregisterCli()`
- use PowerShell to read/write the user PATH entry
- keep the existing macOS and Linux registration flows unchanged
- add focused regression tests for case-insensitive and slash-insensitive PATH handling

## Testing
- `node --experimental-strip-types --test tests/windows-cli-path.test.ts`

## Notes
- the updated PATH is user-scoped, so newly opened terminals should pick it up after registration

Closes #34