### PR TITLE
fix #21: attribute Hydra usage to spawning project

### DIFF
--- a/electron/insights-engine.ts
+++ b/electron/insights-engine.ts
@@ -349,7 +349,7 @@ function extractClaudeSession(file: SessionFileInfo): SessionInfo | null {
   const rel = path.relative(projectsDir, file.filePath);
   const topDir = rel.split(path.sep)[0];
   if (topDir && topDir.startsWith("-")) {
-    const cleaned = topDir.replace(/--worktrees-.*$/, "");
+    const cleaned = topDir.replace(/(--worktrees-|-.worktrees-).*$/, "");
     projectPath = cleaned.replace(/-/g, "/");
   }
 

--- a/electron/usage-collector.ts
+++ b/electron/usage-collector.ts
@@ -261,8 +261,10 @@ export function parseClaudeSession(
   const rel = path.relative(projectsDir, filePath);
   const topDir = rel.split(path.sep)[0];
   if (topDir && topDir.startsWith("-")) {
-    // Strip worktree suffix: -Users-zzzz-foo--worktrees-hydra-abc → -Users-zzzz-foo
-    const cleaned = topDir.replace(/--worktrees-.*$/, "");
+    // Strip worktree suffix so usage is attributed to the parent project:
+    //   --worktrees-*  → EnterWorktree adjacent dirs (e.g. repo--worktrees/branch)
+    //   -.worktrees-*  → Hydra .worktrees subdirs   (e.g. repo/.worktrees/hydra-id)
+    const cleaned = topDir.replace(/(--worktrees-|-.worktrees-).*$/, "");
     projectPath = cleaned.replace(/-/g, "/");
   }
 

--- a/tests/usage-collector.test.ts
+++ b/tests/usage-collector.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 
 import {
   computeCost,
+  parseClaudeSession,
   parseCodexSession,
   shouldReuseTimedCache,
   shouldReuseUsageSummary,
@@ -187,4 +188,95 @@ test("computeCost applies codex pricing correctly", () => {
                  + (5_000 / 1e6) * 6.00
                  + (80_000 / 1e6) * 0.375;
   assert.equal(Math.abs(cost - expected) < 1e-10, true);
+});
+
+// ── Hydra worktree attribution tests ────────────────────────────────────
+
+function writeClaudeJsonl(dirName: string, lines: object[]): { filePath: string; dir: string } {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const dir = path.join(projectsDir, dirName);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, "test-session.jsonl");
+  fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return { filePath, dir };
+}
+
+const sampleClaudeMessage = [
+  {
+    timestamp: "2026-03-20T10:00:00Z",
+    message: {
+      id: "msg_001",
+      model: "claude-sonnet-4-6",
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  },
+];
+
+test("parseClaudeSession maps Hydra .worktrees path to parent project", () => {
+  // Hydra creates worktrees at repo/.worktrees/hydra-id
+  // Claude may encode .worktrees as -.worktrees- (keeping the dot)
+  const { filePath, dir } = writeClaudeJsonl(
+    "-tmp-test-proj-.worktrees-hydra-abc123",
+    sampleClaudeMessage,
+  );
+
+  try {
+    const { records, projectPath } = parseClaudeSession(
+      filePath,
+      "2026-03-20T00:00:00",
+      "2026-03-21T00:00:00",
+    );
+
+    assert.equal(projectPath, "/tmp/test/proj");
+    assert.equal(records.length, 1);
+    assert.equal(records[0].projectPath, "/tmp/test/proj");
+  } finally {
+    fs.rmSync(dir, { recursive: true });
+  }
+});
+
+test("parseClaudeSession maps --worktrees path to parent project", () => {
+  // Claude may also encode .worktrees as --worktrees- (stripping the dot)
+  const { filePath, dir } = writeClaudeJsonl(
+    "-tmp-test-proj--worktrees-feature-branch",
+    sampleClaudeMessage,
+  );
+
+  try {
+    const { records, projectPath } = parseClaudeSession(
+      filePath,
+      "2026-03-20T00:00:00",
+      "2026-03-21T00:00:00",
+    );
+
+    assert.equal(projectPath, "/tmp/test/proj");
+    assert.equal(records.length, 1);
+    assert.equal(records[0].projectPath, "/tmp/test/proj");
+  } finally {
+    fs.rmSync(dir, { recursive: true });
+  }
+});
+
+test("parseClaudeSession preserves normal project path (no worktree)", () => {
+  const { filePath, dir } = writeClaudeJsonl(
+    "-tmp-test-proj",
+    sampleClaudeMessage,
+  );
+
+  try {
+    const { projectPath } = parseClaudeSession(
+      filePath,
+      "2026-03-20T00:00:00",
+      "2026-03-21T00:00:00",
+    );
+
+    assert.equal(projectPath, "/tmp/test/proj");
+  } finally {
+    fs.rmSync(dir, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Summary
- Hydra creates worktrees at `repo/.worktrees/hydra-id`, which Claude encodes as either `-.worktrees-` or `--worktrees-` in `~/.claude/projects/`
- The existing regex only matched `--worktrees-`, missing the `-.worktrees-` pattern
- Updated regex in both `usage-collector.ts` and `insights-engine.ts` to handle both encodings
- Added 3 tests verifying Hydra worktree, EnterWorktree, and normal project path attribution

Fixes #21
Supersedes #75

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 10 usage-collector tests pass (3 new)
- [ ] Spawn Hydra agents from a project, verify usage appears under the parent project
- [ ] Verify no separate "Hydra" entry in stats panel