### PR TITLE
fix #12: fix terminal viewport jump during streaming

### DIFF
--- a/docs/bugs/scroll-pinning-evolution.md
+++ b/docs/bugs/scroll-pinning-evolution.md
@@ -70,3 +70,35 @@ synchronous, user-initiated, and never fired by programmatic scrolls.
 
 These edge cases don't affect the primary use case (mouse wheel scroll-up
 during Claude/Codex streaming).
+
+### Attempt 5: `909dd28` — rely entirely on xterm v6 isUserScrolling
+
+- Removed all manual scroll management. Added an `onScroll` handler to
+  detect when `isUserScrolling` gets stuck at `viewportY=0` (ydisp
+  decremented to 0 by buffer trimming) and snap to bottom.
+- **Failed because**: the fix only triggered at the extreme (ydisp=0).
+  The viewport DRIFT itself was the real problem — as ydisp decremented
+  from the user's position toward 0, the user saw their content scroll
+  away. The snap-to-bottom at 0 was just the final symptom.
+
+### Attempt 6 (current fix): monkey-patch BufferService.scroll()
+
+- **Root cause**: `BufferService.scroll()` decrements `buffer.ydisp` by 1
+  on every buffer trim when `isUserScrolling` is true. This is intended
+  to keep the viewport pointed at the same content (as lines shift in the
+  circular buffer), but it causes the viewport to drift toward ydisp=0
+  during extended streaming.
+- **Fix**: Monkey-patch `_bufferService.scroll()` to freeze `buffer.ydisp`
+  (via a temporary `Object.defineProperty` accessor) during the scroll()
+  call when `isUserScrolling && buffer.lines.isFull`. The trim decrement
+  is silently ignored. The viewport stays at its absolute position while
+  content shifts beneath it (natural for a circular buffer).
+- **Why this works**: The freeze only applies during the synchronous
+  execution of `scroll()`. `scrollLines()` (user-initiated scrolling) is
+  a separate method and is not affected. `onScroll` events fire with the
+  frozen (stable) ydisp, so the Viewport never updates to a drifting
+  position. When the user scrolls to the bottom, `scrollLines()` resets
+  `isUserScrolling` to false, and normal auto-follow resumes.
+- **Trade-off**: The content at the viewport's position shifts as old lines
+  are evicted — the user sees newer content "flow through" their viewport.
+  This is acceptable since the old content is gone regardless.

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -301,22 +301,64 @@ export function TerminalTile({
     // ybase during writes.  We must NOT call scrollToBottom() in the
     // write callback because that would override xterm's protection.
 
-    // Scroll-pinning fix: xterm v6's isUserScrolling flag gets stuck when
-    // the viewport is pushed to the very top (ydisp=0) during buffer trimming.
-    // Once stuck, ybase keeps growing while the viewport stays at 0 — the user
-    // sees stale/evicted content at the top and can't get back to live output.
-    // Fix: detect this state and snap back to the bottom.
+    // Scroll-pinning fix: During buffer trimming (scrollback full), xterm's
+    // BufferService.scroll() decrements ydisp by 1 for each trimmed line
+    // while isUserScrolling is true.  This causes the viewport to drift
+    // toward the top — the user sees their content scroll away and
+    // eventually the viewport reaches ydisp=0 (stuck at top).
+    //
+    // Fix: monkey-patch BufferService.scroll() to lock ydisp at its
+    // pre-trim value when isUserScrolling is true.  We temporarily replace
+    // buffer.ydisp with a frozen property descriptor so that the decrement
+    // inside scroll() is silently ignored.  The onScroll event then fires
+    // with the stable (un-decremented) ydisp, so the Viewport never drifts.
+    //
+    // scrollLines() is NOT affected — it is a separate method that handles
+    // user-initiated scrolling and correctly sets isUserScrolling.
+    //
+    // Why this is safe:
+    // - ydisp stays <= ybase (ybase is unchanged during trim)
+    // - scrollLines() bypasses the lock (only scroll() is patched)
+    // - isUserScrolling resets to false when the user scrolls to bottom
+    // - onScroll events fire with the correct (stable) ydisp value
     const _bufSvc = (xterm as any)._core?._bufferService;
-    xterm.onScroll(() => {
-      if (
-        _bufSvc?.isUserScrolling &&
-        xterm.buffer.active.viewportY === 0 &&
-        xterm.buffer.active.baseY > xterm.rows
-      ) {
-        _bufSvc.isUserScrolling = false;
-        xterm.scrollToBottom();
-      }
-    });
+    if (_bufSvc) {
+      const _origScroll = _bufSvc.scroll.bind(_bufSvc);
+      _bufSvc.scroll = function (this: any, eraseAttr: any, isWrapped?: boolean) {
+        // When the user is NOT scrolling, let xterm handle everything normally
+        if (!this.isUserScrolling) {
+          return _origScroll(eraseAttr, isWrapped);
+        }
+
+        const buf = this.buffer;
+
+        // Only intervene when the buffer is full (trim will happen).
+        // Before the buffer is full, ydisp is not decremented.
+        if (!buf.lines.isFull) {
+          return _origScroll(eraseAttr, isWrapped);
+        }
+
+        // Freeze buffer.ydisp during scroll() so the trim decrement
+        // (buffer.ydisp = Math.max(ydisp - 1, 0)) is silently ignored.
+        // The onScroll event fires inside scroll() and reads ydisp via
+        // this getter, so all downstream handlers (Viewport, etc.) see
+        // the stable value — no drift.
+        const frozenYdisp = buf.ydisp;
+        Object.defineProperty(buf, 'ydisp', {
+          get: () => frozenYdisp,
+          set: () => {},  // swallow writes
+          configurable: true,
+        });
+
+        try {
+          _origScroll(eraseAttr, isWrapped);
+        } finally {
+          // Restore plain data property with the frozen (unchanged) value
+          delete buf.ydisp;
+          buf.ydisp = frozenYdisp;
+        }
+      };
+    }
 
     // GPU-accelerated rendering via context pool (max 8 active contexts)
     acquireWebGL(terminal.id, xterm);


### PR DESCRIPTION
## Summary
- Fix intermittent viewport jump to top when scrolling up during active Claude CLI output
- Root cause: `BufferService.scroll()` decrements `buffer.ydisp` by 1 for each trimmed line during buffer trimming while `isUserScrolling` is true, causing the viewport to drift toward `ydisp=0` (stuck at top)
- Approach: Monkey-patch `BufferService.scroll()` to freeze `buffer.ydisp` via a temporary property descriptor during buffer trimming when `isUserScrolling` is true. The freeze blocks the trim decrement while letting `onScroll` events fire with the stable ydisp value, so the Viewport stays at the user's scroll position
- `scrollLines()` (user-initiated scrolling) is unaffected — it's a separate code path
- Prior attempts history: see `docs/bugs/scroll-pinning-evolution.md`

## Test plan
- [ ] During Claude streaming, scroll up — viewport stays at user's position
- [ ] When not scrolling, new output auto-scrolls to bottom as normal
- [ ] No viewport lock-to-bottom side effect
- [ ] Scrolling back to bottom during streaming resumes auto-follow
- [ ] No scroll jank or flickering during rapid output