### PR TITLE
fix #14: preserve permission level when restoring sessions

### DIFF
--- a/src/terminal/cliConfig.ts
+++ b/src/terminal/cliConfig.ts
@@ -221,7 +221,7 @@ export function getTerminalLaunchOptions(
   const extraArgs = cliOverride?.args ?? [];
   const base = sessionId ? config.resumeArgs(sessionId) : config.newArgs();
   const extra =
-    autoApprove && !sessionId && config.autoApproveArgs
+    autoApprove && config.autoApproveArgs
       ? config.autoApproveArgs()
       : [];
 

--- a/tests/terminal-adapters.test.ts
+++ b/tests/terminal-adapters.test.ts
@@ -73,6 +73,32 @@ test("getTerminalLaunchOptions prepends cliOverride args", () => {
   assert.deepEqual(result.args, ["--extra", "--resume", "session-1"]);
 });
 
+test("getTerminalLaunchOptions includes autoApprove args for new claude session", () => {
+  const result = getTerminalLaunchOptions("claude", undefined, true);
+  assert.ok(result);
+  assert.deepEqual(result.args, ["--dangerously-skip-permissions"]);
+});
+
+test("getTerminalLaunchOptions includes autoApprove args when resuming claude session", () => {
+  const result = getTerminalLaunchOptions("claude", "session-1", true);
+  assert.ok(result);
+  assert.deepEqual(result.args, [
+    "--dangerously-skip-permissions",
+    "--resume",
+    "session-1",
+  ]);
+});
+
+test("getTerminalLaunchOptions includes autoApprove args when resuming codex session", () => {
+  const result = getTerminalLaunchOptions("codex", "session-1", true);
+  assert.ok(result);
+  assert.deepEqual(result.args, [
+    "--dangerously-bypass-approvals-and-sandbox",
+    "resume",
+    "session-1",
+  ]);
+});
+
 test("getTerminalPromptArgs defaults to a positional prompt", () => {
   assert.deepEqual(getTerminalPromptArgs("claude", "Explore the repo"), [
     "Explore the repo",


### PR DESCRIPTION
## Summary
- Permission level (e.g., bypass mode) is now saved with terminal state and re-applied when resuming sessions
- Removed the `!sessionId` guard in `getTerminalLaunchOptions` so `--dangerously-skip-permissions` (Claude) and `--dangerously-bypass-approvals-and-sandbox` (Codex) flags are passed on resume, not only on fresh launch
- Added 3 test cases covering autoApprove behavior for new and resumed sessions

## Test plan
- [ ] Launch Claude with bypass permissions, save canvas, restart app, verify session resumes in bypass mode
- [ ] Launch Codex with bypass permissions, save canvas, restart app, verify session resumes in bypass mode
- [ ] Verify new sessions without autoApprove still launch without bypass flags