### PR TITLE
fix #55: preserve Claude sessions across app updates

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -447,6 +447,53 @@ function setupIpc() {
     sessionWatcher.unwatch(sessionId);
   });
 
+  // Validate that a session's JSONL file still exists on disk.
+  // Used before attempting --resume to avoid launching with a stale session ID.
+  ipcMain.handle(
+    "session:validate",
+    (_event, type: string, sessionId: string, cwd: string) => {
+      try {
+        if (type === "claude") {
+          const projectKey = cwd.replaceAll(/[/\\.:-]/g, "-");
+          const jsonlPath = path.join(
+            os.homedir(),
+            ".claude",
+            "projects",
+            projectKey,
+            sessionId + ".jsonl",
+          );
+          const exists = fs.existsSync(jsonlPath);
+          dbg(`session:validate type=claude sid=${sessionId} file=${jsonlPath} exists=${exists}`);
+          return exists;
+        }
+        if (type === "codex") {
+          const sessionsDir = path.join(os.homedir(), ".codex", "sessions");
+          const now = new Date();
+          for (let d = 0; d < 7; d++) {
+            const date = new Date(now.getTime() - d * 86400000);
+            const yyyy = String(date.getFullYear());
+            const mm = String(date.getMonth() + 1).padStart(2, "0");
+            const dd = String(date.getDate()).padStart(2, "0");
+            const dayDir = path.join(sessionsDir, yyyy, mm, dd);
+            if (!fs.existsSync(dayDir)) continue;
+            const files = fs.readdirSync(dayDir);
+            if (files.find((f) => f.includes(sessionId))) {
+              dbg(`session:validate type=codex sid=${sessionId} found=true`);
+              return true;
+            }
+          }
+          dbg(`session:validate type=codex sid=${sessionId} found=false`);
+          return false;
+        }
+        // For other types (kimi, gemini, etc.), assume valid — no known file layout
+        return true;
+      } catch (err) {
+        dbg(`session:validate ERROR: ${err}`);
+        return false;
+      }
+    },
+  );
+
   // State IPC
   ipcMain.handle("state:load", () => {
     return statePersistence.load();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -49,6 +49,8 @@ contextBridge.exposeInMainWorld("termcanvas", {
       >,
     unwatch: (sessionId: string) =>
       ipcRenderer.invoke("session:unwatch", sessionId),
+    validate: (type: string, sessionId: string, cwd: string) =>
+      ipcRenderer.invoke("session:validate", type, sessionId, cwd) as Promise<boolean>,
     onTurnComplete: (callback: (sessionId: string) => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -551,7 +551,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
       ),
     })),
 
-  updateTerminalSessionId: (projectId, worktreeId, terminalId, sessionId) =>
+  updateTerminalSessionId: (projectId, worktreeId, terminalId, sessionId) => {
     set((state) => ({
       projects: mapTerminals(
         state.projects,
@@ -560,7 +560,9 @@ export const useProjectStore = create<ProjectStore>((set) => ({
         terminalId,
         (t) => ({ ...t, sessionId }),
       ),
-    })),
+    }));
+    markDirty();
+  },
 
   updateTerminalType: (projectId, worktreeId, terminalId, type) =>
     set((state) => ({

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -376,7 +376,8 @@ export function TerminalTile({
 
     let ptyId: number | null = null;
     const cliOverride = usePreferencesStore.getState().cliCommands[terminal.type] ?? undefined;
-    const wasResumeAttempt = !!terminal.sessionId && !!getTerminalLaunchOptions(terminal.type, terminal.sessionId, terminal.autoApprove);
+    let validatedSessionId: string | undefined = terminal.sessionId;
+    let wasResumeAttempt = !!terminal.sessionId && !!getTerminalLaunchOptions(terminal.type, terminal.sessionId, terminal.autoApprove);
     let hasRespawned = false;
     let inputDisposable: { dispose(): void } | null = null;
     let resizeDisposable: { dispose(): void } | null = null;
@@ -502,7 +503,31 @@ export function TerminalTile({
         });
     };
 
-    spawnPty(terminal.sessionId);
+    // Validate session before attempting resume: if the CLI's session file
+    // was cleaned up (e.g. after force-kill during app update), start fresh
+    // immediately instead of launching with a stale --resume that will fail.
+    if (terminal.sessionId && (terminal.type === "claude" || terminal.type === "codex")) {
+      window.termcanvas.session
+        .validate(terminal.type, terminal.sessionId, worktreePath)
+        .then((valid) => {
+          if (valid) {
+            spawnPty(terminal.sessionId);
+          } else {
+            console.log(`[TermCanvas] Session ${terminal.sessionId} no longer valid, starting fresh`);
+            validatedSessionId = undefined;
+            wasResumeAttempt = false;
+            updateTerminalSessionId(projectId, worktreeId, terminal.id, undefined);
+            xterm.write("\x1b[33m[Previous session no longer available, starting fresh…]\x1b[0m\r\n");
+            spawnPty(undefined);
+          }
+        })
+        .catch(() => {
+          // Validation failed (IPC error), attempt resume anyway
+          spawnPty(terminal.sessionId);
+        });
+    } else {
+      spawnPty(terminal.sessionId);
+    }
 
     let currentStatus: string = "running";
     let waitingTimer: ReturnType<typeof setTimeout> | null = null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -231,6 +231,7 @@ export interface TermCanvasAPI {
     getKimiLatest: (cwd: string) => Promise<string | null>;
     watch: (type: string, sessionId: string, cwd: string) => Promise<{ ok: boolean; reason?: string }>;
     unwatch: (sessionId: string) => Promise<void>;
+    validate: (type: string, sessionId: string, cwd: string) => Promise<boolean>;
     onTurnComplete: (callback: (sessionId: string) => void) => () => void;
   };
   project: {


### PR DESCRIPTION
## Summary
- **Session ID persistence**: `updateTerminalSessionId` now calls `markDirty()`, triggering auto-save so session IDs survive force-kill scenarios. Previously, session IDs were only persisted on explicit save or graceful quit.
- **Pre-launch validation**: New `session:validate` IPC checks whether a session's JSONL file still exists on disk before attempting `--resume`. If the file is gone (e.g. cleaned up by Claude CLI during update), the terminal starts fresh immediately with a clear message instead of failing with "No conversation found".
- **Cleaner UX**: Instead of the confusing error → exit → respawn cycle, users see "[Previous session no longer available, starting fresh...]" upfront.

## Test plan
- [ ] Start Claude session, capture session ID, force-quit app (kill process), relaunch — session should resume
- [ ] Delete a Claude session JSONL file manually, relaunch — should see "starting fresh" message, no error
- [ ] Normal quit + relaunch — sessions resume as before
- [ ] Codex session validation path works similarly