### PR TITLE
fix #32: fix font download crash on Windows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import { execSync } from "child_process";
 import https from "https";
 import path from "path";
 import fs from "fs";
+import AdmZip from "adm-zip";
 import os from "os";
 import { fileURLToPath } from "url";
 import { PtyManager, OutputBatcher } from "./pty-manager";
@@ -781,25 +782,20 @@ function setupIpc() {
         }
         fs.writeFileSync(tmpZip, buf);
 
-        // Extract target font file from zip
-        const zipList = execSync(`unzip -l "${tmpZip}"`, {
-          encoding: "utf-8",
-        });
-        const lines = zipList.split("\n");
-        const matchLine = lines.find((l) => l.trim().endsWith(fileName));
-        if (!matchLine) {
+        // Extract target font file from zip (cross-platform, no shell unzip)
+        const zip = new AdmZip(tmpZip);
+        const zipEntries = zip.getEntries();
+        const matchEntry = zipEntries.find((e) =>
+          e.entryName.endsWith(fileName),
+        );
+        if (!matchEntry) {
           fs.unlinkSync(tmpZip);
           return {
             ok: false,
             error: `Font file "${fileName}" not found in archive`,
           };
         }
-        const innerPath = matchLine.trim().split(/\s+/).pop()!;
-
-        execSync(
-          `unzip -jo "${tmpZip}" "${innerPath}" -d "${fontsDir}"`,
-          { encoding: "utf-8" },
-        );
+        fs.writeFileSync(destPath, matchEntry.getData());
         fs.unlinkSync(tmpZip);
 
         return { ok: true, path: destPath };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "termcanvas",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termcanvas",
-      "version": "0.8.43",
+      "version": "0.8.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.99.3",
         "@xterm/addon-image": "^0.9.0",
         "@xterm/addon-serialize": "^0.14.0",
+        "adm-zip": "^0.5.16",
         "electron-updater": "^6.8.3",
         "geist": "^1.7.0",
         "marked": "^17.0.4",
@@ -28,6 +29,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "@types/adm-zip": "^0.5.8",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
@@ -798,6 +800,7 @@
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2992,6 +2995,16 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3268,6 +3281,15 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@supabase/supabase-js": "^2.99.3",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "adm-zip": "^0.5.16",
     "electron-updater": "^6.8.3",
     "geist": "^1.7.0",
     "marked": "^17.0.4",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "@types/adm-zip": "^0.5.8",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",


### PR DESCRIPTION
## Summary
- Replace Unix `unzip` shell commands with `adm-zip` Node.js library for cross-platform zip extraction
- Font download now works on Windows, macOS, and Linux
- Added `adm-zip` as a dependency and `@types/adm-zip` as a dev dependency

## Test plan
- [ ] Download a font on macOS — verify extraction works
- [ ] Download a font on Windows — verify extraction works
- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)