### PR TITLE
fix #61: show all time buckets for past dates in usage panel

### DIFF
--- a/src/components/UsagePanel.tsx
+++ b/src/components/UsagePanel.tsx
@@ -252,7 +252,7 @@ function TimelineSection({
         {t.usage_timeline}
       </span>
       <div className="mt-2">
-        <SparklineChart buckets={summary.buckets} animate={animate} />
+        <SparklineChart buckets={summary.buckets} animate={animate} date={summary.date} />
       </div>
     </div>
   );

--- a/src/components/usage/SparklineChart.tsx
+++ b/src/components/usage/SparklineChart.tsx
@@ -17,22 +17,27 @@ interface SparklineChartProps {
   buckets: UsageBucket[];
   /** When true, bars animate in with stagger */
   animate: boolean;
+  /** YYYY-MM-DD date string for the displayed data */
+  date?: string;
 }
 
-export function SparklineChart({ buckets, animate }: SparklineChartProps) {
+export function SparklineChart({ buckets, animate, date }: SparklineChartProps) {
   const t = useT();
   const [hovered, setHovered] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const max = Math.max(...buckets.map((b) => b.cost), 0.001);
   const now = new Date();
   const currentHour = now.getHours();
+  // Past dates have no future buckets — the full 24h has elapsed
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  const isToday = !date || date === todayStr;
 
   return (
     <div ref={containerRef} className="relative">
       <div className="flex items-end gap-px h-10">
         {buckets.map((b, i) => {
           const h = max > 0 ? Math.max(0, (b.cost / max) * 100) : 0;
-          const isFuture = b.hourStart > currentHour;
+          const isFuture = isToday && b.hourStart > currentHour;
           const isActive = b.calls > 0;
           const barH = isFuture ? 4 : Math.max(isActive ? 12 : 4, h);
           const isHovered = hovered === i;


### PR DESCRIPTION
## Summary
- Past dates now show all 12 time buckets (full 24h) instead of being limited to current time of day
- Only today's view limits buckets to the current hour

## Test plan
- [ ] View usage for a past date — verify all 12 time buckets appear
- [ ] View usage for today — verify only buckets up to current time appear