### PR TITLE
fix #31: fix process-detector on Windows

### DIFF
--- a/electron/process-detector.ts
+++ b/electron/process-detector.ts
@@ -1,4 +1,5 @@
 import { execFile } from "child_process";
+import path from "path";
 
 export interface DetectedCli {
   pid: number;
@@ -23,7 +24,7 @@ const WRAPPER_NAMES = new Set(["node", "bun", "npx", "bunx"]);
 function matchCli(args: string): string | null {
   // Extract the process name (first token)
   const firstToken = args.split(/\s+/)[0];
-  const baseName = firstToken.split("/").pop() ?? "";
+  const baseName = path.basename(firstToken);
 
   // If the process is a wrapper (node, bun, npx, bunx), match against the full args string
   // to catch patterns like `node /usr/local/bin/claude` or `npx codex`
@@ -109,18 +110,61 @@ export function parsePsOutput(psOutput: string, shellPids: number[]): DetectedCl
 }
 
 /**
+ * Get process list output in `ps -eo pid,ppid,args` format.
+ * On Windows, uses PowerShell Get-CimInstance as `ps` is not available.
+ */
+async function getProcessList(): Promise<string> {
+  if (process.platform === "win32") {
+    const csvOutput = await new Promise<string>((resolve, reject) => {
+      execFile(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-Command",
+          'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Csv -NoTypeInformation',
+        ],
+        (err, stdout) => {
+          if (err) return reject(err);
+          resolve(stdout);
+        },
+      );
+    });
+
+    // Convert CSV to the same whitespace-delimited format as `ps -eo pid,ppid,args`
+    const lines = csvOutput.split("\n");
+    const converted: string[] = ["  PID  PPID ARGS"];
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      // CSV fields are quoted: "ProcessId","ParentProcessId","CommandLine"
+      const match = line.match(/^"(\d+)","(\d+)","(.*)"$/);
+      if (!match) continue;
+
+      const pid = match[1];
+      const ppid = match[2];
+      const cmdline = match[3] || "";
+      converted.push(`${pid} ${ppid} ${cmdline}`);
+    }
+    return converted.join("\n");
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    execFile("ps", ["-eo", "pid,ppid,args"], (err, stdout) => {
+      if (err) return reject(err);
+      resolve(stdout);
+    });
+  });
+}
+
+/**
  * Detect a CLI tool running as a descendant of the given shell PID.
  * Returns the CLI type and optional session name (for tmux).
  */
 export async function detectCli(
   shellPid: number,
 ): Promise<{ cliType: string; pid?: number; sessionName?: string } | null> {
-  const psOutput = await new Promise<string>((resolve, reject) => {
-    execFile("ps", ["-eo", "pid,ppid,args"], (err, stdout) => {
-      if (err) return reject(err);
-      resolve(stdout);
-    });
-  });
+  const psOutput = await getProcessList();
 
   const results = parsePsOutput(psOutput, [shellPid]);
   if (results.length === 0) return null;


### PR DESCRIPTION
## Summary
- Add Windows process enumeration using PowerShell `Get-CimInstance Win32_Process`, since `ps -eo` is not available on Windows
- Fix path splitting to handle Windows backslash paths using `path.basename()` instead of manual `/` splitting

## Test plan
- [ ] Verify process detection still works on macOS/Linux
- [ ] Verify CLI detection works on Windows with PowerShell fallback