### PR TITLE
Fix main-process updater crash on broken pipe in dev mode

### DIFF
--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -4,6 +4,10 @@ import fs from "fs";
 import path from "path";
 import { sendToWindow } from "./window-events";
 import { MacCustomUpdater } from "./mac-updater";
+import {
+  createSafeUpdaterLogger,
+  shouldScheduleAutoUpdateChecks,
+} from "./updater-helpers";
 
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const IS_MAC = process.platform === "darwin";
@@ -18,6 +22,10 @@ export function setupAutoUpdater(window: BrowserWindow): void {
 
   // Shared IPC: version query
   ipcMain.handle("updater:get-version", () => app.getVersion());
+
+  if (!shouldScheduleAutoUpdateChecks(app.isPackaged)) {
+    return;
+  }
 
   // Initial check after short delay, then periodic
   setTimeout(() => checkFn(), 5000);
@@ -57,6 +65,7 @@ function setupMacUpdater(window: BrowserWindow): () => void {
 // ---------------------------------------------------------------------------
 
 function setupElectronUpdater(window: BrowserWindow): () => void {
+  autoUpdater.logger = createSafeUpdaterLogger(console);
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 

--- a/electron/updater-helpers.ts
+++ b/electron/updater-helpers.ts
@@ -1,0 +1,54 @@
+export interface UpdaterLoggerLike {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+}
+
+function noop(): void {}
+
+function getMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === "string" ? message : "";
+  }
+  return "";
+}
+
+export function isBrokenPipeError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === "EPIPE") return true;
+  }
+  return /broken pipe/i.test(getMessage(error));
+}
+
+function wrapLogMethod(
+  method: ((...args: unknown[]) => void) | undefined,
+  receiver: unknown,
+): (...args: unknown[]) => void {
+  const target = method ?? noop;
+  return (...args: unknown[]) => {
+    try {
+      Reflect.apply(target, receiver, args);
+    } catch (error) {
+      if (!isBrokenPipeError(error)) throw error;
+    }
+  };
+}
+
+export function createSafeUpdaterLogger(
+  base: Partial<UpdaterLoggerLike> = console,
+): UpdaterLoggerLike {
+  return {
+    info: wrapLogMethod(base.info, base),
+    warn: wrapLogMethod(base.warn, base),
+    error: wrapLogMethod(base.error, base),
+    ...(base.debug ? { debug: wrapLogMethod(base.debug, base) } : {}),
+  };
+}
+
+export function shouldScheduleAutoUpdateChecks(isPackaged: boolean): boolean {
+  return isPackaged;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:icons": "python3 scripts/generate-icons.py",
     "postinstall": "electron-builder install-app-deps",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts"
+    "test": "node --experimental-strip-types --test tests/pty-launch.test.ts tests/window-events.test.ts tests/diff-card-expansion.test.ts tests/session-watcher.test.ts tests/process-detector.test.ts tests/preferences-store.test.ts tests/cli-launchers.test.ts tests/insights-engine.test.ts tests/usage-collector.test.ts tests/terminal-state.test.ts tests/terminal-adapters.test.ts tests/composer-submit.test.ts tests/composer-input-behavior.test.ts tests/composer-store.test.ts tests/shortcut-behavior.test.ts tests/auto-updater.test.ts"
   },
   "keywords": [
     "terminal",

--- a/tests/auto-updater.test.ts
+++ b/tests/auto-updater.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createSafeUpdaterLogger,
+  isBrokenPipeError,
+  shouldScheduleAutoUpdateChecks,
+} from "../electron/updater-helpers.ts";
+
+test("isBrokenPipeError detects EPIPE by code", () => {
+  assert.equal(isBrokenPipeError({ code: "EPIPE" }), true);
+  assert.equal(isBrokenPipeError({ code: "ENOENT" }), false);
+});
+
+test("isBrokenPipeError detects broken pipe by message", () => {
+  assert.equal(isBrokenPipeError(new Error("broken pipe")), true);
+  assert.equal(isBrokenPipeError(new Error("something else")), false);
+});
+
+test("createSafeUpdaterLogger swallows broken pipe errors", () => {
+  const logger = createSafeUpdaterLogger({
+    info: () => {
+      const error = new Error("broken pipe");
+      Object.assign(error, { code: "EPIPE" });
+      throw error;
+    },
+    warn: () => {},
+    error: () => {},
+  });
+
+  assert.doesNotThrow(() => logger.info("Checking for update"));
+});
+
+test("createSafeUpdaterLogger preserves non-EPIPE failures", () => {
+  const logger = createSafeUpdaterLogger({
+    info: () => {
+      throw new Error("permission denied");
+    },
+    warn: () => {},
+    error: () => {},
+  });
+
+  assert.throws(() => logger.info("Checking for update"), /permission denied/);
+});
+
+test("shouldScheduleAutoUpdateChecks only enables packaged apps", () => {
+  assert.equal(shouldScheduleAutoUpdateChecks(true), true);
+  assert.equal(shouldScheduleAutoUpdateChecks(false), false);
+});


### PR DESCRIPTION
## Summary
- disable scheduled auto-update checks in dev mode
- wrap `electron-updater` logging with an `EPIPE`-safe logger
- add regression coverage for broken-pipe handling and dev-mode scheduling

## Why
On Windows dev runs, `electron-updater` can log through a broken output pipe and throw `EPIPE`, which crashes the Electron main process and leaves the app partially unusable behind the system error dialog.

## Validation
- `node --experimental-strip-types --test tests/auto-updater.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit`