### PR TITLE
refactor(hydra): Workbench/Dispatch redesign — remove DAG, rename core abstractions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,23 +28,24 @@
 
 ## Hydra Orchestration Toolkit
 
-Hydra is an orchestration toolkit. Lead holds system-level context and
-dispatches dev/reviewer into isolated context windows. `result.json` is the
-only completion evidence.
+Hydra is Lead's persistent workbench for multi-role orchestration. Lead holds
+system-level context, dispatches roles into isolated terminals, and reads every
+report to decide next steps. Hydra manages terminal lifecycle (retry, timeout,
+session capture). `result.json` is the only completion evidence.
 
 ### Lead
 
 Lead is the human's primary terminal. It holds the system picture (architecture,
-module boundaries, dependencies) and dispatches dev/reviewer. Lead always reads
-every report.md to keep its system understanding current. Lead never writes
-code. For large changes (refactors, new modules, architectural shifts), Lead
-uses subagents to research approaches before dispatching.
+module boundaries, dependencies) and dispatches roles. Lead always reads every
+report.md to keep its system understanding current. Lead never writes code. For
+large changes (refactors, new modules, architectural shifts), Lead uses
+subagents to research approaches before dispatching.
 
 See `hydra/src/roles/builtin/lead.md` for the full role definition.
 
 ### Design rationale
 - **SWF decider pattern.** `hydra watch` is `PollForDecisionTask`; `lead_terminal_id` enforces single-decider semantics.
-- **Parallel-first.** `dispatch` + `depends_on` + worktree + `merge` are first-class.
+- **Parallel-first.** `dispatch` + worktree + `merge` are first-class. Lead sequences dispatches manually and passes context via `--context-ref`.
 - **Typed result contract.** Schema-validated `result.json` (`outcome: completed | stuck | error`).
 - **Lead intervention points.** `hydra reset --feedback` for mid-flight course correction.
 
@@ -54,15 +55,15 @@ Core rules:
 - Do not add silent fallbacks or swallowed errors.
 - An assignment run is only complete when `result.json` exists and passes schema validation.
 
-Workflow patterns:
-1. Do the task directly when it is simple, local, or clearly faster without workflow overhead.
+Workbench patterns:
+1. Do the task directly when it is simple, local, or clearly faster without orchestration overhead.
 2. Use Hydra for ambiguous, risky, parallel, or multi-step work:
    ```
    hydra init --intent "<task>" --repo .
-   hydra dispatch --workflow W --node <id> --role <role> --intent "<desc>" --repo .
-   hydra watch --workflow W --repo .
+   hydra dispatch --workbench W --dispatch <id> --role <role> --intent "<desc>" --repo .
+   hydra watch --workbench W --repo .
    # → DecisionPoint returned, decide next step
-   hydra complete --workflow W --repo .
+   hydra complete --workbench W --repo .
    ```
 3. Use a direct isolated dev when only a single task is needed:
    `hydra spawn --task "<specific task>" --repo . [--worktree .]`
@@ -71,26 +72,26 @@ Agent launch rule:
 - When dispatching Claude/Codex through TermCanvas CLI, start a fresh agent terminal with `termcanvas terminal create --prompt "..."`
 - Do not use `termcanvas terminal input` for task dispatch; it is not a supported automation path
 
-Workflow control:
-- After dispatching nodes, always call `hydra watch`. It returns at decision points.
-1. Watch until decision point: `hydra watch --workflow <workflowId> --repo .`
-2. Inspect structured state: `hydra status --workflow <workflowId> --repo .`
-3. Reset a node for rework: `hydra reset --workflow W --node N --feedback "..." --repo .`
-4. Approve a node's output: `hydra approve --workflow W --node N --repo .`
-5. Merge parallel branches: `hydra merge --workflow W --nodes A,B --repo .`
-6. View event log: `hydra ledger --workflow <workflowId> --repo .`
-7. Clean up: `hydra cleanup --workflow <workflowId> --repo .`
+Workbench control:
+- After dispatching, always call `hydra watch`. It returns at decision points.
+1. Watch until decision point: `hydra watch --workbench <workbenchId> --repo .`
+2. Inspect structured state: `hydra status --workbench <workbenchId> --repo .`
+3. Reset a dispatch for rework: `hydra reset --workbench W --dispatch N --feedback "..." --repo .`
+4. Approve a dispatch's output: `hydra approve --workbench W --dispatch N --repo .`
+5. Merge parallel branches: `hydra merge --workbench W --dispatches A,B --repo .`
+6. View event log: `hydra ledger --workbench <workbenchId> --repo .`
+7. Clean up: `hydra cleanup --workbench <workbenchId> --repo .`
 
 Telemetry polling:
 1. Treat `hydra watch` as the main polling loop; do not infer progress from terminal prose alone.
 2. Before deciding wait / retry / takeover, query:
-   - `termcanvas telemetry get --workflow <workflowId> --repo .`
+   - `termcanvas telemetry get --workbench <workbenchId> --repo .`
    - `termcanvas telemetry get --terminal <terminalId>`
    - `termcanvas telemetry events --terminal <terminalId> --limit 20`
 3. Trust `derived_status` and `task_status` as the primary decision signals.
 
 `result.json` must contain (slim, schema_version `hydra/result/v0.1`):
-- `schema_version`, `workflow_id`, `assignment_id`, `run_id` (passthrough IDs)
+- `schema_version`, `workbench_id`, `assignment_id`, `run_id` (passthrough IDs)
 - `outcome` (completed/stuck/error — Hydra routes on this)
 - `report_file` (path to a `report.md` written alongside `result.json`)
 

--- a/hydra/scripts/e2e-acceptance.ts
+++ b/hydra/scripts/e2e-acceptance.ts
@@ -5,16 +5,16 @@ import { cleanup } from "../src/cleanup.ts";
 import { AssignmentManager } from "../src/assignment/manager.ts";
 import { terminalDestroy, terminalStatus } from "../src/termcanvas.ts";
 import {
-  initWorkflow,
-  dispatchNode,
-  redispatchNode,
+  initWorkbench,
+  dispatch,
+  redispatch,
   watchUntilDecision,
-  approveNode,
-  resetNode,
-  completeWorkflow,
-  getWorkflowStatus,
+  approveDispatch,
+  resetDispatch,
+  completeWorkbench,
+  getWorkbenchStatus,
 } from "../src/workflow-lead.ts";
-import { loadWorkflow } from "../src/workflow-store.ts";
+import { loadWorkbench } from "../src/workflow-store.ts";
 import { RESULT_SCHEMA_VERSION } from "../src/protocol.ts";
 import { getReportFilePath } from "../src/artifacts.ts";
 import type { AssignmentRecord } from "../src/assignment/types.ts";
@@ -26,7 +26,7 @@ interface Args {
 
 interface StageRecord {
   stage: string;
-  nodeId: string;
+  dispatchId: string;
   assignmentId: string;
   role: string;
   terminalId: string | null;
@@ -58,13 +58,13 @@ function latestRun(assignment: AssignmentRecord): AssignmentRecord["runs"][numbe
 
 function writeResult(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
   assignmentId: string,
   run: AssignmentRecord["runs"][number],
   summary: string,
   outcome: "completed" | "stuck" | "error",
 ): void {
-  const reportFile = getReportFilePath(repoPath, workflowId, assignmentId, run.id);
+  const reportFile = getReportFilePath(repoPath, workbenchId, assignmentId, run.id);
   fs.mkdirSync(path.dirname(reportFile), { recursive: true });
   fs.writeFileSync(
     reportFile,
@@ -91,7 +91,7 @@ function writeResult(
     run.result_file,
     JSON.stringify({
       schema_version: RESULT_SCHEMA_VERSION,
-      workflow_id: workflowId,
+      workbench_id: workbenchId,
       assignment_id: assignmentId,
       run_id: run.id,
       outcome,
@@ -102,7 +102,7 @@ function writeResult(
 }
 
 function captureStage(
-  nodeId: string,
+  dispatchId: string,
   assignmentId: string,
   role: string,
   terminalId: string | null,
@@ -112,23 +112,23 @@ function captureStage(
   if (terminalId) {
     try { status = terminalStatus(terminalId).status; } catch { status = "missing"; }
   }
-  return { stage: role, nodeId, assignmentId, role, terminalId, terminalStatus: status, summary };
+  return { stage: role, dispatchId, assignmentId, role, terminalId, terminalStatus: status, summary };
 }
 
-function renderReport(args: Args, workflowId: string, records: StageRecord[]): string {
+function renderReport(args: Args, workbenchId: string, records: StageRecord[]): string {
   return [
     "# Hydra Acceptance Report",
     "",
     `- Date: ${new Date().toISOString()}`,
     `- Repo: ${args.repo}`,
-    `- Workflow ID: ${workflowId}`,
+    `- Workbench ID: ${workbenchId}`,
     `- Mode: Lead-driven dispatch + deterministic result injection`,
     "",
     "## Observed Stages",
     "",
-    "| Stage | Node ID | Assignment ID | Terminal ID | Summary |",
-    "|-------|---------|---------------|-------------|---------|",
-    ...records.map((r) => `| ${r.stage} | ${r.nodeId} | ${r.assignmentId} | ${r.terminalId ?? "-"} | ${r.summary} |`),
+    "| Stage | Dispatch ID | Assignment ID | Terminal ID | Summary |",
+    "|-------|-------------|---------------|-------------|---------|",
+    ...records.map((r) => `| ${r.stage} | ${r.dispatchId} | ${r.assignmentId} | ${r.terminalId ?? "-"} | ${r.summary} |`),
     "",
     "## Outcome",
     "",
@@ -140,98 +140,98 @@ function renderReport(args: Args, workflowId: string, records: StageRecord[]): s
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const records: StageRecord[] = [];
-  let workflowId: string | null = null;
+  let workbenchId: string | null = null;
 
   try {
-    // 1. Init workflow
-    const init = await initWorkflow({
+    // 1. Init workbench
+    const init = await initWorkbench({
       intent: "Hydra acceptance harness: exercise the Lead-driven control plane.",
       repoPath: args.repo,
       worktreePath: args.repo,
     });
-    workflowId = init.workflow_id;
+    workbenchId = init.workbench_id;
 
-    // 2. Dispatch the first node (cli/model come from the role file's terminals[0])
-    const researcher = await dispatchNode({
-      repoPath: args.repo, workflowId, nodeId: "researcher",
+    // 2. Dispatch the first dispatch (cli/model come from the role file's terminals[0])
+    const researcher = await dispatch({
+      repoPath: args.repo, workbenchId, dispatchId: "researcher",
       role: "dev", intent: "Produce acceptance research brief.",
     });
     assert.equal(researcher.status, "dispatched");
 
     // Write researcher result
-    const manager = new AssignmentManager(args.repo, workflowId);
-    let assignment = manager.load(researcher.assignment_id)!;
+    const manager = new AssignmentManager(args.repo, workbenchId);
+    let assignment = manager.load(researcher.dispatch_id)!;
     let run = latestRun(assignment);
-    writeResult(args.repo, workflowId, assignment.id, run, "Research brief produced.", "completed");
+    writeResult(args.repo, workbenchId, assignment.id, run, "Research brief produced.", "completed");
     records.push(captureStage("researcher", assignment.id, "dev", researcher.terminal_id ?? null, "Research brief produced."));
 
     // 3. Watch → researcher completes
-    let decision = await watchUntilDecision({ repoPath: args.repo, workflowId, timeoutMs: 10_000 });
-    assert.equal(decision.type, "node_completed");
+    let decision = await watchUntilDecision({ repoPath: args.repo, workbenchId, timeoutMs: 10_000 });
+    assert.equal(decision.type, "dispatch_completed");
 
     // 4. Approve researcher
-    await approveNode({ repoPath: args.repo, workflowId, nodeId: "researcher" });
+    await approveDispatch({ repoPath: args.repo, workbenchId, dispatchId: "researcher" });
 
     // 5. Dispatch dev
-    const dev = await dispatchNode({
-      repoPath: args.repo, workflowId, nodeId: "dev",
-      role: "dev", intent: "Implement first pass.", dependsOn: ["researcher"],
+    const dev = await dispatch({
+      repoPath: args.repo, workbenchId, dispatchId: "dev",
+      role: "dev", intent: "Implement first pass.",
     });
     assert.equal(dev.status, "dispatched");
 
-    assignment = manager.load(dev.assignment_id)!;
+    assignment = manager.load(dev.dispatch_id)!;
     run = latestRun(assignment);
-    writeResult(args.repo, workflowId, assignment.id, run, "First implementation pass done.", "completed");
+    writeResult(args.repo, workbenchId, assignment.id, run, "First implementation pass done.", "completed");
     records.push(captureStage("dev", assignment.id, "dev", dev.terminal_id ?? null, "First pass done."));
 
-    decision = await watchUntilDecision({ repoPath: args.repo, workflowId, timeoutMs: 10_000 });
-    assert.equal(decision.type, "node_completed");
+    decision = await watchUntilDecision({ repoPath: args.repo, workbenchId, timeoutMs: 10_000 });
+    assert.equal(decision.type, "dispatch_completed");
 
     // 6. Dispatch reviewer (codex variant — exercises a cross-CLI workflow)
-    const reviewer = await dispatchNode({
-      repoPath: args.repo, workflowId, nodeId: "review",
-      role: "reviewer", intent: "Review implementation.", dependsOn: ["dev"],
+    const reviewer = await dispatch({
+      repoPath: args.repo, workbenchId, dispatchId: "review",
+      role: "reviewer", intent: "Review implementation.",
     });
     assert.equal(reviewer.status, "dispatched");
 
-    assignment = manager.load(reviewer.assignment_id)!;
+    assignment = manager.load(reviewer.dispatch_id)!;
     run = latestRun(assignment);
-    writeResult(args.repo, workflowId, assignment.id, run, "Found issues, needs rework.", "completed");
+    writeResult(args.repo, workbenchId, assignment.id, run, "Found issues, needs rework.", "completed");
     records.push(captureStage("review", assignment.id, "reviewer", reviewer.terminal_id ?? null, "Found issues."));
 
-    decision = await watchUntilDecision({ repoPath: args.repo, workflowId, timeoutMs: 10_000 });
-    assert.equal(decision.type, "node_completed");
-    assert.equal(decision.completed?.result.outcome, "completed");
+    decision = await watchUntilDecision({ repoPath: args.repo, workbenchId, timeoutMs: 10_000 });
+    assert.equal(decision.type, "dispatch_completed");
+    assert.equal(decision.completed?.outcome, "completed");
 
     // 7. Reset dev based on reviewer feedback
-    await resetNode({ repoPath: args.repo, workflowId, nodeId: "dev", feedback: "Fix the issues the reviewer found." });
+    await resetDispatch({ repoPath: args.repo, workbenchId, dispatchId: "dev", feedback: "Fix the issues the reviewer found." });
 
     // 8. Re-dispatch the same dev node (reset made it eligible)
-    const dev2 = await redispatchNode({
-      repoPath: args.repo, workflowId, nodeId: "dev", intent: "Fix reviewer findings.",
+    const dev2 = await redispatch({
+      repoPath: args.repo, workbenchId, dispatchId: "dev", intent: "Fix reviewer findings.",
     });
     assert.equal(dev2.status, "dispatched");
 
-    assignment = manager.load(dev2.assignment_id)!;
+    assignment = manager.load(dev2.dispatch_id)!;
     run = latestRun(assignment);
-    writeResult(args.repo, workflowId, assignment.id, run, "Fixed all reviewer findings.", "completed");
+    writeResult(args.repo, workbenchId, assignment.id, run, "Fixed all reviewer findings.", "completed");
     records.push(captureStage("dev", assignment.id, "dev", dev2.terminal_id ?? null, "Fixed findings."));
 
-    decision = await watchUntilDecision({ repoPath: args.repo, workflowId, timeoutMs: 10_000 });
-    assert.equal(decision.type, "node_completed");
+    decision = await watchUntilDecision({ repoPath: args.repo, workbenchId, timeoutMs: 10_000 });
+    assert.equal(decision.type, "dispatch_completed");
 
     // 9. Complete
-    await completeWorkflow({ repoPath: args.repo, workflowId, summary: "Acceptance test passed." });
-    const final = getWorkflowStatus(args.repo, workflowId);
-    assert.equal(final.workflow.status, "completed");
+    await completeWorkbench({ repoPath: args.repo, workbenchId, summary: "Acceptance test passed." });
+    const final = getWorkbenchStatus(args.repo, workbenchId);
+    assert.equal(final.workbench.status, "completed");
 
     // Write report
     fs.mkdirSync(path.dirname(args.report), { recursive: true });
-    fs.writeFileSync(args.report, renderReport(args, workflowId, records), "utf-8");
-    console.log(JSON.stringify({ workflowId, report: args.report, stages: records, finalStatus: "completed" }, null, 2));
+    fs.writeFileSync(args.report, renderReport(args, workbenchId, records), "utf-8");
+    console.log(JSON.stringify({ workbenchId, report: args.report, stages: records, finalStatus: "completed" }, null, 2));
   } finally {
-    if (workflowId) {
-      try { await cleanup(["--workflow", workflowId, "--repo", args.repo, "--force"]); } catch {}
+    if (workbenchId) {
+      try { await cleanup(["--workbench", workbenchId, "--repo", args.repo, "--force"]); } catch {}
     }
   }
 }

--- a/hydra/src/artifacts.ts
+++ b/hydra/src/artifacts.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
-  getNodeFeedbackFile,
-  getNodeIntentFile,
+  getDispatchFeedbackFile,
+  getDispatchIntentFile,
   getRunReportFile,
-  getWorkflowIntentFile,
-  getWorkflowSummaryFile,
+  getWorkbenchIntentFile,
+  getWorkbenchSummaryFile,
 } from "./layout.ts";
 
 // Helpers for content files (markdown).
@@ -25,18 +25,18 @@ function readFileIfExists(filePath: string): string | null {
   return fs.readFileSync(filePath, "utf-8");
 }
 
-// --- Workflow-level intent ---
+// --- Workbench-level intent ---
 
-export function writeWorkflowIntent(
+export function writeWorkbenchIntent(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
   intent: string,
 ): string {
-  const filePath = getWorkflowIntentFile(repoPath, workflowId);
+  const filePath = getWorkbenchIntentFile(repoPath, workbenchId);
   writeFileEnsuringDir(filePath, [
-    "# Workflow Intent",
+    "# Workbench Intent",
     "",
-    "This file is the canonical statement of what the workflow is trying to achieve.",
+    "This file is the canonical statement of what the workbench is trying to achieve.",
     "Read it before making downstream decisions.",
     "",
     intent,
@@ -45,20 +45,20 @@ export function writeWorkflowIntent(
   return filePath;
 }
 
-export function readWorkflowIntent(filePath: string): string | null {
+export function readWorkbenchIntent(filePath: string): string | null {
   return readFileIfExists(filePath);
 }
 
-// --- Workflow-level summary (final) ---
+// --- Workbench-level summary (final) ---
 
-export function writeWorkflowSummary(
+export function writeWorkbenchSummary(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
   summary: string,
 ): string {
-  const filePath = getWorkflowSummaryFile(repoPath, workflowId);
+  const filePath = getWorkbenchSummaryFile(repoPath, workbenchId);
   writeFileEnsuringDir(filePath, [
-    "# Workflow Summary",
+    "# Workbench Summary",
     "",
     summary,
     "",
@@ -66,18 +66,18 @@ export function writeWorkflowSummary(
   return filePath;
 }
 
-// --- Node intent ---
+// --- Dispatch intent ---
 
-export function writeNodeIntent(
+export function writeDispatchIntent(
   repoPath: string,
-  workflowId: string,
-  nodeId: string,
+  workbenchId: string,
+  dispatchId: string,
   role: string,
   intent: string,
 ): string {
-  const filePath = getNodeIntentFile(repoPath, workflowId, nodeId);
+  const filePath = getDispatchIntentFile(repoPath, workbenchId, dispatchId);
   writeFileEnsuringDir(filePath, [
-    `# ${role} — Node ${nodeId}`,
+    `# ${role} — ${dispatchId}`,
     "",
     intent,
     "",
@@ -85,19 +85,19 @@ export function writeNodeIntent(
   return filePath;
 }
 
-export function readNodeIntent(filePath: string): string | null {
+export function readDispatchIntent(filePath: string): string | null {
   return readFileIfExists(filePath);
 }
 
-// --- Node feedback (set by reset) ---
+// --- Dispatch feedback (set by reset) ---
 
-export function writeNodeFeedback(
+export function writeDispatchFeedback(
   repoPath: string,
-  workflowId: string,
-  nodeId: string,
+  workbenchId: string,
+  dispatchId: string,
   feedback: string,
 ): string {
-  const filePath = getNodeFeedbackFile(repoPath, workflowId, nodeId);
+  const filePath = getDispatchFeedbackFile(repoPath, workbenchId, dispatchId);
   writeFileEnsuringDir(filePath, [
     "# Feedback",
     "",
@@ -109,8 +109,8 @@ export function writeNodeFeedback(
   return filePath;
 }
 
-export function clearNodeFeedback(repoPath: string, workflowId: string, nodeId: string): void {
-  const filePath = getNodeFeedbackFile(repoPath, workflowId, nodeId);
+export function clearDispatchFeedback(repoPath: string, workbenchId: string, dispatchId: string): void {
+  const filePath = getDispatchFeedbackFile(repoPath, workbenchId, dispatchId);
   try { fs.unlinkSync(filePath); } catch {}
 }
 
@@ -118,9 +118,9 @@ export function clearNodeFeedback(repoPath: string, workflowId: string, nodeId: 
 
 export function getReportFilePath(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return getRunReportFile(repoPath, workflowId, assignmentId, runId);
+  return getRunReportFile(repoPath, workbenchId, dispatchId, runId);
 }

--- a/hydra/src/assignment/manager.ts
+++ b/hydra/src/assignment/manager.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   getAssignmentStatePath,
-  getWorkflowAssignmentsDir,
 } from "../layout.ts";
 import {
   ASSIGNMENT_STATE_SCHEMA_VERSION,
@@ -13,23 +12,22 @@ import {
 
 export class AssignmentManager {
   private readonly repoPath: string;
-  private readonly workflowId: string;
+  private readonly workbenchId: string;
 
   constructor(
     repoPath: string,
-    workflowId: string,
+    workbenchId: string,
   ) {
     this.repoPath = repoPath;
-    this.workflowId = workflowId;
-    fs.mkdirSync(getWorkflowAssignmentsDir(repoPath, workflowId), { recursive: true });
+    this.workbenchId = workbenchId;
   }
 
   generateAssignmentId(): string {
     return `assignment-${crypto.randomBytes(6).toString("hex")}`;
   }
 
-  getAssignmentPath(assignmentId: string): string {
-    return getAssignmentStatePath(this.repoPath, this.workflowId, assignmentId);
+  getAssignmentPath(dispatchId: string): string {
+    return getAssignmentStatePath(this.repoPath, this.workbenchId, dispatchId);
   }
 
   create(

--- a/hydra/src/cleanup.ts
+++ b/hydra/src/cleanup.ts
@@ -3,11 +3,11 @@ import { execFileSync } from "node:child_process";
 import { loadAgent, listAgents, deleteAgent } from "./store.ts";
 import { isTermCanvasRunning, terminalDestroy, terminalStatus } from "./termcanvas.ts";
 import { AssignmentManager } from "./assignment/manager.ts";
-import { deleteWorkflow, loadWorkflow } from "./workflow-store.ts";
+import { deleteWorkbench, loadWorkbench } from "./workflow-store.ts";
 
 export interface CleanupArgs {
   agentId?: string;
-  workflowId?: string;
+  workbenchId?: string;
   repo?: string;
   all: boolean;
   force: boolean;
@@ -16,12 +16,12 @@ export interface CleanupArgs {
 function printCleanupUsage(): never {
   console.log("Usage: hydra cleanup <agentId> [options]");
   console.log("       hydra cleanup --all [options]");
-  console.log("       hydra cleanup --workflow <workflowId> --repo <path> [options]");
+  console.log("       hydra cleanup --workbench <workbenchId> --repo <path> [options]");
   console.log("");
   console.log("Options:");
   console.log("  --all      Clean up all agents");
-  console.log("  --workflow Clean up a workflow by ID");
-  console.log("  --repo     Repository path for workflow cleanup");
+  console.log("  --workbench Clean up a workbench by ID");
+  console.log("  --repo     Repository path for workbench cleanup");
   console.log("  --force    Force cleanup even if agent is still running");
   process.exit(0);
 }
@@ -34,11 +34,11 @@ export function parseCleanupArgs(args: string[]): CleanupArgs {
   const consumed = new Set<number>();
   const all = args.includes("--all");
   const force = args.includes("--force");
-  const workflowIdx = args.indexOf("--workflow");
-  const workflowId = workflowIdx >= 0 && workflowIdx + 1 < args.length ? args[workflowIdx + 1] : undefined;
-  if (workflowIdx >= 0) {
-    consumed.add(workflowIdx);
-    if (workflowIdx + 1 < args.length) consumed.add(workflowIdx + 1);
+  const workbenchIdx = args.indexOf("--workbench");
+  const workbenchId = workbenchIdx >= 0 && workbenchIdx + 1 < args.length ? args[workbenchIdx + 1] : undefined;
+  if (workbenchIdx >= 0) {
+    consumed.add(workbenchIdx);
+    if (workbenchIdx + 1 < args.length) consumed.add(workbenchIdx + 1);
   }
   const repoIdx = args.indexOf("--repo");
   const repo = repoIdx >= 0 && repoIdx + 1 < args.length ? args[repoIdx + 1] : undefined;
@@ -53,15 +53,15 @@ export function parseCleanupArgs(args: string[]): CleanupArgs {
   }
   const agentId = args.find((arg, index) => !arg.startsWith("--") && !consumed.has(index));
 
-  if (workflowId && !repo) {
-    throw new Error("Provide --repo when cleaning up a workflow");
+  if (workbenchId && !repo) {
+    throw new Error("Provide --repo when cleaning up a workbench");
   }
 
-  if (!all && !agentId && !workflowId) {
-    throw new Error("Provide an agent ID, --workflow, or --all");
+  if (!all && !agentId && !workbenchId) {
+    throw new Error("Provide an agent ID, --workbench, or --all");
   }
 
-  return { agentId, workflowId, repo, all, force };
+  return { agentId, workbenchId, repo, all, force };
 }
 
 export function buildGitWorktreeRemoveArgs(worktreePath: string): string[] {
@@ -133,18 +133,18 @@ function cleanupOne(agentId: string, force: boolean): void {
   console.log(`Cleaned up ${agentId}.`);
 }
 
-function cleanupWorkflow(workflowId: string, repo: string, force: boolean): void {
-  const workflow = loadWorkflow(repo, workflowId);
+function cleanupWorkbench(workbenchId: string, repo: string, force: boolean): void {
+  const workflow = loadWorkbench(repo, workbenchId);
   if (!workflow) {
-    console.error(`Workflow ${workflowId} not found.`);
+    console.error(`Workbench ${workbenchId} not found.`);
     return;
   }
 
-  const manager = new AssignmentManager(repo, workflowId);
+  const manager = new AssignmentManager(repo, workbenchId);
 
   if (isTermCanvasRunning()) {
-    for (const assignmentId of workflow.assignment_ids) {
-      const assignment = manager.load(assignmentId);
+    for (const dispatchId of Object.keys(workflow.dispatches)) {
+      const assignment = manager.load(dispatchId);
       const activeRun = assignment?.active_run_id
         ? assignment.runs.find((run) => run.id === assignment.active_run_id)
         : assignment?.runs[assignment.runs.length - 1];
@@ -156,7 +156,7 @@ function cleanupWorkflow(workflowId: string, repo: string, force: boolean): void
           const { status } = terminalStatus(terminalId);
           if (isLiveTerminalStatus(status)) {
             console.error(
-              `Workflow ${workflowId} has a running terminal (${terminalId}, status: ${status}). Use --force to clean up anyway.`,
+              `Workbench ${workbenchId} has a running terminal (${terminalId}, status: ${status}). Use --force to clean up anyway.`,
             );
             return;
           }
@@ -195,15 +195,15 @@ function cleanupWorkflow(workflowId: string, repo: string, force: boolean): void
     }
   }
 
-  deleteWorkflow(repo, workflowId);
-  console.log(`Cleaned up workflow ${workflowId}.`);
+  deleteWorkbench(repo, workbenchId);
+  console.log(`Cleaned up workbench ${workbenchId}.`);
 }
 
 export async function cleanup(args: string[]): Promise<void> {
   const opts = parseCleanupArgs(args);
 
-  if (opts.workflowId && opts.repo) {
-    cleanupWorkflow(opts.workflowId, opts.repo, opts.force);
+  if (opts.workbenchId && opts.repo) {
+    cleanupWorkbench(opts.workbenchId, opts.repo, opts.force);
   } else if (opts.all) {
     const agents = listAgents();
     if (agents.length === 0) {

--- a/hydra/src/cli-commands.ts
+++ b/hydra/src/cli-commands.ts
@@ -2,17 +2,17 @@ import path from "node:path";
 import { readLedger, type LeadAssessment, type LedgerEntry, type LedgerEvent } from "./ledger.ts";
 import { listRoles } from "./roles/loader.ts";
 import {
-  initWorkflow,
-  dispatchNode,
-  redispatchNode,
+  initWorkbench,
+  dispatch,
+  redispatch,
   watchUntilDecision,
-  approveNode,
-  resetNode,
+  approveDispatch,
+  resetDispatch,
   mergeWorktrees,
-  completeWorkflow,
-  failWorkflow,
-  getWorkflowStatus,
-  askNode,
+  completeWorkbench,
+  failWorkbench,
+  getWorkbenchStatus,
+  askDispatch,
 } from "./workflow-lead.ts";
 
 // --- Shared arg parser helpers ---
@@ -64,23 +64,23 @@ function repeatableFlag(args: string[], flag: string): string[] {
 export async function cliInit(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
     console.log("Usage: hydra init --intent <desc> --repo <path> [options]");
-    console.log("  --intent <desc>              Workflow intent (required)");
+    console.log("  --intent <desc>              Workbench intent (required)");
     console.log("  --repo <path>                Repository path (required)");
     console.log("  --worktree <path>            Use existing worktree");
-    console.log("  --timeout-minutes <n>        Default per-node timeout");
+    console.log("  --timeout-minutes <n>        Default per-dispatch timeout");
     console.log("  --max-retries <n>            Default max retries");
     console.log("  --no-auto-approve            Disable auto-approve");
-    console.log("  --human-request <text>       Original human request (broadcast to all nodes)");
-    console.log("  --overall-plan <text>        Lead's plan summary (broadcast to all nodes)");
-    console.log("  --shared-constraint <text>   Workflow-wide constraint (repeatable)");
+    console.log("  --human-request <text>       Original human request (broadcast to all dispatches)");
+    console.log("  --overall-plan <text>        Lead's plan summary (broadcast to all dispatches)");
+    console.log("  --shared-constraint <text>   Workbench-wide constraint (repeatable)");
     console.log("");
-    console.log("Note: agent_type is no longer a workflow-level default; the role file's");
+    console.log("Note: agent_type is no longer a workbench-level default; the role file's");
     console.log("terminals[] array selects the CLI per dispatch.");
     process.exit(0);
   }
 
   const sharedConstraints = repeatableFlag(args, "--shared-constraint");
-  const result = await initWorkflow({
+  const result = await initWorkbench({
     intent: requireFlag(args, "--intent"),
     repoPath: requireFlag(args, "--repo"),
     worktreePath: optionalFlag(args, "--worktree"),
@@ -98,19 +98,18 @@ export async function cliInit(args: string[]): Promise<void> {
 
 export async function cliDispatch(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra dispatch --workflow <id> --node <id> --role <role> --intent <desc> --repo <path> [options]");
-    console.log("  --workflow <id>         Workflow ID (required)");
-    console.log("  --node <id>            Node ID (required)");
+    console.log("Usage: hydra dispatch --workbench <id> --dispatch <id> --role <role> --intent <desc> --repo <path> [options]");
+    console.log("  --workbench <id>       Workbench ID (required)");
+    console.log("  --dispatch <id>        Dispatch ID (required)");
     console.log("  --role <role>          Registered role name (required, e.g. dev)");
     console.log("  --intent <desc>        Task intent (required)");
     console.log("  --repo <path>          Repository path (required)");
-    console.log("  --depends-on <a,b>     Comma-separated dependency node IDs");
     console.log("  --model <name>         Override the role's default model (e.g. opus)");
     console.log("  --context-ref <l:p>    Context ref as label:path (repeatable)");
     console.log("  --feedback <text>      Feedback text (for reset re-dispatch)");
     console.log("  --worktree <path>      Isolated worktree path");
     console.log("  --worktree-branch <b>  Branch name for isolated worktree");
-    console.log("  --timeout-minutes <n>  Per-node timeout override");
+    console.log("  --timeout-minutes <n>  Per-dispatch timeout override");
     console.log("  --max-retries <n>      Max retries override");
     console.log("  --assessment <json>    Lead assessment JSON: {coupling,novelty,mode,rationale?}");
     process.exit(0);
@@ -139,13 +138,12 @@ export async function cliDispatch(args: string[]): Promise<void> {
     }
   }
 
-  const result = await dispatchNode({
+  const result = await dispatch({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    nodeId: requireFlag(args, "--node"),
+    workbenchId: requireFlag(args, "--workbench"),
+    dispatchId: requireFlag(args, "--dispatch"),
     role: requireFlag(args, "--role"),
     intent: requireFlag(args, "--intent"),
-    dependsOn: listFlag(args, "--depends-on"),
     model: optionalFlag(args, "--model"),
     contextRefs: contextRefs.length > 0 ? contextRefs : undefined,
     feedback: optionalFlag(args, "--feedback"),
@@ -162,22 +160,22 @@ export async function cliDispatch(args: string[]): Promise<void> {
 
 export async function cliAsk(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra ask --workflow <id> --node <id> --message <text> --repo <path> [options]");
-    console.log("  --workflow <id>        Workflow ID (required)");
-    console.log("  --node <id>            Node ID to ask (required, node must have completed at least one run)");
+    console.log("Usage: hydra ask --workbench <id> --dispatch <id> --message <text> --repo <path> [options]");
+    console.log("  --workbench <id>       Workbench ID (required)");
+    console.log("  --dispatch <id>        Dispatch ID to ask (required, dispatch must have completed at least one run)");
     console.log("  --message <text>       Question to send (required)");
     console.log("  --repo <path>          Repository path (required)");
     console.log("  --timeout-ms <n>       Subprocess timeout (default 300000 = 5 min)");
     console.log("");
-    console.log("Spins up a one-shot subprocess that resumes the node's session");
-    console.log("and asks a follow-up question. Does not touch workflow state.");
+    console.log("Spins up a one-shot subprocess that resumes the dispatch's session");
+    console.log("and asks a follow-up question. Does not touch workbench state.");
     process.exit(0);
   }
 
-  const result = await askNode({
+  const result = await askDispatch({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    nodeId: requireFlag(args, "--node"),
+    workbenchId: requireFlag(args, "--workbench"),
+    dispatchId: requireFlag(args, "--dispatch"),
     message: requireFlag(args, "--message"),
     timeoutMs: optionalNumber(args, "--timeout-ms"),
   });
@@ -215,14 +213,14 @@ export async function cliListRoles(args: string[]): Promise<void> {
 
 export async function cliRedispatch(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra redispatch --workflow <id> --node <id> --repo <path> [--intent <desc>]");
+    console.log("Usage: hydra redispatch --workbench <id> --dispatch <id> --repo <path> [--intent <desc>]");
     process.exit(0);
   }
 
-  const result = await redispatchNode({
+  const result = await redispatch({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    nodeId: requireFlag(args, "--node"),
+    workbenchId: requireFlag(args, "--workbench"),
+    dispatchId: requireFlag(args, "--dispatch"),
     intent: optionalFlag(args, "--intent"),
   });
   console.log(JSON.stringify(result, null, 2));
@@ -232,8 +230,8 @@ export async function cliRedispatch(args: string[]): Promise<void> {
 
 export async function cliWatch(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra watch --workflow <id> --repo <path> [options]");
-    console.log("  --workflow <id>        Workflow ID (required)");
+    console.log("Usage: hydra watch --workbench <id> --repo <path> [options]");
+    console.log("  --workbench <id>       Workbench ID (required)");
     console.log("  --repo <path>          Repository path (required)");
     console.log("  --interval-ms <n>      Poll interval (default 5000)");
     console.log("  --timeout-ms <n>       Max watch duration");
@@ -242,7 +240,7 @@ export async function cliWatch(args: string[]): Promise<void> {
 
   const result = await watchUntilDecision({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
+    workbenchId: requireFlag(args, "--workbench"),
     intervalMs: optionalNumber(args, "--interval-ms"),
     timeoutMs: optionalNumber(args, "--timeout-ms"),
   });
@@ -253,14 +251,14 @@ export async function cliWatch(args: string[]): Promise<void> {
 
 export async function cliApprove(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra approve --workflow <id> --node <id> --repo <path>");
+    console.log("Usage: hydra approve --workbench <id> --dispatch <id> --repo <path>");
     process.exit(0);
   }
 
-  await approveNode({
+  await approveDispatch({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    nodeId: requireFlag(args, "--node"),
+    workbenchId: requireFlag(args, "--workbench"),
+    dispatchId: requireFlag(args, "--dispatch"),
   });
   console.log("Approved.");
 }
@@ -269,16 +267,15 @@ export async function cliApprove(args: string[]): Promise<void> {
 
 export async function cliReset(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra reset --workflow <id> --node <id> --repo <path> [--feedback <text>] [--no-cascade]");
+    console.log("Usage: hydra reset --workbench <id> --dispatch <id> --repo <path> [--feedback <text>]");
     process.exit(0);
   }
 
-  const result = await resetNode({
+  const result = await resetDispatch({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    nodeId: requireFlag(args, "--node"),
+    workbenchId: requireFlag(args, "--workbench"),
+    dispatchId: requireFlag(args, "--dispatch"),
     feedback: optionalFlag(args, "--feedback"),
-    cascade: !hasFlag(args, "--no-cascade"),
   });
   console.log(JSON.stringify(result, null, 2));
 }
@@ -287,14 +284,14 @@ export async function cliReset(args: string[]): Promise<void> {
 
 export async function cliMerge(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra merge --workflow <id> --nodes <a,b,c> --repo <path> [--target-branch <branch>]");
+    console.log("Usage: hydra merge --workbench <id> --dispatches <a,b,c> --repo <path> [--target-branch <branch>]");
     process.exit(0);
   }
 
   const result = await mergeWorktrees({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
-    sourceNodeIds: listFlag(args, "--nodes"),
+    workbenchId: requireFlag(args, "--workbench"),
+    sourceDispatchIds: listFlag(args, "--dispatches"),
     targetBranch: optionalFlag(args, "--target-branch"),
   });
   console.log(JSON.stringify(result, null, 2));
@@ -304,45 +301,45 @@ export async function cliMerge(args: string[]): Promise<void> {
 
 export async function cliComplete(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra complete --workflow <id> --repo <path> [--summary <text>]");
+    console.log("Usage: hydra complete --workbench <id> --repo <path> [--summary <text>]");
     process.exit(0);
   }
 
-  await completeWorkflow({
+  await completeWorkbench({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
+    workbenchId: requireFlag(args, "--workbench"),
     summary: optionalFlag(args, "--summary"),
   });
-  console.log("Workflow completed.");
+  console.log("Workbench completed.");
 }
 
 // --- fail ---
 
 export async function cliFail(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra fail --workflow <id> --repo <path> --reason <text>");
+    console.log("Usage: hydra fail --workbench <id> --repo <path> --reason <text>");
     process.exit(0);
   }
 
-  await failWorkflow({
+  await failWorkbench({
     repoPath: requireFlag(args, "--repo"),
-    workflowId: requireFlag(args, "--workflow"),
+    workbenchId: requireFlag(args, "--workbench"),
     reason: requireFlag(args, "--reason"),
   });
-  console.log("Workflow failed.");
+  console.log("Workbench failed.");
 }
 
 // --- status ---
 
 export async function cliStatus(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra status --workflow <id> --repo <path>");
+    console.log("Usage: hydra status --workbench <id> --repo <path>");
     process.exit(0);
   }
 
-  const result = getWorkflowStatus(
+  const result = getWorkbenchStatus(
     requireFlag(args, "--repo"),
-    requireFlag(args, "--workflow"),
+    requireFlag(args, "--workbench"),
   );
   console.log(JSON.stringify(result, null, 2));
 }
@@ -351,7 +348,7 @@ export async function cliStatus(args: string[]): Promise<void> {
 
 export async function cliLedger(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra ledger --workflow <id> --repo <path> [--json]");
+    console.log("Usage: hydra ledger --workbench <id> --repo <path> [--json]");
     console.log("  Default: one-line scannable view, prefixed with [L]/[W]/[S] actor.");
     console.log("  --json:  raw JSON-per-line for machine consumption.");
     process.exit(0);
@@ -359,7 +356,7 @@ export async function cliLedger(args: string[]): Promise<void> {
 
   const entries = readLedger(
     path.resolve(requireFlag(args, "--repo")),
-    requireFlag(args, "--workflow"),
+    requireFlag(args, "--workbench"),
   );
   const json = hasFlag(args, "--json");
   for (const entry of entries) {
@@ -378,48 +375,45 @@ function formatLedgerLine(entry: LedgerEntry): string {
 
 function formatEventSummary(event: LedgerEvent): string {
   switch (event.type) {
-    case "workflow_created":
-      return `workflow_created           intent=${event.intent_file}`;
-    case "node_dispatched": {
+    case "workbench_created":
+      return `workbench_created          intent=${event.intent_file}`;
+    case "dispatch_started": {
       const assess = event.assessment?.rationale ? ` — ${truncate(event.assessment.rationale, 60)}` : "";
-      return `node_dispatched            ${event.node_id} role=${event.role} cause=${event.cause}${assess}`;
+      return `dispatch_started           ${event.dispatch_id} role=${event.role} cause=${event.cause}${assess}`;
     }
-    case "node_completed": {
+    case "dispatch_completed": {
       const stuck = event.stuck_reason ? ` stuck_reason=${event.stuck_reason}` : "";
-      return `node_completed             ${event.node_id} outcome=${event.outcome}${stuck} report=${event.report_file}`;
+      return `dispatch_completed         ${event.dispatch_id} outcome=${event.outcome}${stuck} report=${event.report_file}`;
     }
-    case "node_failed": {
+    case "dispatch_failed": {
       const msg = event.failure_message ? ` "${truncate(event.failure_message, 60)}"` : "";
       const ref = event.report_file ? ` report=${event.report_file}` : "";
-      return `node_failed                ${event.node_id} code=${event.failure_code}${msg}${ref}`;
+      return `dispatch_failed            ${event.dispatch_id} code=${event.failure_code}${msg}${ref}`;
     }
-    case "node_reset": {
-      const cascade = event.cascade_targets.length > 0 ? ` cascade=[${event.cascade_targets.join(",")}]` : "";
+    case "dispatch_reset": {
       const fb = event.feedback_file ? ` feedback=${event.feedback_file}` : "";
-      return `node_reset                 ${event.node_id}${cascade}${fb}`;
+      return `dispatch_reset             ${event.dispatch_id}${fb}`;
     }
-    case "node_approved":
-      return `node_approved              ${event.node_id}`;
-    case "assignment_retried": {
+    case "dispatch_approved":
+      return `dispatch_approved          ${event.dispatch_id}`;
+    case "dispatch_retried": {
       const next = event.next_retry_at ? ` next=${event.next_retry_at.slice(11, 19)}` : "";
       const msg = event.failure_message ? ` "${truncate(event.failure_message, 60)}"` : "";
-      return `assignment_retried         ${event.node_id} cause=${event.cause} attempt=${event.attempt}/${event.max_attempts}${next} code=${event.failure_code}${msg}`;
+      return `dispatch_retried           ${event.dispatch_id} cause=${event.cause} attempt=${event.attempt}/${event.max_attempts}${next} code=${event.failure_code}${msg}`;
     }
-    case "node_promoted_eligible":
-      return `node_promoted_eligible     ${event.node_id} triggered_by=[${event.triggered_by.join(",")}]`;
     case "lead_asked_followup": {
       const fork = event.new_session_id && event.new_session_id !== event.session_id
         ? ` forked=${event.new_session_id.slice(0, 8)}`
         : "";
-      return `lead_asked_followup        ${event.node_id} role=${event.role} session=${event.session_id.slice(0, 8)}${fork} "${truncate(event.message_excerpt, 50)}"`;
+      return `lead_asked_followup        ${event.dispatch_id} role=${event.role} session=${event.session_id.slice(0, 8)}${fork} "${truncate(event.message_excerpt, 50)}"`;
     }
     case "merge_attempted":
-      return `merge_attempted            sources=[${event.source_nodes.join(",")}] outcome=${event.outcome}`;
-    case "workflow_completed":
-      return `workflow_completed         nodes=${event.total_nodes} retries=${event.total_retries} duration_ms=${event.total_duration_ms}`;
-    case "workflow_failed": {
-      const failedNode = event.failed_node_id ? ` failed_node=${event.failed_node_id}` : "";
-      return `workflow_failed            "${truncate(event.reason, 60)}"${failedNode}`;
+      return `merge_attempted            sources=[${event.source_dispatches.join(",")}] outcome=${event.outcome}`;
+    case "workbench_completed":
+      return `workbench_completed        dispatches=${event.total_dispatches} retries=${event.total_retries} duration_ms=${event.total_duration_ms}`;
+    case "workbench_failed": {
+      const failedDispatch = event.failed_dispatch_id ? ` failed_dispatch=${event.failed_dispatch_id}` : "";
+      return `workbench_failed           "${truncate(event.reason, 60)}"${failedDispatch}`;
     }
   }
 }

--- a/hydra/src/collector.ts
+++ b/hydra/src/collector.ts
@@ -28,7 +28,7 @@ export type CollectRunResult =
     };
 
 export interface RunResultExpectation {
-  workflow_id: string;
+  workbench_id: string;
   assignment_id: string;
   run_id: string;
   result_file: string;

--- a/hydra/src/decision.ts
+++ b/hydra/src/decision.ts
@@ -1,7 +1,6 @@
 import type { StuckReason, SubAgentOutcome } from "./protocol.ts";
 
-export type NodeStatus =
-  | "blocked"
+export type DispatchStatus =
   | "eligible"
   | "dispatched"
   | "completed"
@@ -9,14 +8,14 @@ export type NodeStatus =
   | "reset";
 
 export type DecisionPointType =
-  | "node_completed"
-  | "node_failed"
-  | "node_failed_final"
+  | "dispatch_completed"
+  | "dispatch_failed"
+  | "dispatch_failed_final"
   | "batch_completed"
   | "watch_timeout";
 
-export interface CompletedNodeInfo {
-  node_id: string;
+export interface CompletedDispatchInfo {
+  dispatch_id: string;
   role: string;
   outcome: SubAgentOutcome;
   /**
@@ -38,8 +37,8 @@ export interface CompletedNodeInfo {
   };
 }
 
-export interface FailedNodeInfo {
-  node_id: string;
+export interface FailedDispatchInfo {
+  dispatch_id: string;
   role: string;
   code: string;
   message: string;
@@ -47,20 +46,18 @@ export interface FailedNodeInfo {
   max_retries: number;
 }
 
-export interface NodeSummary {
-  node_id: string;
+export interface DispatchSummary {
+  dispatch_id: string;
   role: string;
-  status: NodeStatus;
-  depends_on: string[];
+  status: DispatchStatus;
   assignment_id?: string;
 }
 
 export interface DecisionPoint {
   type: DecisionPointType;
-  workflow_id: string;
+  workbench_id: string;
   timestamp: string;
-  completed?: CompletedNodeInfo;
-  failed?: FailedNodeInfo;
-  nodes: NodeSummary[];
-  newly_eligible?: string[];
+  completed?: CompletedDispatchInfo;
+  failed?: FailedDispatchInfo;
+  dispatches: DispatchSummary[];
 }

--- a/hydra/src/dispatcher.ts
+++ b/hydra/src/dispatcher.ts
@@ -6,7 +6,7 @@ import {
 } from "./termcanvas.ts";
 
 export interface DispatchCreateOnlyRequest {
-  workflowId: string;
+  workbenchId: string;
   assignmentId: string;
   runId: string;
   repoPath: string;
@@ -49,7 +49,7 @@ export interface DispatcherDependencies {
     prompt?: string,
     autoApprove?: boolean,
     parentTerminalId?: string,
-    workflowId?: string,
+    workbenchId?: string,
     assignmentId?: string,
     repoPath?: string,
     resumeSessionId?: string,
@@ -64,7 +64,7 @@ const DEFAULT_DEPENDENCIES: DispatcherDependencies = {
 
 export function buildCreateOnlyPrompt(
   taskFile: string,
-  workflowId: string,
+  workbenchId: string,
   resultFile: string,
   options: {
     assignmentId: string;
@@ -83,7 +83,7 @@ export async function dispatchCreateOnly(
       errorCode: "DISPATCH_TERMCANVAS_NOT_RUNNING",
       stage: "dispatcher.preflight",
       ids: {
-        workflow_id: request.workflowId,
+        workbench_id: request.workbenchId,
         assignment_id: request.assignmentId,
       },
     });
@@ -95,7 +95,7 @@ export async function dispatchCreateOnly(
       errorCode: "DISPATCH_REPO_NOT_ON_CANVAS",
       stage: "dispatcher.preflight",
       ids: {
-        workflow_id: request.workflowId,
+        workbench_id: request.workbenchId,
         assignment_id: request.assignmentId,
       },
     });
@@ -103,7 +103,7 @@ export async function dispatchCreateOnly(
 
   const prompt = buildCreateOnlyPrompt(
     request.taskFile,
-    request.workflowId,
+    request.workbenchId,
     request.resultFile,
     {
       assignmentId: request.assignmentId,
@@ -116,7 +116,7 @@ export async function dispatchCreateOnly(
     prompt,
     request.autoApprove,
     request.parentTerminalId,
-    request.workflowId,
+    request.workbenchId,
     request.assignmentId,
     request.repoPath,
     request.resumeSessionId,

--- a/hydra/src/init.ts
+++ b/hydra/src/init.ts
@@ -14,7 +14,7 @@ decisions at decision points; Hydra handles operational management.
 
 Why this design (vs. other coding-agent products):
 - **SWF decider pattern, specialized for LLM deciders.** Hydra is the AWS SWF / Cadence / Temporal decider pattern. \`hydra watch\` is \`PollForDecisionTask\`; the Lead is the decider; \`lead_terminal_id\` enforces single-decider semantics.
-- **Parallel-first, not bolted on.** \`dispatch\` + \`depends_on\` + worktree + \`merge\` are first-class. Other products (Factory.ai's Droid, Amp, Claude Code subagents) treat parallelism as open research; Hydra makes it the default.
+- **Parallel-first, not bolted on.** \`dispatch\` + worktree + \`merge\` are first-class. Lead sequences nodes manually and passes context explicitly via \`--context-ref\`. Other products treat parallelism as open research; Hydra makes it the default.
 - **Typed result contract.** Workers publish a schema-validated \`result.json\` (\`outcome: completed | stuck | error\`, optional \`stuck_reason: needs_clarification | needs_credentials | needs_context | blocked_technical\`). Other products return free-text final messages and require downstream parsing.
 - **Lead intervention points.** \`hydra reset --feedback\` lets the Lead actually intervene at decision points instead of being block-and-join. A stale or wrong run is one \`reset\` away.
 
@@ -29,10 +29,10 @@ Workflow patterns:
 2. Use Hydra for ambiguous, risky, parallel, or multi-step work:
    \`\`\`
    hydra init --intent "<task>" --repo .
-   hydra dispatch --workflow W --node <id> --role <role> --intent "<desc>" --repo .
-   hydra watch --workflow W --repo .
+   hydra dispatch --workbench W --dispatch <id> --role <role> --intent "<desc>" --repo .
+   hydra watch --workbench W --repo .
    # → DecisionPoint returned, decide next step
-   hydra complete --workflow W --repo .
+   hydra complete --workbench W --repo .
    \`\`\`
 3. Use a direct isolated worker when only a separate worker is needed:
    \`hydra spawn --task "<specific task>" --repo . [--worktree .]\`
@@ -42,25 +42,25 @@ Agent launch rule:
 - Do not use \`termcanvas terminal input\` for task dispatch; it is not a supported automation path
 
 Workflow control:
-- After dispatching nodes, always call \`hydra watch\`. It returns at decision points.
-1. Watch until decision point: \`hydra watch --workflow <workflowId> --repo .\`
-2. Inspect structured state: \`hydra status --workflow <workflowId> --repo .\`
-3. Reset a node for rework: \`hydra reset --workflow W --node N --feedback "..." --repo .\`
-4. Approve a node's output: \`hydra approve --workflow W --node N --repo .\`
-5. Merge parallel branches: \`hydra merge --workflow W --nodes A,B --repo .\`
-6. View event log: \`hydra ledger --workflow <workflowId> --repo .\`
-7. Clean up: \`hydra cleanup --workflow <workflowId> --repo .\`
+- After dispatching, always call \`hydra watch\`. It returns at decision points.
+1. Watch until decision point: \`hydra watch --workbench <workbenchId> --repo .\`
+2. Inspect structured state: \`hydra status --workbench <workbenchId> --repo .\`
+3. Reset a dispatch for rework: \`hydra reset --workbench W --dispatch N --feedback "..." --repo .\`
+4. Approve a dispatch's output: \`hydra approve --workbench W --dispatch N --repo .\`
+5. Merge parallel branches: \`hydra merge --workbench W --dispatches A,B --repo .\`
+6. View event log: \`hydra ledger --workbench <workbenchId> --repo .\`
+7. Clean up: \`hydra cleanup --workbench <workbenchId> --repo .\`
 
 Telemetry polling:
 1. Treat \`hydra watch\` as the main polling loop; do not infer progress from terminal prose alone.
 2. Before deciding wait / retry / takeover, query:
-   - \`termcanvas telemetry get --workflow <workflowId> --repo .\`
+   - \`termcanvas telemetry get --workbench <workbenchId> --repo .\`
    - \`termcanvas telemetry get --terminal <terminalId>\`
    - \`termcanvas telemetry events --terminal <terminalId> --limit 20\`
 3. Trust \`derived_status\` and \`task_status\` as the primary decision signals.
 
 \`result.json\` must contain (slim, schema_version \`hydra/result/v0.1\`):
-- \`schema_version\`, \`workflow_id\`, \`assignment_id\`, \`run_id\` (passthrough IDs)
+- \`schema_version\`, \`workbench_id\`, \`assignment_id\`, \`run_id\` (passthrough IDs)
 - \`outcome\` (completed/stuck/error — Hydra routes on this)
 - \`report_file\` (path to a \`report.md\` written alongside \`result.json\`)
 

--- a/hydra/src/layout.ts
+++ b/hydra/src/layout.ts
@@ -4,143 +4,124 @@ export function getHydraRoot(repoPath: string): string {
   return path.join(path.resolve(repoPath), ".hydra");
 }
 
-export function getWorkflowsRoot(repoPath: string): string {
-  return path.join(getHydraRoot(repoPath), "workflows");
+export function getWorkbenchesRoot(repoPath: string): string {
+  return path.join(getHydraRoot(repoPath), "workbenches");
 }
 
-export function getWorkflowDir(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowsRoot(repoPath), workflowId);
+export function getWorkbenchDir(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchesRoot(repoPath), workbenchId);
 }
 
-export function getWorkflowStatePath(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowDir(repoPath, workflowId), "workflow.json");
+export function getWorkbenchStatePath(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchDir(repoPath, workbenchId), "workbench.json");
 }
 
-export function getWorkflowInputsDir(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowDir(repoPath, workflowId), "inputs");
+export function getWorkbenchInputsDir(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchDir(repoPath, workbenchId), "inputs");
 }
 
-export function getWorkflowIntentFile(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowInputsDir(repoPath, workflowId), "intent.md");
+export function getWorkbenchIntentFile(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchInputsDir(repoPath, workbenchId), "intent.md");
 }
 
-/** @deprecated use getWorkflowIntentFile */
-export function getWorkflowUserRequestPath(repoPath: string, workflowId: string): string {
-  return getWorkflowIntentFile(repoPath, workflowId);
+export function getWorkbenchOutputsDir(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchDir(repoPath, workbenchId), "outputs");
 }
 
-export function getWorkflowOutputsDir(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowDir(repoPath, workflowId), "outputs");
+export function getWorkbenchSummaryFile(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchOutputsDir(repoPath, workbenchId), "summary.md");
 }
 
-export function getWorkflowSummaryFile(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowOutputsDir(repoPath, workflowId), "summary.md");
+export function getWorkbenchDispatchesDir(repoPath: string, workbenchId: string): string {
+  return path.join(getWorkbenchDir(repoPath, workbenchId), "dispatches");
 }
 
-export function getWorkflowNodesDir(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowDir(repoPath, workflowId), "nodes");
+export function getDispatchDir(repoPath: string, workbenchId: string, dispatchId: string): string {
+  return path.join(getWorkbenchDispatchesDir(repoPath, workbenchId), dispatchId);
 }
 
-export function getNodeDir(repoPath: string, workflowId: string, nodeId: string): string {
-  return path.join(getWorkflowNodesDir(repoPath, workflowId), nodeId);
+export function getDispatchIntentFile(repoPath: string, workbenchId: string, dispatchId: string): string {
+  return path.join(getDispatchDir(repoPath, workbenchId, dispatchId), "intent.md");
 }
 
-export function getNodeIntentFile(repoPath: string, workflowId: string, nodeId: string): string {
-  return path.join(getNodeDir(repoPath, workflowId, nodeId), "intent.md");
+export function getDispatchFeedbackFile(repoPath: string, workbenchId: string, dispatchId: string): string {
+  return path.join(getDispatchDir(repoPath, workbenchId, dispatchId), "feedback.md");
 }
 
-export function getNodeFeedbackFile(repoPath: string, workflowId: string, nodeId: string): string {
-  return path.join(getNodeDir(repoPath, workflowId, nodeId), "feedback.md");
-}
-
-export function getWorkflowAssignmentsDir(repoPath: string, workflowId: string): string {
-  return path.join(getWorkflowDir(repoPath, workflowId), "assignments");
-}
-
-export function getAssignmentDir(
+export function getDispatchStateDir(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
 ): string {
-  return path.join(getWorkflowAssignmentsDir(repoPath, workflowId), assignmentId);
+  return getDispatchDir(repoPath, workbenchId, dispatchId);
 }
 
 export function getAssignmentStatePath(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
 ): string {
-  return path.join(getAssignmentDir(repoPath, workflowId, assignmentId), "assignment.json");
+  return path.join(getDispatchDir(repoPath, workbenchId, dispatchId), "assignment.json");
 }
 
 export function getAssignmentRunsDir(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
 ): string {
-  return path.join(getAssignmentDir(repoPath, workflowId, assignmentId), "runs");
+  return path.join(getDispatchDir(repoPath, workbenchId, dispatchId), "runs");
 }
 
 export function getRunDir(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getAssignmentRunsDir(repoPath, workflowId, assignmentId), runId);
+  return path.join(getAssignmentRunsDir(repoPath, workbenchId, dispatchId), runId);
 }
 
 export function getRunTaskFile(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getRunDir(repoPath, workflowId, assignmentId, runId), "task.md");
+  return path.join(getRunDir(repoPath, workbenchId, dispatchId, runId), "task.md");
 }
 
 export function getRunResultFile(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getRunDir(repoPath, workflowId, assignmentId, runId), "result.json");
+  return path.join(getRunDir(repoPath, workbenchId, dispatchId, runId), "result.json");
 }
 
 export function getRunArtifactsDir(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getRunDir(repoPath, workflowId, assignmentId, runId), "artifacts");
+  return path.join(getRunDir(repoPath, workbenchId, dispatchId, runId), "artifacts");
 }
 
 export function getRunReportFile(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getRunDir(repoPath, workflowId, assignmentId, runId), "report.md");
-}
-
-/** @deprecated use getRunReportFile */
-export function getRunBriefFile(
-  repoPath: string,
-  workflowId: string,
-  assignmentId: string,
-  runId: string,
-): string {
-  return getRunReportFile(repoPath, workflowId, assignmentId, runId);
+  return path.join(getRunDir(repoPath, workbenchId, dispatchId, runId), "report.md");
 }
 
 export function getRunApprovalRequestFile(
   repoPath: string,
-  workflowId: string,
-  assignmentId: string,
+  workbenchId: string,
+  dispatchId: string,
   runId: string,
 ): string {
-  return path.join(getRunArtifactsDir(repoPath, workflowId, assignmentId, runId), "approval-request.md");
+  return path.join(getRunArtifactsDir(repoPath, workbenchId, dispatchId, runId), "approval-request.md");
 }

--- a/hydra/src/lead-guard.ts
+++ b/hydra/src/lead-guard.ts
@@ -1,31 +1,31 @@
 import { HydraError } from "./errors.ts";
-import type { WorkflowRecord } from "./workflow-store.ts";
+import type { WorkbenchRecord } from "./workflow-store.ts";
 
 // Lead guard: every Lead-facing operation (dispatch, watch, approve,
 // reset, complete, fail, etc.) must verify that the calling terminal
-// matches the workflow's lead_terminal_id. This enforces single-Lead
+// matches the workbench's lead_terminal_id. This enforces single-Lead
 // semantics and prevents accidental cross-terminal interference.
 
 export function getCurrentTerminalId(): string | undefined {
   return process.env.TERMCANVAS_TERMINAL_ID;
 }
 
-export function ensureLeadCaller(workflow: WorkflowRecord): void {
+export function ensureLeadCaller(workbench: WorkbenchRecord): void {
   const callerId = getCurrentTerminalId();
   if (!callerId) {
     // No TERMCANVAS_TERMINAL_ID — caller is outside TermCanvas. Allow this
-    // for tooling/scripts; the workflow's lead_terminal_id is informational.
+    // for tooling/scripts; the workbench's lead_terminal_id is informational.
     // If we want strict enforcement, change this to throw.
     return;
   }
-  if (callerId !== workflow.lead_terminal_id) {
+  if (callerId !== workbench.lead_terminal_id) {
     throw new HydraError(
-      `Workflow ${workflow.id} is owned by terminal ${workflow.lead_terminal_id}; ` +
-      `current terminal is ${callerId}. Only the Lead terminal may operate on this workflow.`,
+      `Workbench ${workbench.id} is owned by terminal ${workbench.lead_terminal_id}; ` +
+      `current terminal is ${callerId}. Only the Lead terminal may operate on this workbench.`,
       {
-        errorCode: "WORKFLOW_NOT_LEAD",
+        errorCode: "WORKBENCH_NOT_LEAD",
         stage: "lead_guard",
-        ids: { workflow_id: workflow.id },
+        ids: { workbench_id: workbench.id },
       },
     );
   }

--- a/hydra/src/ledger.ts
+++ b/hydra/src/ledger.ts
@@ -14,10 +14,10 @@ export type LedgerActor = "lead" | "worker" | "system";
 // --- Ledger event types ---
 //
 // Why each event records what it does:
-//   - cause / failure_message / stuck_reason / failed_node_id let the
+//   - cause / failure_message / stuck_reason / failed_dispatch_id let the
 //     reader scan a single line and judge correctness without drilling
 //     down (drill-down still works via report_file / feedback_file).
-//   - assignment_retried + node_promoted_eligible surface system
+//   - dispatch_retried surface system
 //     decisions that used to be silent inside the state machine.
 
 export type DispatchCause = "initial" | "system_retry" | "lead_redispatch";
@@ -38,21 +38,21 @@ export interface LeadAssessment {
 }
 
 export type LedgerEvent =
-  | { type: "workflow_created"; intent_file: string; lead_terminal_id: string }
+  | { type: "workbench_created"; intent_file: string; lead_terminal_id: string }
   | {
-      type: "node_dispatched";
-      node_id: string;
+      type: "dispatch_started";
+      dispatch_id: string;
       role: string;
       agent_type: AgentType;
       intent_file: string;
       cause: DispatchCause;
       resumed_from_session?: string;
-      /** Lead's coupling × novelty assessment at dispatch time. */
+      /** Lead's coupling x novelty assessment at dispatch time. */
       assessment?: LeadAssessment;
     }
   | {
-      type: "node_completed";
-      node_id: string;
+      type: "dispatch_completed";
+      dispatch_id: string;
       role: string;
       agent_type: AgentType;
       duration_ms: number;
@@ -63,8 +63,8 @@ export type LedgerEvent =
       session_id?: string;
     }
   | {
-      type: "node_failed";
-      node_id: string;
+      type: "dispatch_failed";
+      dispatch_id: string;
       role: string;
       agent_type: AgentType;
       duration_ms: number;
@@ -74,23 +74,22 @@ export type LedgerEvent =
       report_file?: string;
     }
   | {
-      type: "node_reset";
-      node_id: string;
+      type: "dispatch_reset";
+      dispatch_id: string;
       role: string;
       feedback_file?: string;
-      cascade_targets: string[];
     }
-  | { type: "node_approved"; node_id: string; role: string }
+  | { type: "dispatch_approved"; dispatch_id: string; role: string }
   /**
    * System-side retry of a single assignment after a timeout or an
    * agent-reported error. Emitted when scheduleRetry queues a fresh attempt
-   * (so a corresponding node_dispatched with cause=system_retry follows).
+   * (so a corresponding dispatch_started with cause=system_retry follows).
    * Lets the reader audit "should we have retried this / how long until
    * the next attempt".
    */
   | {
-      type: "assignment_retried";
-      node_id: string;
+      type: "dispatch_retried";
+      dispatch_id: string;
       cause: "timeout" | "agent_reported_error";
       attempt: number;
       max_attempts: number;
@@ -99,18 +98,8 @@ export type LedgerEvent =
       failure_message?: string;
     }
   /**
-   * System-side promotion of a previously blocked node to "eligible" once
-   * its dependencies completed. Lets the reader audit "did Hydra promote
-   * the right node, at the right time, after the right deps".
-   */
-  | {
-      type: "node_promoted_eligible";
-      node_id: string;
-      triggered_by: string[];
-    }
-  /**
-   * Lead asked a follow-up question to a completed node via `hydra ask`.
-   * A one-shot subprocess resumed the node's session, answered the
+   * Lead asked a follow-up question to a completed dispatch via `hydra ask`.
+   * A one-shot subprocess resumed the dispatch's session, answered the
    * question, and exited. The new_session_id is only populated when
    * the CLI supports fork (currently claude via --fork-session); for
    * codex the follow-up appends to the original session id so
@@ -118,7 +107,7 @@ export type LedgerEvent =
    */
   | {
       type: "lead_asked_followup";
-      node_id: string;
+      dispatch_id: string;
       role: string;
       agent_type: AgentType;
       session_id: string;
@@ -127,19 +116,19 @@ export type LedgerEvent =
       answer_excerpt: string;
       duration_ms: number;
     }
-  | { type: "merge_attempted"; source_nodes: string[]; outcome: "merged" | "conflict" }
+  | { type: "merge_attempted"; source_dispatches: string[]; outcome: "merged" | "conflict" }
   | {
-      type: "workflow_completed";
+      type: "workbench_completed";
       result_file?: string;
       total_duration_ms: number;
-      total_nodes: number;
+      total_dispatches: number;
       total_retries: number;
     }
   | {
-      type: "workflow_failed";
+      type: "workbench_failed";
       reason: string;
       total_duration_ms: number;
-      failed_node_id?: string;
+      failed_dispatch_id?: string;
     };
 
 export interface LedgerEntry {
@@ -150,17 +139,17 @@ export interface LedgerEntry {
 
 // --- Storage ---
 
-function getLedgerPath(repoPath: string, workflowId: string): string {
-  return path.join(path.resolve(repoPath), ".hydra", "workflows", workflowId, "ledger.jsonl");
+function getLedgerPath(repoPath: string, workbenchId: string): string {
+  return path.join(path.resolve(repoPath), ".hydra", "workbenches", workbenchId, "ledger.jsonl");
 }
 
 export function appendLedger(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
   actor: LedgerActor,
   event: LedgerEvent,
 ): void {
-  const filePath = getLedgerPath(repoPath, workflowId);
+  const filePath = getLedgerPath(repoPath, workbenchId);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const entry: LedgerEntry = {
     timestamp: new Date().toISOString(),
@@ -172,9 +161,9 @@ export function appendLedger(
 
 export function readLedger(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
 ): LedgerEntry[] {
-  const filePath = getLedgerPath(repoPath, workflowId);
+  const filePath = getLedgerPath(repoPath, workbenchId);
   if (!fs.existsSync(filePath)) return [];
   const content = fs.readFileSync(filePath, "utf-8").trim();
   if (content === "") return [];

--- a/hydra/src/list.ts
+++ b/hydra/src/list.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { listAgents } from "./store.ts";
-import { listWorkflows } from "./workflow-store.ts";
+import { listWorkbenches } from "./workflow-store.ts";
 
 export async function list(args: string[]): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
@@ -8,19 +8,19 @@ export async function list(args: string[]): Promise<void> {
     console.log("");
     console.log("Options:");
     console.log("  --repo <path>  Filter agents by repository path");
-    console.log("  --workflows    List workflow records instead of agents");
+    console.log("  --workbenches  List workbench records instead of agents");
     process.exit(0);
   }
 
   const repoIdx = args.indexOf("--repo");
   const repo = repoIdx >= 0 ? path.resolve(args[repoIdx + 1]) : undefined;
-  const workflowsMode = args.includes("--workflows");
+  const workflowsMode = args.includes("--workbenches");
 
   if (workflowsMode) {
     const workflowRepo = repo ?? process.cwd();
-    const workflows = listWorkflows(workflowRepo);
+    const workflows = listWorkbenches(workflowRepo);
     if (workflows.length === 0) {
-      console.log("No workflows.");
+      console.log("No workbenches.");
       return;
     }
     for (const workflow of workflows) {

--- a/hydra/src/protocol.ts
+++ b/hydra/src/protocol.ts
@@ -33,7 +33,7 @@ export type StuckReason =
 
 export interface SubAgentResult {
   schema_version: typeof RESULT_SCHEMA_VERSION;
-  workflow_id: string;
+  workbench_id: string;
   assignment_id: string;
   run_id: string;
 
@@ -56,7 +56,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function extractIds(value: unknown): Record<string, string> {
   if (!isRecord(value)) return {};
   const ids: Record<string, string> = {};
-  if (typeof value.workflow_id === "string" && value.workflow_id) ids.workflow_id = value.workflow_id;
+  if (typeof value.workbench_id === "string" && value.workbench_id) ids.workbench_id = value.workbench_id;
   if (typeof value.assignment_id === "string" && value.assignment_id) ids.assignment_id = value.assignment_id;
   if (typeof value.run_id === "string" && value.run_id) ids.run_id = value.run_id;
   return ids;
@@ -129,7 +129,7 @@ function validateStuckReason(
 
 export function validateSubAgentResult(
   value: unknown,
-  expected: Pick<SubAgentResult, "workflow_id" | "assignment_id" | "run_id">,
+  expected: Pick<SubAgentResult, "workbench_id" | "assignment_id" | "run_id">,
 ): SubAgentResult {
   const record = expectRecord(value, "result", value);
   const schemaVersion = expectString(record, "schema_version", value);
@@ -143,7 +143,7 @@ export function validateSubAgentResult(
   const outcome = validateOutcome(record, value);
   const validated: SubAgentResult = {
     schema_version: RESULT_SCHEMA_VERSION,
-    workflow_id: expectString(record, "workflow_id", value),
+    workbench_id: expectString(record, "workbench_id", value),
     assignment_id: expectString(record, "assignment_id", value),
     run_id: expectString(record, "run_id", value),
     outcome,
@@ -151,8 +151,8 @@ export function validateSubAgentResult(
     stuck_reason: validateStuckReason(record, outcome, value),
   };
 
-  if (validated.workflow_id !== expected.workflow_id) {
-    failValidation("Invalid workflow_id: result does not match workflow", value);
+  if (validated.workbench_id !== expected.workbench_id) {
+    failValidation("Invalid workbench_id: result does not match workbench", value);
   }
   if (validated.assignment_id !== expected.assignment_id) {
     failValidation("Invalid assignment_id: result does not match assignment", value);

--- a/hydra/src/replay.ts
+++ b/hydra/src/replay.ts
@@ -1,20 +1,20 @@
-import type { NodeStatus } from "./decision.ts";
+import type { DispatchStatus } from "./decision.ts";
 import type { LedgerActor, LedgerEntry } from "./ledger.ts";
 import type { StuckReason, SubAgentOutcome } from "./protocol.ts";
-import type { WorkflowStatus } from "./workflow-store.ts";
+import type { WorkbenchStatus } from "./workflow-store.ts";
 
 /**
  * Ledger summary builder.
  *
  * **This is not an event-sourcing recovery layer.** Hydra's source of truth
- * is `workflow.json` + `assignment.json`; the ledger is a Lead-readable
+ * is `workbench.json` + `assignment.json`; the ledger is a Lead-readable
  * audit log used to scan "what happened and was every decision correct".
  *
  * `summarizeLedger` reduces a stream of `LedgerEntry` events into a
  * structured summary that answers the five questions a Lead or a periodic
  * auditor wants to ask without opening any other file:
  *
- *   1. What is this workflow's lifecycle status, and how did it get there?
+ *   1. What is this workbench's lifecycle status, and how did it get there?
  *   2. What decisions did the Lead make, and on what?
  *   3. What decisions did the system make on its own (retries, promotions)?
  *   4. What did each worker conclude (outcome + stuck_reason)?
@@ -26,20 +26,20 @@ import type { WorkflowStatus } from "./workflow-store.ts";
  * the ledger past the point a human can usefully scan it.
  */
 
-export interface ReplayedNode {
-  node_id: string;
+export interface ReplayedDispatch {
+  dispatch_id: string;
   role: string;
-  status: NodeStatus;
+  status: DispatchStatus;
   intent_file: string;
   feedback_file?: string;
   approved: boolean;
   /** Total dispatches observed (initial + Lead redispatches + system retries). */
   dispatch_count: number;
-  /** Most recent worker verdict, if the node ever reported one. */
+  /** Most recent worker verdict, if the dispatch ever reported one. */
   last_outcome?: SubAgentOutcome;
   /** Sub-state Lead can route on when last_outcome === "stuck". */
   last_stuck_reason?: StuckReason;
-  /** Most recent failure code, if the node ever failed. */
+  /** Most recent failure code, if the dispatch ever failed. */
   last_failure_code?: string;
   /** Most recent failure message (human-readable). */
   last_failure_message?: string;
@@ -48,7 +48,7 @@ export interface ReplayedNode {
 }
 
 export interface SystemRetryEvent {
-  node_id: string;
+  dispatch_id: string;
   cause: "timeout" | "agent_reported_error";
   attempt: number;
   max_attempts: number;
@@ -57,29 +57,22 @@ export interface SystemRetryEvent {
   failure_message?: string;
 }
 
-export interface NodePromotionEvent {
-  node_id: string;
-  triggered_by: string[];
-}
-
 export interface ReplayedMerge {
-  source_nodes: string[];
+  source_dispatches: string[];
   outcome: "merged" | "conflict";
 }
 
-export interface ReplayedWorkflow {
-  status: WorkflowStatus;
+export interface ReplayedWorkbench {
+  status: WorkbenchStatus;
   intent_file?: string;
   lead_terminal_id?: string;
   result_file?: string;
   failure_reason?: string;
-  failed_node_id?: string;
-  nodes: Record<string, ReplayedNode>;
+  failed_dispatch_id?: string;
+  dispatches: Record<string, ReplayedDispatch>;
   merges: ReplayedMerge[];
   /** System decisions to retry an assignment after timeout / agent error. */
   system_retries: SystemRetryEvent[];
-  /** System decisions to promote blocked nodes to eligible. */
-  promotions: NodePromotionEvent[];
   /** Per-actor counts so callers can filter "what did Lead vs system do". */
   actor_counts: Record<LedgerActor, number>;
 }
@@ -110,11 +103,10 @@ export const INTENTIONALLY_NOT_LEDGERED = {
       "approved_refs",
     ],
     rationale:
-      "Workflow setup parameters are configuration, not decisions. They live in workflow.json and never change after init. Putting them in the ledger would bloat every audit scan with static config the reader does not need to judge.",
+      "Workflow setup parameters are configuration, not decisions. They live in workbench.json and never change after init. Putting them in the ledger would bloat every audit scan with static config the reader does not need to judge.",
   },
   node_configuration: {
     fields: [
-      "depends_on",
       "model",
       "retry_policy",
       "context_refs",
@@ -125,7 +117,7 @@ export const INTENTIONALLY_NOT_LEDGERED = {
       "assignment_id",
     ],
     rationale:
-      "Node-level configuration lives in workflow.json. The ledger records the dispatch *decision* (role, cause, intent_file). To answer 'is this dispatch correct', the reader judges the decision; to answer 'what config did it use', the reader drills into workflow.json.",
+      "Dispatch-level configuration lives in workbench.json. The ledger records the dispatch *decision* (role, cause, intent_file). To answer 'is this dispatch correct', the reader judges the decision; to answer 'what config did it use', the reader drills into workbench.json.",
   },
   assignment_state_machine: {
     fields: [
@@ -139,45 +131,44 @@ export const INTENTIONALLY_NOT_LEDGERED = {
       "result",
     ],
     rationale:
-      "AssignmentStateMachine internal state lives in assignment.json. The ledger records *user-meaningful* state-machine outcomes (assignment_retried, node_completed, node_failed) but not every claim_pending → claimed → in_progress micro-transition. Recording every micro-transition is the wrong granularity for 'is this decision correct'.",
+      "AssignmentStateMachine internal state lives in assignment.json. The ledger records *user-meaningful* state-machine outcomes (assignment_retried, dispatch_completed, dispatch_failed) but not every claim_pending → claimed → in_progress micro-transition. Recording every micro-transition is the wrong granularity for 'is this decision correct'.",
   },
 } as const;
 
 export interface ReplayResult {
-  workflow: ReplayedWorkflow;
+  workbench: ReplayedWorkbench;
 }
 
 export function replayLedger(entries: LedgerEntry[]): ReplayResult {
-  const workflow: ReplayedWorkflow = {
+  const workbench: ReplayedWorkbench = {
     status: "active",
-    nodes: {},
+    dispatches: {},
     merges: [],
     system_retries: [],
-    promotions: [],
     actor_counts: { lead: 0, worker: 0, system: 0 },
   };
 
   for (const entry of entries) {
-    workflow.actor_counts[entry.actor] = (workflow.actor_counts[entry.actor] ?? 0) + 1;
+    workbench.actor_counts[entry.actor] = (workbench.actor_counts[entry.actor] ?? 0) + 1;
 
     const { event } = entry;
     switch (event.type) {
-      case "workflow_created": {
-        workflow.intent_file = event.intent_file;
-        workflow.lead_terminal_id = event.lead_terminal_id;
-        workflow.status = "active";
+      case "workbench_created": {
+        workbench.intent_file = event.intent_file;
+        workbench.lead_terminal_id = event.lead_terminal_id;
+        workbench.status = "active";
         break;
       }
 
-      case "node_dispatched": {
-        const existing = workflow.nodes[event.node_id];
+      case "dispatch_started": {
+        const existing = workbench.dispatches[event.dispatch_id];
         if (existing) {
           existing.intent_file = event.intent_file;
           existing.dispatch_count += 1;
           existing.status = "dispatched";
         } else {
-          workflow.nodes[event.node_id] = {
-            node_id: event.node_id,
+          workbench.dispatches[event.dispatch_id] = {
+            dispatch_id: event.dispatch_id,
             role: event.role,
             status: "dispatched",
             intent_file: event.intent_file,
@@ -188,55 +179,48 @@ export function replayLedger(entries: LedgerEntry[]): ReplayResult {
         break;
       }
 
-      case "node_completed": {
-        const node = workflow.nodes[event.node_id];
-        if (node) {
-          node.status = "completed";
-          node.last_outcome = event.outcome;
-          node.last_stuck_reason = event.stuck_reason;
+      case "dispatch_completed": {
+        const disp = workbench.dispatches[event.dispatch_id];
+        if (disp) {
+          disp.status = "completed";
+          disp.last_outcome = event.outcome;
+          disp.last_stuck_reason = event.stuck_reason;
         }
         break;
       }
 
-      case "node_failed": {
-        const node = workflow.nodes[event.node_id];
-        if (node) {
-          node.status = "failed";
-          node.last_failure_code = event.failure_code;
-          node.last_failure_message = event.failure_message;
-          node.last_failure_report_file = event.report_file;
+      case "dispatch_failed": {
+        const disp = workbench.dispatches[event.dispatch_id];
+        if (disp) {
+          disp.status = "failed";
+          disp.last_failure_code = event.failure_code;
+          disp.last_failure_message = event.failure_message;
+          disp.last_failure_report_file = event.report_file;
         }
         break;
       }
 
-      case "node_reset": {
-        const node = workflow.nodes[event.node_id];
-        if (node) {
-          node.status = "reset";
-          node.feedback_file = event.feedback_file;
-          node.approved = false;
-        }
-        for (const cascadeId of event.cascade_targets) {
-          const cascade = workflow.nodes[cascadeId];
-          if (cascade) {
-            cascade.status = "blocked";
-            cascade.approved = false;
-          }
+      case "dispatch_reset": {
+        const disp = workbench.dispatches[event.dispatch_id];
+        if (disp) {
+          disp.status = "reset";
+          disp.feedback_file = event.feedback_file;
+          disp.approved = false;
         }
         break;
       }
 
-      case "node_approved": {
-        const node = workflow.nodes[event.node_id];
-        if (node) {
-          node.approved = true;
+      case "dispatch_approved": {
+        const disp = workbench.dispatches[event.dispatch_id];
+        if (disp) {
+          disp.approved = true;
         }
         break;
       }
 
-      case "assignment_retried": {
-        workflow.system_retries.push({
-          node_id: event.node_id,
+      case "dispatch_retried": {
+        workbench.system_retries.push({
+          dispatch_id: event.dispatch_id,
           cause: event.cause,
           attempt: event.attempt,
           max_attempts: event.max_attempts,
@@ -247,36 +231,28 @@ export function replayLedger(entries: LedgerEntry[]): ReplayResult {
         break;
       }
 
-      case "node_promoted_eligible": {
-        workflow.promotions.push({
-          node_id: event.node_id,
-          triggered_by: event.triggered_by,
-        });
-        break;
-      }
-
       case "merge_attempted": {
-        workflow.merges.push({
-          source_nodes: event.source_nodes,
+        workbench.merges.push({
+          source_dispatches: event.source_dispatches,
           outcome: event.outcome,
         });
         break;
       }
 
-      case "workflow_completed": {
-        workflow.status = "completed";
-        workflow.result_file = event.result_file;
+      case "workbench_completed": {
+        workbench.status = "completed";
+        workbench.result_file = event.result_file;
         break;
       }
 
-      case "workflow_failed": {
-        workflow.status = "failed";
-        workflow.failure_reason = event.reason;
-        workflow.failed_node_id = event.failed_node_id;
+      case "workbench_failed": {
+        workbench.status = "failed";
+        workbench.failure_reason = event.reason;
+        workbench.failed_dispatch_id = event.failed_dispatch_id;
         break;
       }
     }
   }
 
-  return { workflow };
+  return { workbench };
 }

--- a/hydra/src/roles/builtin/dev.md
+++ b/hydra/src/roles/builtin/dev.md
@@ -20,12 +20,10 @@ Dev owns implementation. You do not own verification testing — that is handled
 - **Verify your work builds** — compilation, type checks, and any existing tests that touch your change must still pass.
 - **Do not write new tests for your own change.** If you write tests for your own code, you test what you built, not what was asked for.
 
-If upstream reports contain verification plans or test expectations, read them for awareness — but do not let them constrain your implementation approach.
-
 ## Decision rules
 
 - Solve the real implementation problem first. Do not work around it with silent fallbacks, placeholder outputs, or weakened assertions.
-- If the upstream brief or assumptions fail in the real codebase, flag it in report.md rather than forcing a brittle implementation.
+- If the brief or assumptions fail in the real codebase, flag it in report.md rather than forcing a brittle implementation.
 - Do not expand scope beyond what the intent asks for. If you discover that the scope should be larger, surface it in report.md for Lead to decide.
 - Run existing tests before declaring completion. If your change breaks them:
   - If the failure is a regression in behavior, fix your implementation.
@@ -33,7 +31,7 @@ If upstream reports contain verification plans or test expectations, read them f
 
 ## Strategy
 
-- Read Lead's intent and any upstream reports as the contract for what to build. Plan your approach, then implement.
+- Read Lead's intent and any context refs as the contract for what to build. Plan your approach, then implement.
 - Prefer changing existing code over adding new abstractions.
 - When the path forward is ambiguous, pick the simplest approach that satisfies the intent and explain your reasoning in report.md.
 
@@ -44,4 +42,4 @@ The report must explain:
 - The approach taken and alternatives considered
 - Which risks remain and what is unverified
 - What downstream verification should focus on (concrete file:line references)
-- Any upstream assumptions that did not hold
+- Any assumptions from the brief that did not hold

--- a/hydra/src/roles/builtin/lead.md
+++ b/hydra/src/roles/builtin/lead.md
@@ -38,9 +38,7 @@ The intent is the contract between you and the dispatched role. Always include:
 - What other modules expect from this change (shared types, API contracts, data flow)
 - Constraints from the human or from upstream reports
 
-When upstream reports exist, include them as context — not as mandates.
-
-When dispatching a role that verifies other roles' work, always include the **original intent** as the primary reference, not a downstream role's interpretation of it.
+When dispatching a role that verifies other roles' work, always include the **original intent** as the primary reference, not a downstream role's interpretation of it. Use `--context-ref` to explicitly pass relevant reports from prior dispatches.
 
 Do not vary the amount of system context based on task size. Always give the full picture of where the work sits in the system.
 
@@ -85,7 +83,7 @@ After every node completes:
 3. If the report is incomplete or the outcome is `stuck`/`error`:
    - Reset the node with specific feedback (up to 2 retries)
    - After 2 failed retries, escalate to the human with what was tried
-4. Do not proceed to downstream nodes with incomplete upstream work
+4. Do not proceed to downstream dispatches with incomplete upstream work
 
 ## At each DecisionPoint
 

--- a/hydra/src/roles/builtin/qa.md
+++ b/hydra/src/roles/builtin/qa.md
@@ -19,7 +19,7 @@ You test the feature as a user would encounter it. You do not review code qualit
 ## Workflow
 
 1. **Read the intent** from Lead's dispatch — this tells you what the feature should do.
-2. **Read upstream reports** for context on what was built and any known risks.
+2. **Read any context refs** Lead provided for background on what was built and any known risks.
 3. **Write e2e tests** that exercise the feature through its public interface, the way a user would use it.
 4. **Run the tests.** Failures are your primary output.
 5. **Write report.md** with results.

--- a/hydra/src/roles/builtin/reviewer.md
+++ b/hydra/src/roles/builtin/reviewer.md
@@ -16,15 +16,15 @@ You run at the highest available reasoning effort because your job is to catch w
 
 ## Workflow
 
-1. **Read the original intent** from Lead's dispatch — this is your primary reference, not dev's report.
-2. **Read upstream reports** for context: what changed, what risks were flagged, where to focus.
+1. **Read the original intent** from Lead's dispatch — this is your primary reference.
+2. **Read any context refs** Lead provided for additional context: what changed, what risks were flagged, where to focus.
 3. **Read the diff** and trace each change back to the intent.
 4. **Write targeted verification tests** that prove the intent was met. Base these on what was asked for, not on what was implemented.
 5. **Run the tests.** Failures are hard evidence for your review.
 6. **Review the code** for correctness, edge cases, and anything the tests do not cover.
 7. **Write the report** with structured findings.
 
-If a verification plan or e2e test results exist in upstream reports, use them as input — they reflect the intent independently.
+If a verification plan or e2e test results exist in context refs, use them as input — they reflect the intent independently.
 
 ## What to test
 

--- a/hydra/src/roles/loader.ts
+++ b/hydra/src/roles/loader.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
  * Why `terminals: []` is an array, not a single field:
  *   - Different roles want different SOTA model + reasoning combinations
  *     (e.g. dev = Opus max, reviewer = GPT-5 xhigh).
- *   - Order expresses preference. dispatchNode picks `terminals[0]`
+ *   - Order expresses preference. dispatch picks `terminals[0]`
  *     today; future fallback logic can walk the array if the first CLI
  *     is unavailable. Project- and user-level role files can override
  *     the order without forking the schema.

--- a/hydra/src/run-task.ts
+++ b/hydra/src/run-task.ts
@@ -24,7 +24,7 @@ export interface TaskExtraSection {
 
 export interface RunTaskSpec {
   repoPath: string;
-  workflowId: string;
+  workbenchId: string;
   assignmentId: string;
   runId: string;
   role: string;
@@ -103,7 +103,7 @@ export function renderRunTask(spec: RunTaskSpec): string {
   lines.push(
     "## Run Context",
     "",
-    `- Workflow ID: ${spec.workflowId}`,
+    `- Workbench ID: ${spec.workbenchId}`,
     `- Assignment ID: ${spec.assignmentId}`,
     `- Run ID: ${spec.runId}`,
     "",
@@ -152,7 +152,7 @@ export function renderRunTask(spec: RunTaskSpec): string {
     "",
     "## Completion",
     "",
-    `- Finish every required write target before publishing ${path.basename(getRunResultFile(spec.repoPath, spec.workflowId, spec.assignmentId, spec.runId))}.`,
+    `- Finish every required write target before publishing ${path.basename(getRunResultFile(spec.repoPath, spec.workbenchId, spec.assignmentId, spec.runId))}.`,
     "- Make sure result.json reflects the real outcome, not a hopeful guess.",
     "",
   );
@@ -161,9 +161,9 @@ export function renderRunTask(spec: RunTaskSpec): string {
 }
 
 export function writeRunTask(spec: RunTaskSpec): RunArtifacts {
-  const taskFile = getRunTaskFile(spec.repoPath, spec.workflowId, spec.assignmentId, spec.runId);
-  const resultFile = getRunResultFile(spec.repoPath, spec.workflowId, spec.assignmentId, spec.runId);
-  const artifactDir = getRunArtifactsDir(spec.repoPath, spec.workflowId, spec.assignmentId, spec.runId);
+  const taskFile = getRunTaskFile(spec.repoPath, spec.workbenchId, spec.assignmentId, spec.runId);
+  const resultFile = getRunResultFile(spec.repoPath, spec.workbenchId, spec.assignmentId, spec.runId);
+  const artifactDir = getRunArtifactsDir(spec.repoPath, spec.workbenchId, spec.assignmentId, spec.runId);
   const runDir = path.dirname(taskFile);
 
   fs.mkdirSync(artifactDir, { recursive: true });

--- a/hydra/src/spawn.ts
+++ b/hydra/src/spawn.ts
@@ -159,7 +159,7 @@ export async function spawn(args: string[]): Promise<void> {
 
   const taskRun = writeRunTask({
     repoPath: repo,
-    workflowId,
+    workbenchId: workflowId,
     assignmentId,
     runId,
     role: "dev",
@@ -188,7 +188,7 @@ export async function spawn(args: string[]): Promise<void> {
 
   const parentTerminalId = process.env.TERMCANVAS_TERMINAL_ID;
   const dispatch = await dispatchCreateOnly({
-    workflowId,
+    workbenchId: workflowId,
     assignmentId,
     runId,
     repoPath: repo,

--- a/hydra/src/task-spec-builder.ts
+++ b/hydra/src/task-spec-builder.ts
@@ -1,16 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
-import { AssignmentManager } from "./assignment/manager.ts";
-import type { AssignmentRecord } from "./assignment/types.ts";
 import {
   getRunReportFile,
   getRunResultFile,
-  getWorkflowIntentFile,
+  getWorkbenchIntentFile,
 } from "./layout.ts";
 import { RESULT_SCHEMA_VERSION } from "./protocol.ts";
 import { loadRole } from "./roles/loader.ts";
 import type { RunTaskSpec, TaskFileRef, TaskWriteTarget } from "./run-task.ts";
-import type { WorkflowRecord, WorkflowNode } from "./workflow-store.ts";
+import type { AssignmentRecord } from "./assignment/types.ts";
+import type { WorkbenchRecord, Dispatch } from "./workflow-store.ts";
 
 function readFileOrEmpty(filePath: string): string {
   try { return fs.readFileSync(filePath, "utf-8"); } catch { return ""; }
@@ -27,7 +26,7 @@ const RESULT_CONTRACT_SECTION = {
   lines: [
     `result.json must contain ONLY these fields:`,
     `- schema_version: "${RESULT_SCHEMA_VERSION}"`,
-    "- workflow_id, assignment_id, run_id (from the Run Context section above)",
+    "- workbench_id, assignment_id, run_id (from the Run Context section above)",
     "- outcome: \"completed\" | \"stuck\" | \"error\"",
     "- report_file: relative path to your report.md (typically just \"report.md\")",
     "",
@@ -50,78 +49,34 @@ const RESULT_CONTRACT_SECTION = {
 // --- Builder ---
 
 export interface BuildTaskSpecInput {
-  workflow: WorkflowRecord;
-  node: WorkflowNode;
+  workbench: WorkbenchRecord;
+  dispatch: Dispatch;
   assignment: AssignmentRecord;
   runId: string;
 }
 
 export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec {
-  const { workflow, node, assignment, runId } = input;
-  const repoPath = workflow.repo_path;
+  const { workbench, dispatch: disp, assignment, runId } = input;
+  const repoPath = workbench.repo_path;
 
   // Resolve role from registry. agent_type is locked by the role file —
   // dispatchers must not override it. fail-fast on missing/malformed role.
-  const role = loadRole(node.role, repoPath);
+  const role = loadRole(disp.role, repoPath);
 
   // --- Objective: read intent file content ---
-  const intentText = readFileOrEmpty(resolvePath(repoPath, node.intent_file));
+  const intentText = readFileOrEmpty(resolvePath(repoPath, disp.intent_file));
   const objectiveLines: string[] = [
-    intentText.trim() || `(intent_file is empty: ${node.intent_file})`,
+    intentText.trim() || `(intent_file is empty: ${disp.intent_file})`,
   ];
 
   // --- Read files ---
   const readFiles: TaskFileRef[] = [
-    { label: "Workflow intent", path: getWorkflowIntentFile(repoPath, workflow.id) },
+    { label: "Workflow intent", path: getWorkbenchIntentFile(repoPath, workbench.id) },
   ];
 
-  // Auto-inject outputs from depends_on nodes (their report.md + result.json).
-  // We also collect a parallel list of "upstream summaries" — (role, nodeId,
-  // report path, session_id) tuples — that get rendered as an Upstream Nodes
-  // section below. Reviewer in particular needs a structured pointer to
-  // "here is what dev produced and how to follow up with it", not just a
-  // readFiles bag.
-  const manager = new AssignmentManager(repoPath, workflow.id);
-  interface UpstreamSummary {
-    nodeId: string;
-    role: string;
-    reportPath: string | null;
-    resultPath: string | null;
-    sessionId: string | null;
-    sessionProvider: string | null;
-  }
-  const upstreamSummaries: UpstreamSummary[] = [];
-  for (const depId of node.depends_on) {
-    const depNode = workflow.nodes[depId];
-    if (!depNode?.assignment_id) continue;
-    const depAssignment = manager.load(depNode.assignment_id);
-    if (!depAssignment) continue;
-    const depRun = depAssignment.active_run_id
-      ? depAssignment.runs.find((r) => r.id === depAssignment.active_run_id)
-      : depAssignment.runs[depAssignment.runs.length - 1];
-    if (!depRun) continue;
-    const reportPath = getRunReportFile(repoPath, workflow.id, depAssignment.id, depRun.id);
-    const reportExists = fs.existsSync(reportPath);
-    if (reportExists) {
-      readFiles.push({ label: `${depNode.role} report (${depId})`, path: reportPath });
-    }
-    const resultExists = fs.existsSync(depRun.result_file);
-    if (resultExists) {
-      readFiles.push({ label: `${depNode.role} result (${depId})`, path: depRun.result_file });
-    }
-    upstreamSummaries.push({
-      nodeId: depId,
-      role: depNode.role,
-      reportPath: reportExists ? reportPath : null,
-      resultPath: resultExists ? depRun.result_file : null,
-      sessionId: depRun.session_id ?? null,
-      sessionProvider: depRun.session_provider ?? null,
-    });
-  }
-
   // Auto-inject approved refs
-  if (workflow.approved_refs) {
-    for (const [refNodeId, ref] of Object.entries(workflow.approved_refs)) {
+  if (workbench.approved_refs) {
+    for (const [refNodeId, ref] of Object.entries(workbench.approved_refs)) {
       if (fs.existsSync(ref.brief_file)) {
         readFiles.push({ label: `Approved report (${refNodeId})`, path: ref.brief_file });
       }
@@ -132,8 +87,8 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
   }
 
   // Add extra context refs provided by Lead (supplements)
-  if (node.context_refs) {
-    for (const ref of node.context_refs) {
+  if (disp.context_refs) {
+    for (const ref of disp.context_refs) {
       if (fs.existsSync(ref.path)) {
         readFiles.push({ label: ref.label, path: ref.path });
       }
@@ -141,8 +96,8 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
   }
 
   // Add feedback file if present (from reset)
-  if (node.feedback_file) {
-    const feedbackAbs = resolvePath(repoPath, node.feedback_file);
+  if (disp.feedback_file) {
+    const feedbackAbs = resolvePath(repoPath, disp.feedback_file);
     if (fs.existsSync(feedbackAbs)) {
       readFiles.push({ label: "Feedback from Lead", path: feedbackAbs });
     }
@@ -161,8 +116,8 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
   readFiles.push(...dedupedReadFiles);
 
   // --- Write targets ---
-  const reportFile = getRunReportFile(repoPath, workflow.id, assignment.id, runId);
-  const resultFile = getRunResultFile(repoPath, workflow.id, assignment.id, runId);
+  const reportFile = getRunReportFile(repoPath, workbench.id, assignment.id, runId);
+  const resultFile = getRunResultFile(repoPath, workbench.id, assignment.id, runId);
 
   const writeTargets: TaskWriteTarget[] = [
     {
@@ -200,19 +155,19 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
   const extraSections: { title: string; lines: string[] }[] = [];
 
   const workflowContextLines: string[] = [];
-  if (workflow.human_request && workflow.human_request.trim()) {
+  if (workbench.human_request && workbench.human_request.trim()) {
     workflowContextLines.push("**Original human request:**");
-    workflowContextLines.push(workflow.human_request.trim());
+    workflowContextLines.push(workbench.human_request.trim());
     workflowContextLines.push("");
   }
-  if (workflow.overall_plan && workflow.overall_plan.trim()) {
+  if (workbench.overall_plan && workbench.overall_plan.trim()) {
     workflowContextLines.push("**Lead's overall plan:**");
-    workflowContextLines.push(workflow.overall_plan.trim());
+    workflowContextLines.push(workbench.overall_plan.trim());
     workflowContextLines.push("");
   }
-  if (workflow.shared_constraints && workflow.shared_constraints.length > 0) {
+  if (workbench.shared_constraints && workbench.shared_constraints.length > 0) {
     workflowContextLines.push("**Workflow-wide constraints (apply to every node):**");
-    for (const c of workflow.shared_constraints) {
+    for (const c of workbench.shared_constraints) {
       workflowContextLines.push(`- ${c}`);
     }
     workflowContextLines.push("");
@@ -228,49 +183,21 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
     });
   }
 
-  if (upstreamSummaries.length > 0) {
-    const lines: string[] = [
-      "These upstream nodes already ran and their outputs are in your Read First list.",
-      "Read their report.md before forming conclusions — they contain self-assessment,",
-      "risks, and guidance written by the upstream worker itself.",
-      "",
-    ];
-    for (const s of upstreamSummaries) {
-      lines.push(`### ${s.role} (node: ${s.nodeId})`);
-      if (s.reportPath) lines.push(`- Report: ${s.reportPath}`);
-      if (s.resultPath) lines.push(`- Result: ${s.resultPath}`);
-      if (s.sessionId) {
-        // The session id is what `hydra ask` uses to spin up a one-shot
-        // follow-up subprocess via `claude --resume` / `codex exec resume`.
-        lines.push(
-          `- Session id: \`${s.sessionId}\` (${s.sessionProvider ?? "unknown"}) — Lead can ask follow-up questions via \`hydra ask --workflow <id> --node ${s.nodeId} --message "..."\``,
-        );
-      }
-      lines.push("");
-    }
-    // Trim trailing blank line.
-    while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-    extraSections.push({
-      title: "Upstream Nodes",
-      lines,
-    });
-  }
-
   extraSections.push(RESULT_CONTRACT_SECTION);
 
   return {
-    repoPath: workflow.repo_path,
-    workflowId: workflow.id,
+    repoPath: workbench.repo_path,
+    workbenchId: workbench.id,
     assignmentId: assignment.id,
     runId,
-    role: node.role,
-    // Cached on the node at dispatch time from the chosen role terminal.
-    // task-spec-builder reads from the node, not the role, because the
-    // node carries the locked-in choice; the role file's terminals[]
+    role: disp.role,
+    // Cached on the dispatch at dispatch time from the chosen role terminal.
+    // task-spec-builder reads from the dispatch, not the role, because the
+    // dispatch carries the locked-in choice; the role file's terminals[]
     // could in principle change between dispatches.
-    agentType: node.agent_type,
-    model: node.model,
-    reasoningEffort: node.reasoning_effort,
+    agentType: disp.agent_type,
+    model: disp.model,
+    reasoningEffort: disp.reasoning_effort,
     sourceRole: null,
     roleBody: role.body,
     objective: objectiveLines,

--- a/hydra/src/workflow-lead.ts
+++ b/hydra/src/workflow-lead.ts
@@ -21,21 +21,21 @@ import { loadRole } from "./roles/loader.ts";
 import { writeRunTask } from "./run-task.ts";
 import { buildTaskSpecFromIntent } from "./task-spec-builder.ts";
 import {
-  clearNodeFeedback,
-  writeNodeFeedback,
-  writeNodeIntent,
-  writeWorkflowIntent,
-  writeWorkflowSummary,
+  clearDispatchFeedback,
+  writeDispatchFeedback,
+  writeDispatchIntent,
+  writeWorkbenchIntent,
+  writeWorkbenchSummary,
 } from "./artifacts.ts";
 import {
-  deleteWorkflow,
-  loadWorkflow,
-  saveWorkflow,
-  WORKFLOW_STATE_SCHEMA_VERSION,
+  deleteWorkbench,
+  loadWorkbench,
+  saveWorkbench,
+  WORKBENCH_STATE_SCHEMA_VERSION,
   type RetryPolicy,
-  type WorkflowFailure,
-  type WorkflowNode,
-  type WorkflowRecord,
+  type WorkbenchFailure,
+  type Dispatch,
+  type WorkbenchRecord,
 } from "./workflow-store.ts";
 import {
   ensureProjectTracked,
@@ -47,18 +47,18 @@ import {
 } from "./termcanvas.ts";
 import { buildGitWorktreeAddArgs, validateWorktreePath } from "./spawn.ts";
 import {
-  getNodeFeedbackFile,
-  getNodeIntentFile,
+  getDispatchFeedbackFile,
+  getDispatchIntentFile,
   getRunReportFile,
   getRunResultFile,
   getRunTaskFile,
-  getWorkflowIntentFile,
-  getWorkflowSummaryFile,
+  getWorkbenchIntentFile,
+  getWorkbenchSummaryFile,
 } from "./layout.ts";
 import { appendLedger } from "./ledger.ts";
 import { ensureLeadCaller } from "./lead-guard.ts";
 import { askFollowUp, type AskFollowUpResult } from "./ask.ts";
-import type { DecisionPoint, NodeStatus } from "./decision.ts";
+import type { DecisionPoint, DispatchStatus } from "./decision.ts";
 import type { LeadAssessment } from "./ledger.ts";
 
 // --- Constants ---
@@ -67,7 +67,7 @@ const SPAWN_GRACE_PERIOD_MS = 15_000;
 
 // --- Dependencies ---
 
-export interface WorkflowDependencies {
+export interface WorkbenchDependencies {
   now?: () => string;
   dispatchCreateOnly?: (request: DispatchCreateOnlyRequest) => Promise<DispatchCreateOnlyResult>;
   sleep?: (ms: number) => Promise<void>;
@@ -75,7 +75,7 @@ export interface WorkflowDependencies {
   destroyTerminal?: (terminalId: string) => void;
   checkTerminalAlive?: (terminalId: string) => boolean | null;
   /**
-   * Test seam for `askNode`. In production this delegates to
+   * Test seam for `askDispatch`. In production this delegates to
    * askFollowUp from ./ask.ts, which spawns a real claude/codex
    * subprocess. Tests inject a fake that returns a deterministic
    * answer without touching the network.
@@ -91,26 +91,26 @@ export interface WorkflowDependencies {
 
 const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-function nowFn(deps?: WorkflowDependencies): () => string {
+function nowFn(deps?: WorkbenchDependencies): () => string {
   return deps?.now ?? (() => new Date().toISOString());
 }
-function dispatchFn(deps?: WorkflowDependencies) {
+function dispatchFn(deps?: WorkbenchDependencies) {
   return deps?.dispatchCreateOnly ?? defaultDispatchCreateOnly;
 }
-function sleepFn(deps?: WorkflowDependencies) {
+function sleepFn(deps?: WorkbenchDependencies) {
   return deps?.sleep ?? DEFAULT_SLEEP;
 }
-function syncProjectFn(deps?: WorkflowDependencies) {
+function syncProjectFn(deps?: WorkbenchDependencies) {
   if (deps?.syncProject) return deps.syncProject;
   if (deps?.dispatchCreateOnly) return (_: string) => {};
   return ensureProjectTracked;
 }
-function destroyTerminalFn(deps?: WorkflowDependencies) {
+function destroyTerminalFn(deps?: WorkbenchDependencies) {
   if (deps?.destroyTerminal) return deps.destroyTerminal;
   if (deps?.dispatchCreateOnly) return (_: string) => {};
   return terminalDestroy;
 }
-function checkTerminalAliveFn(deps?: WorkflowDependencies): (id: string) => boolean | null {
+function checkTerminalAliveFn(deps?: WorkbenchDependencies): (id: string) => boolean | null {
   if (deps?.checkTerminalAlive) return deps.checkTerminalAlive;
   return (_id: string) => {
     try {
@@ -122,8 +122,8 @@ function checkTerminalAliveFn(deps?: WorkflowDependencies): (id: string) => bool
 
 // --- ID generation ---
 
-function generateWorkflowId(): string {
-  return `workflow-${crypto.randomBytes(6).toString("hex")}`;
+function generateWorkbenchId(): string {
+  return `workbench-${crypto.randomBytes(6).toString("hex")}`;
 }
 function generateAssignmentId(): string {
   return `assignment-${crypto.randomBytes(6).toString("hex")}`;
@@ -142,11 +142,11 @@ function getCurrentBranch(repoPath: string): string {
   } catch { return "main"; }
 }
 
-function prepareWorkflowWorkspace(
+function prepareWorkbenchWorkspace(
   repoPath: string,
-  workflowId: string,
+  workbenchId: string,
   requestedWorktreePath: string | undefined,
-  deps?: WorkflowDependencies,
+  deps?: WorkbenchDependencies,
 ): { worktreePath: string; branch: string | null; baseBranch: string; ownWorktree: boolean } {
   const repo = path.resolve(repoPath);
   const baseBranch = getCurrentBranch(repo);
@@ -156,8 +156,8 @@ function prepareWorkflowWorkspace(
     return { worktreePath: validateWorktreePath(repo, requestedWorktreePath), branch: null, baseBranch, ownWorktree: false };
   }
 
-  const branch = `hydra/${workflowId}`;
-  const worktreePath = path.join(repo, ".worktrees", workflowId);
+  const branch = `hydra/${workbenchId}`;
+  const worktreePath = path.join(repo, ".worktrees", workbenchId);
   execFileSync("git", buildGitWorktreeAddArgs(branch, worktreePath, baseBranch), { cwd: repo, encoding: "utf-8" });
   const project = findProjectByPath(repo);
   if (project) { projectRescan(project.id); } else { syncProjectFn(deps)(repo); }
@@ -166,26 +166,26 @@ function prepareWorkflowWorkspace(
 
 // --- Loading helpers ---
 
-function loadWorkflowOrThrow(repoPath: string, workflowId: string): WorkflowRecord {
-  const workflow = loadWorkflow(repoPath, workflowId);
-  if (!workflow) {
-    throw new HydraError(`Workflow not found: ${workflowId}`, {
-      errorCode: "WORKFLOW_NOT_FOUND", stage: "workflow.load", ids: { workflow_id: workflowId },
+function loadWorkbenchOrThrow(repoPath: string, workbenchId: string): WorkbenchRecord {
+  const workbench = loadWorkbench(repoPath, workbenchId);
+  if (!workbench) {
+    throw new HydraError(`Workbench not found: ${workbenchId}`, {
+      errorCode: "WORKBENCH_NOT_FOUND", stage: "workbench.load", ids: { workbench_id: workbenchId },
     });
   }
-  return workflow;
+  return workbench;
 }
 
-function managerForWorkflow(workflow: WorkflowRecord): AssignmentManager {
-  return new AssignmentManager(workflow.repo_path, workflow.id);
+function managerForWorkbench(workbench: WorkbenchRecord): AssignmentManager {
+  return new AssignmentManager(workbench.repo_path, workbench.id);
 }
 
-function loadAssignmentByIdOrThrow(manager: AssignmentManager, workflow: WorkflowRecord, assignmentId: string): AssignmentRecord {
+function loadAssignmentByIdOrThrow(manager: AssignmentManager, workbench: WorkbenchRecord, assignmentId: string): AssignmentRecord {
   const assignment = manager.load(assignmentId);
   if (!assignment) {
     throw new HydraError(`Assignment not found: ${assignmentId}`, {
-      errorCode: "WORKFLOW_ASSIGNMENT_NOT_FOUND", stage: "workflow.load_assignment",
-      ids: { workflow_id: workflow.id, assignment_id: assignmentId },
+      errorCode: "WORKBENCH_ASSIGNMENT_NOT_FOUND", stage: "workbench.load_assignment",
+      ids: { workbench_id: workbench.id, assignment_id: assignmentId },
     });
   }
   return assignment;
@@ -200,7 +200,7 @@ function latestRun(assignment: AssignmentRecord): AssignmentRecord["runs"][numbe
 
 async function destroyAssignmentTerminal(
   assignment: AssignmentRecord,
-  deps?: WorkflowDependencies,
+  deps?: WorkbenchDependencies,
 ): Promise<void> {
   const run = latestRun(assignment);
   if (!run?.terminal_id) return;
@@ -224,54 +224,6 @@ async function destroyAssignmentTerminal(
   try { destroyTerminalFn(deps)(run.terminal_id); } catch {}
 }
 
-// --- Dependency tracking ---
-
-function allDepsCompleted(workflow: WorkflowRecord, node: WorkflowNode): boolean {
-  return node.depends_on.every((depId) => workflow.node_statuses[depId] === "completed");
-}
-
-function promoteEligibleNodes(workflow: WorkflowRecord): string[] {
-  const promoted: string[] = [];
-  for (const [id, status] of Object.entries(workflow.node_statuses)) {
-    if (status !== "blocked") continue;
-    const node = workflow.nodes[id];
-    if (node && allDepsCompleted(workflow, node)) {
-      workflow.node_statuses[id] = "eligible";
-      promoted.push(id);
-    }
-  }
-  return promoted;
-}
-
-function cascadeReset(workflow: WorkflowRecord, nodeId: string): string[] {
-  const resetIds: string[] = [];
-  function collect(id: string): void {
-    if (resetIds.includes(id)) return;
-    resetIds.push(id);
-    for (const [childId, childNode] of Object.entries(workflow.nodes)) {
-      if (childNode.depends_on.includes(id)) collect(childId);
-    }
-  }
-  collect(nodeId);
-  // Target node → eligible (its own deps are already met); downstream → blocked
-  for (const id of resetIds) {
-    workflow.node_statuses[id] = id === nodeId ? "eligible" : "blocked";
-  }
-  return resetIds;
-}
-
-function hasCycle(workflow: WorkflowRecord, newNodeId: string, dependsOn: string[]): boolean {
-  const visited = new Set<string>();
-  function visit(id: string): boolean {
-    if (id === newNodeId) return true;
-    if (visited.has(id)) return false;
-    visited.add(id);
-    const node = workflow.nodes[id];
-    if (!node) return false;
-    return node.depends_on.some(visit);
-  }
-  return dependsOn.some(visit);
-}
 
 // --- Dispatch helper ---
 
@@ -290,32 +242,32 @@ function findResumableSessionId(
 }
 
 function buildDispatchRequest(
-  workflow: WorkflowRecord, assignment: AssignmentRecord, node: WorkflowNode, runId: string,
+  workbench: WorkbenchRecord, assignment: AssignmentRecord, disp: Dispatch, runId: string,
 ): DispatchCreateOnlyRequest {
   return {
-    workflowId: workflow.id, assignmentId: assignment.id, runId,
-    repoPath: workflow.repo_path,
-    worktreePath: node.worktree_path ?? workflow.worktree_path,
+    workbenchId: workbench.id, assignmentId: assignment.id, runId,
+    repoPath: workbench.repo_path,
+    worktreePath: disp.worktree_path ?? workbench.worktree_path,
     agentType: assignment.requested_agent_type,
-    model: node.model,
-    reasoningEffort: node.reasoning_effort,
-    taskFile: getRunTaskFile(workflow.repo_path, workflow.id, assignment.id, runId),
-    resultFile: getRunResultFile(workflow.repo_path, workflow.id, assignment.id, runId),
-    autoApprove: workflow.auto_approve,
-    parentTerminalId: workflow.lead_terminal_id,
+    model: disp.model,
+    reasoningEffort: disp.reasoning_effort,
+    taskFile: getRunTaskFile(workbench.repo_path, workbench.id, assignment.id, runId),
+    resultFile: getRunResultFile(workbench.repo_path, workbench.id, assignment.id, runId),
+    autoApprove: workbench.auto_approve,
+    parentTerminalId: workbench.lead_terminal_id,
     resumeSessionId: findResumableSessionId(assignment),
   };
 }
 
 async function dispatchAssignment(
-  workflow: WorkflowRecord, assignment: AssignmentRecord, node: WorkflowNode,
-  runId: string, deps?: WorkflowDependencies,
-): Promise<{ status: "dispatched" | "failed"; terminalId?: string; failure?: WorkflowFailure }> {
+  workbench: WorkbenchRecord, assignment: AssignmentRecord, disp: Dispatch,
+  runId: string, deps?: WorkbenchDependencies,
+): Promise<{ status: "dispatched" | "failed"; terminalId?: string; failure?: WorkbenchFailure }> {
   const now = nowFn(deps);
   const sleep = sleepFn(deps);
-  const manager = managerForWorkflow(workflow);
+  const manager = managerForWorkbench(workbench);
   const stateMachine = new AssignmentStateMachine(manager, { now });
-  const tickId = `tick:${workflow.id}:${now()}`;
+  const tickId = `tick:${workbench.id}:${now()}`;
 
   // Honor retry backoff: scheduleRetry stamps next_retry_at when a policy
   // configures initial_interval_ms. Wait inline before claiming so the
@@ -326,39 +278,38 @@ async function dispatchAssignment(
   }
 
   const claim = await stateMachine.claimPending(assignment.id, tickId);
-  if (!claim.changed) return { status: "failed", failure: { code: "CLAIM_FAILED", message: "Could not claim assignment", stage: "workflow.dispatch" } };
+  if (!claim.changed) return { status: "failed", failure: { code: "CLAIM_FAILED", message: "Could not claim assignment", stage: "workbench.dispatch" } };
 
-  const taskSpec = buildTaskSpecFromIntent({ workflow, node, assignment, runId });
+  const taskSpec = buildTaskSpecFromIntent({ workbench, dispatch: disp, assignment, runId });
   let dispatchedTerminalId: string | undefined;
   try {
     const runArtifacts = writeRunTask(taskSpec);
-    const dispatch = await dispatchFn(deps)(buildDispatchRequest(workflow, assignment, node, runId));
-    dispatchedTerminalId = dispatch.terminalId;
+    const dispatchResult = await dispatchFn(deps)(buildDispatchRequest(workbench, assignment, disp, runId));
+    dispatchedTerminalId = dispatchResult.terminalId;
     registerDispatchAttempt(manager, assignment.id, {
-      runId, terminalId: dispatch.terminalId, agentType: dispatch.terminalType as AgentType,
-      prompt: dispatch.prompt, taskFile: runArtifacts.task_file, resultFile: runArtifacts.result_file,
+      runId, terminalId: dispatchResult.terminalId, agentType: dispatchResult.terminalType as AgentType,
+      prompt: dispatchResult.prompt, taskFile: runArtifacts.task_file, resultFile: runArtifacts.result_file,
       artifactDir: runArtifacts.artifact_dir, startedAt: now(),
     });
     await stateMachine.markInProgress(assignment.id, { tickId, runId });
-    return { status: "dispatched", terminalId: dispatch.terminalId };
+    return { status: "dispatched", terminalId: dispatchResult.terminalId };
   } catch (error) {
     if (dispatchedTerminalId) { try { destroyTerminalFn(deps)(dispatchedTerminalId); } catch {} }
-    const failure: WorkflowFailure = {
+    const failure: WorkbenchFailure = {
       code: "ASSIGNMENT_DISPATCH_FAILED",
       message: error instanceof Error ? error.message : String(error),
-      stage: "workflow.dispatch",
+      stage: "workbench.dispatch",
     };
     try { await stateMachine.markFailed(assignment.id, failure); } catch {}
     return { status: "failed", failure };
   }
 }
 
-// --- Node status snapshot for DecisionPoint ---
+// --- Dispatch status snapshot for DecisionPoint ---
 
-function buildNodesSummary(workflow: WorkflowRecord): DecisionPoint["nodes"] {
-  return Object.entries(workflow.nodes).map(([id, node]) => ({
-    node_id: id, role: node.role, status: workflow.node_statuses[id] ?? "blocked",
-    depends_on: node.depends_on, assignment_id: node.assignment_id,
+function buildDispatchesSummary(workbench: WorkbenchRecord): DecisionPoint["dispatches"] {
+  return Object.entries(workbench.dispatches).map(([id, disp]) => ({
+    dispatch_id: id, role: disp.role, status: disp.status,
   }));
 }
 
@@ -366,9 +317,9 @@ function buildNodesSummary(workflow: WorkflowRecord): DecisionPoint["nodes"] {
 // Public API
 // ============================================================
 
-// --- initWorkflow ---
+// --- initWorkbench ---
 
-export interface InitWorkflowOptions {
+export interface InitWorkbenchOptions {
   intent: string;
   repoPath: string;
   worktreePath?: string;
@@ -376,48 +327,48 @@ export interface InitWorkflowOptions {
   defaultMaxRetries?: number;
   autoApprove?: boolean;
   /**
-   * Optional workflow-level shared context. These fields are persisted on
-   * the WorkflowRecord and broadcast to every dispatched node's task.md
+   * Optional workbench-level shared context. These fields are persisted on
+   * the WorkbenchRecord and broadcast to every dispatched task's task.md
    * under a `## Workflow Context` section. They exist so Dev and Reviewer
    * can see the wider picture (the original human ask, Lead's overall plan,
-   * workflow-wide constraints) instead of working from only their local
-   * node intent.
+   * workbench-wide constraints) instead of working from only their local
+   * dispatch intent.
    */
   humanRequest?: string;
   overallPlan?: string;
   sharedConstraints?: string[];
 }
 
-export interface InitWorkflowResult {
-  workflow_id: string;
+export interface InitWorkbenchResult {
+  workbench_id: string;
   worktree_path: string;
   branch: string | null;
   base_branch: string;
 }
 
-export async function initWorkflow(
-  options: InitWorkflowOptions, deps?: WorkflowDependencies,
-): Promise<InitWorkflowResult> {
+export async function initWorkbench(
+  options: InitWorkbenchOptions, deps?: WorkbenchDependencies,
+): Promise<InitWorkbenchResult> {
   const now = nowFn(deps);
   const repoPath = path.resolve(options.repoPath);
-  const workflowId = generateWorkflowId();
+  const workbenchId = generateWorkbenchId();
 
-  // Lead identity comes from the calling terminal. Without it, the workflow
+  // Lead identity comes from the calling terminal. Without it, the workbench
   // has no owner and lead-guard cannot enforce single-Lead semantics.
   const leadTerminalId = process.env.TERMCANVAS_TERMINAL_ID;
   if (!leadTerminalId) {
     throw new HydraError(
-      "Cannot init workflow: TERMCANVAS_TERMINAL_ID is not set. The Lead must be a TermCanvas terminal.",
-      { errorCode: "WORKFLOW_NO_LEAD", stage: "workflow.init" },
+      "Cannot init workbench: TERMCANVAS_TERMINAL_ID is not set. The Lead must be a TermCanvas terminal.",
+      { errorCode: "WORKBENCH_NO_LEAD", stage: "workbench.init" },
     );
   }
 
-  const workspace = prepareWorkflowWorkspace(repoPath, workflowId, options.worktreePath, deps);
-  const intentFile = writeWorkflowIntent(repoPath, workflowId, options.intent);
+  const workspace = prepareWorkbenchWorkspace(repoPath, workbenchId, options.worktreePath, deps);
+  const intentFile = writeWorkbenchIntent(repoPath, workbenchId, options.intent);
 
-  const workflow: WorkflowRecord = {
-    schema_version: WORKFLOW_STATE_SCHEMA_VERSION,
-    id: workflowId,
+  const workbench: WorkbenchRecord = {
+    schema_version: WORKBENCH_STATE_SCHEMA_VERSION,
+    id: workbenchId,
     lead_terminal_id: leadTerminalId,
     intent_file: path.relative(repoPath, intentFile),
     repo_path: repoPath,
@@ -427,8 +378,7 @@ export async function initWorkflow(
     own_worktree: workspace.ownWorktree,
     created_at: now(), updated_at: now(),
     status: "active",
-    nodes: {}, node_statuses: {},
-    assignment_ids: [],
+    dispatches: {},
     default_timeout_minutes: options.defaultTimeoutMinutes ?? 30,
     default_max_retries: options.defaultMaxRetries ?? 1,
     auto_approve: options.autoApprove ?? true,
@@ -438,27 +388,27 @@ export async function initWorkflow(
       ? { shared_constraints: options.sharedConstraints }
       : {}),
   };
-  saveWorkflow(workflow);
-  appendLedger(repoPath, workflowId, "lead", {
-    type: "workflow_created",
-    intent_file: workflow.intent_file,
+  saveWorkbench(workbench);
+  appendLedger(repoPath, workbenchId, "lead", {
+    type: "workbench_created",
+    intent_file: workbench.intent_file,
     lead_terminal_id: leadTerminalId,
   });
 
   return {
-    workflow_id: workflowId,
+    workbench_id: workbenchId,
     worktree_path: workspace.worktreePath,
     branch: workspace.branch,
     base_branch: workspace.baseBranch,
   };
 }
 
-// --- dispatchNode ---
+// --- dispatch ---
 
-export interface DispatchNodeOptions {
+export interface DispatchOptions {
   repoPath: string;
-  workflowId: string;
-  nodeId: string;
+  workbenchId: string;
+  dispatchId: string;
   /**
    * Role name from the registry (e.g. "dev", "reviewer").
    * The role file's terminals[] array locks cli/model/reasoning_effort —
@@ -466,7 +416,6 @@ export interface DispatchNodeOptions {
    */
   role: string;
   intent: string;
-  dependsOn?: string[];
   /**
    * Optional model override that takes precedence over the role file's
    * frontmatter `model`. Validated against the resolved CLI adapter at
@@ -480,55 +429,40 @@ export interface DispatchNodeOptions {
   timeoutMinutes?: number;
   maxRetries?: number;
   /**
-   * Declarative retry policy for this node. When set, takes precedence over
+   * Declarative retry policy for this dispatch. When set, takes precedence over
    * maxRetries and enables exponential backoff + non-retryable error codes.
    */
   retryPolicy?: RetryPolicy;
   /**
-   * Lead's pre-dispatch assessment of coupling × novelty for this node.
+   * Lead's pre-dispatch assessment for this dispatch.
    * Recorded in the ledger for audit. Not enforced by Hydra — the Lead
    * is trusted to self-assess and choose the right intervention mode.
    */
   assessment?: LeadAssessment;
 }
 
-export interface DispatchNodeResult {
-  node_id: string;
-  assignment_id: string;
-  status: "dispatched" | "blocked" | "failed";
+export interface DispatchResult {
+  dispatch_id: string;
+  status: "dispatched" | "failed";
   terminal_id?: string;
-  failure?: WorkflowFailure;
+  failure?: WorkbenchFailure;
 }
 
-export async function dispatchNode(
-  options: DispatchNodeOptions, deps?: WorkflowDependencies,
-): Promise<DispatchNodeResult> {
+export async function dispatch(
+  options: DispatchOptions, deps?: WorkbenchDependencies,
+): Promise<DispatchResult> {
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
 
-  if (workflow.status !== "active") {
-    throw new HydraError(`Workflow is not active: ${workflow.status}`, {
-      errorCode: "WORKFLOW_NOT_ACTIVE", stage: "workflow.dispatch_node", ids: { workflow_id: workflow.id },
+  if (workbench.status !== "active") {
+    throw new HydraError(`Workbench is not active: ${workbench.status}`, {
+      errorCode: "WORKBENCH_NOT_ACTIVE", stage: "workbench.dispatch", ids: { workbench_id: workbench.id },
     });
   }
-  if (workflow.nodes[options.nodeId]) {
-    throw new HydraError(`Node already exists: ${options.nodeId}`, {
-      errorCode: "WORKFLOW_NODE_EXISTS", stage: "workflow.dispatch_node", ids: { workflow_id: workflow.id },
-    });
-  }
-
-  const dependsOn = options.dependsOn ?? [];
-  for (const depId of dependsOn) {
-    if (!workflow.nodes[depId]) {
-      throw new HydraError(`Dependency node not found: ${depId}`, {
-        errorCode: "WORKFLOW_DEP_NOT_FOUND", stage: "workflow.dispatch_node", ids: { workflow_id: workflow.id },
-      });
-    }
-  }
-  if (hasCycle(workflow, options.nodeId, dependsOn)) {
-    throw new HydraError(`Adding node "${options.nodeId}" would create a cycle`, {
-      errorCode: "WORKFLOW_CYCLE", stage: "workflow.dispatch_node", ids: { workflow_id: workflow.id },
+  if (workbench.dispatches[options.dispatchId]) {
+    throw new HydraError(`Dispatch already exists: ${options.dispatchId}`, {
+      errorCode: "WORKBENCH_DISPATCH_EXISTS", stage: "workbench.dispatch", ids: { workbench_id: workbench.id },
     });
   }
 
@@ -544,153 +478,136 @@ export async function dispatchNode(
   const model = options.model ?? chosenTerminal.model;
   const reasoningEffort = chosenTerminal.reasoning_effort;
 
-  // Create node — write intent to nodes/{id}/intent.md
-  const intentFileAbs = writeNodeIntent(repoPath, workflow.id, options.nodeId, options.role, options.intent);
+  // Create dispatch — write intent to dispatches/{id}/intent.md
+  const intentFileAbs = writeDispatchIntent(repoPath, workbench.id, options.dispatchId, options.role, options.intent);
   let feedbackFileRel: string | undefined;
   if (options.feedback) {
-    const feedbackAbs = writeNodeFeedback(repoPath, workflow.id, options.nodeId, options.feedback);
+    const feedbackAbs = writeDispatchFeedback(repoPath, workbench.id, options.dispatchId, options.feedback);
     feedbackFileRel = path.relative(repoPath, feedbackAbs);
   }
 
-  const node: WorkflowNode = {
-    id: options.nodeId, role: options.role, depends_on: dependsOn, agent_type: agentType,
+  const disp: Dispatch = {
+    id: options.dispatchId, role: options.role, agent_type: agentType,
     model,
     reasoning_effort: reasoningEffort,
+    status: "eligible",
     intent_file: path.relative(repoPath, intentFileAbs),
     feedback_file: feedbackFileRel,
     context_refs: options.contextRefs,
     worktree_path: options.worktreePath, worktree_branch: options.worktreeBranch,
-    timeout_minutes: options.timeoutMinutes ?? workflow.default_timeout_minutes,
-    max_retries: options.maxRetries ?? workflow.default_max_retries,
+    timeout_minutes: options.timeoutMinutes ?? workbench.default_timeout_minutes,
+    max_retries: options.maxRetries ?? workbench.default_max_retries,
     retry_policy: options.retryPolicy,
   };
 
   // Create assignment — snapshot the retry_policy onto the assignment so the
-  // state machine never has to load the workflow to make retry decisions.
-  const manager = managerForWorkflow(workflow);
-  const assignmentId = generateAssignmentId();
-  const fromAssignmentId = dependsOn.length > 0
-    ? workflow.nodes[dependsOn[0]]?.assignment_id ?? null : null;
+  // state machine never has to load the workbench to make retry decisions.
+  // Use dispatchId as the assignment ID directly.
+  const manager = managerForWorkbench(workbench);
   manager.create({
-    id: assignmentId, workflow_id: workflow.id,
-    workspace_root: workflow.repo_path, worktree_path: node.worktree_path ?? workflow.worktree_path,
-    role: options.role, from_assignment_id: fromAssignmentId,
+    id: options.dispatchId, workflow_id: workbench.id,
+    workspace_root: workbench.repo_path, worktree_path: disp.worktree_path ?? workbench.worktree_path,
+    role: options.role, from_assignment_id: null,
     requested_agent_type: agentType,
-    timeout_minutes: node.timeout_minutes ?? workflow.default_timeout_minutes,
-    max_retries: node.max_retries ?? workflow.default_max_retries,
-    retry_policy: node.retry_policy,
+    timeout_minutes: disp.timeout_minutes ?? workbench.default_timeout_minutes,
+    max_retries: disp.max_retries ?? workbench.default_max_retries,
+    retry_policy: disp.retry_policy,
   });
-  node.assignment_id = assignmentId;
 
-  // Register node
-  workflow.nodes[options.nodeId] = node;
-  workflow.assignment_ids.push(assignmentId);
+  // Register dispatch
+  workbench.dispatches[options.dispatchId] = disp;
 
-  const eligible = allDepsCompleted(workflow, node);
-  workflow.node_statuses[options.nodeId] = eligible ? "eligible" : "blocked";
-
-  appendLedger(repoPath, workflow.id, "lead", {
-    type: "node_dispatched", node_id: options.nodeId, role: options.role,
-    agent_type: agentType, intent_file: node.intent_file,
+  appendLedger(repoPath, workbench.id, "lead", {
+    type: "dispatch_started", dispatch_id: options.dispatchId, role: options.role,
+    agent_type: agentType, intent_file: disp.intent_file,
     cause: "initial",
     ...(options.assessment ? { assessment: options.assessment } : {}),
   });
 
-  if (eligible) {
-    const assignment = loadAssignmentByIdOrThrow(manager, workflow, assignmentId);
-    const runId = generateRunId();
-    const result = await dispatchAssignment(workflow, assignment, node, runId, deps);
-    if (result.status === "dispatched") {
-      workflow.node_statuses[options.nodeId] = "dispatched";
-      saveWorkflow(workflow);
-      return { node_id: options.nodeId, assignment_id: assignmentId, status: "dispatched", terminal_id: result.terminalId };
-    }
-    workflow.node_statuses[options.nodeId] = "failed";
-    workflow.failure = result.failure;
-    saveWorkflow(workflow);
-    return { node_id: options.nodeId, assignment_id: assignmentId, status: "failed", failure: result.failure };
+  const assignment = loadAssignmentByIdOrThrow(manager, workbench, options.dispatchId);
+  const runId = generateRunId();
+  const result = await dispatchAssignment(workbench, assignment, disp, runId, deps);
+  if (result.status === "dispatched") {
+    workbench.dispatches[options.dispatchId].status = "dispatched";
+    saveWorkbench(workbench);
+    return { dispatch_id: options.dispatchId, status: "dispatched", terminal_id: result.terminalId };
   }
-
-  saveWorkflow(workflow);
-  return { node_id: options.nodeId, assignment_id: assignmentId, status: "blocked" };
+  workbench.dispatches[options.dispatchId].status = "failed";
+  workbench.failure = result.failure;
+  saveWorkbench(workbench);
+  return { dispatch_id: options.dispatchId, status: "failed", failure: result.failure };
 }
 
-// --- redispatchNode ---
+// --- redispatch ---
 
-export interface RedispatchNodeOptions {
+export interface RedispatchOptions {
   repoPath: string;
-  workflowId: string;
-  nodeId: string;
+  workbenchId: string;
+  dispatchId: string;
   intent?: string;
 }
 
-export async function redispatchNode(
-  options: RedispatchNodeOptions, deps?: WorkflowDependencies,
-): Promise<DispatchNodeResult> {
+export async function redispatch(
+  options: RedispatchOptions, deps?: WorkbenchDependencies,
+): Promise<DispatchResult> {
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const node = workflow.nodes[options.nodeId];
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const disp = workbench.dispatches[options.dispatchId];
 
-  if (!node) {
-    throw new HydraError(`Node not found: ${options.nodeId}`, {
-      errorCode: "WORKFLOW_NODE_NOT_FOUND", stage: "workflow.redispatch_node", ids: { workflow_id: workflow.id },
+  if (!disp) {
+    throw new HydraError(`Dispatch not found: ${options.dispatchId}`, {
+      errorCode: "WORKBENCH_DISPATCH_NOT_FOUND", stage: "workbench.redispatch", ids: { workbench_id: workbench.id },
     });
   }
 
-  const currentStatus = workflow.node_statuses[options.nodeId];
+  const currentStatus = disp.status;
   if (currentStatus !== "eligible" && currentStatus !== "reset") {
-    throw new HydraError(`Node "${options.nodeId}" is not eligible for redispatch (status: ${currentStatus})`, {
-      errorCode: "WORKFLOW_NODE_NOT_ELIGIBLE", stage: "workflow.redispatch_node", ids: { workflow_id: workflow.id },
-    });
-  }
-
-  if (!node.assignment_id) {
-    throw new HydraError(`Node "${options.nodeId}" has no assignment`, {
-      errorCode: "WORKFLOW_NODE_NO_ASSIGNMENT", stage: "workflow.redispatch_node", ids: { workflow_id: workflow.id },
+    throw new HydraError(`Dispatch "${options.dispatchId}" is not eligible for redispatch (status: ${currentStatus})`, {
+      errorCode: "WORKBENCH_DISPATCH_NOT_ELIGIBLE", stage: "workbench.redispatch", ids: { workbench_id: workbench.id },
     });
   }
 
   // Update intent if provided — overwrite the intent file
   if (options.intent) {
-    const intentAbs = writeNodeIntent(repoPath, workflow.id, options.nodeId, node.role, options.intent);
-    node.intent_file = path.relative(repoPath, intentAbs);
+    const intentAbs = writeDispatchIntent(repoPath, workbench.id, options.dispatchId, disp.role, options.intent);
+    disp.intent_file = path.relative(repoPath, intentAbs);
   }
 
-  const manager = managerForWorkflow(workflow);
-  const assignment = loadAssignmentByIdOrThrow(manager, workflow, node.assignment_id);
+  const manager = managerForWorkbench(workbench);
+  const assignment = loadAssignmentByIdOrThrow(manager, workbench, options.dispatchId);
   const runId = generateRunId();
 
-  appendLedger(repoPath, workflow.id, "lead", {
-    type: "node_dispatched", node_id: options.nodeId, role: node.role,
-    agent_type: node.agent_type, intent_file: node.intent_file,
+  appendLedger(repoPath, workbench.id, "lead", {
+    type: "dispatch_started", dispatch_id: options.dispatchId, role: disp.role,
+    agent_type: disp.agent_type, intent_file: disp.intent_file,
     cause: "lead_redispatch",
   });
 
-  const result = await dispatchAssignment(workflow, assignment, node, runId, deps);
+  const result = await dispatchAssignment(workbench, assignment, disp, runId, deps);
   if (result.status === "dispatched") {
-    workflow.node_statuses[options.nodeId] = "dispatched";
-    saveWorkflow(workflow);
-    return { node_id: options.nodeId, assignment_id: node.assignment_id, status: "dispatched", terminal_id: result.terminalId };
+    workbench.dispatches[options.dispatchId].status = "dispatched";
+    saveWorkbench(workbench);
+    return { dispatch_id: options.dispatchId, status: "dispatched", terminal_id: result.terminalId };
   }
 
-  workflow.node_statuses[options.nodeId] = "failed";
-  workflow.failure = result.failure;
-  saveWorkflow(workflow);
-  return { node_id: options.nodeId, assignment_id: node.assignment_id, status: "failed", failure: result.failure };
+  workbench.dispatches[options.dispatchId].status = "failed";
+  workbench.failure = result.failure;
+  saveWorkbench(workbench);
+  return { dispatch_id: options.dispatchId, status: "failed", failure: result.failure };
 }
 
 // --- watchUntilDecision ---
 
 export interface WatchOptions {
   repoPath: string;
-  workflowId: string;
+  workbenchId: string;
   intervalMs?: number;
   timeoutMs?: number;
 }
 
 export async function watchUntilDecision(
-  options: WatchOptions, deps?: WorkflowDependencies,
+  options: WatchOptions, deps?: WorkbenchDependencies,
 ): Promise<DecisionPoint> {
   const now = nowFn(deps);
   const sleep = sleepFn(deps);
@@ -699,41 +616,39 @@ export async function watchUntilDecision(
   const repoPath = path.resolve(options.repoPath);
 
   // Guard once outside the loop — Lead identity doesn't change mid-watch
-  ensureLeadCaller(loadWorkflowOrThrow(repoPath, options.workflowId));
+  ensureLeadCaller(loadWorkbenchOrThrow(repoPath, options.workbenchId));
 
   while (true) {
-    const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-    if (workflow.status !== "active") {
-      return { type: "batch_completed", workflow_id: workflow.id, timestamp: now(), nodes: buildNodesSummary(workflow) };
+    const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+    if (workbench.status !== "active") {
+      return { type: "batch_completed", workbench_id: workbench.id, timestamp: now(), dispatches: buildDispatchesSummary(workbench) };
     }
 
-    const manager = managerForWorkflow(workflow);
+    const manager = managerForWorkbench(workbench);
     const stateMachine = new AssignmentStateMachine(manager, { now });
     let changed = false;
 
-    // Phase 1: Check dispatched nodes for results
-    for (const [nodeId, nodeStatus] of Object.entries(workflow.node_statuses)) {
-      if (nodeStatus !== "dispatched") continue;
-      const node = workflow.nodes[nodeId];
-      if (!node?.assignment_id) continue;
-      const assignment = manager.load(node.assignment_id);
+    // Phase 1: Check dispatched dispatches for results
+    for (const [dispatchId, disp] of Object.entries(workbench.dispatches)) {
+      if (disp.status !== "dispatched") continue;
+      const assignment = manager.load(dispatchId);
       if (!assignment) continue;
 
       // Handle pending assignments that were promoted to eligible but not yet dispatched by Lead
       if (assignment.status === "pending") {
         const runId = generateRunId();
-        const result = await dispatchAssignment(workflow, assignment, node, runId, deps);
+        const result = await dispatchAssignment(workbench, assignment, disp, runId, deps);
         if (result.status === "dispatched") { changed = true; }
-        else { workflow.node_statuses[nodeId] = "failed"; }
-        saveWorkflow(workflow);
+        else { workbench.dispatches[dispatchId].status = "failed"; }
+        saveWorkbench(workbench);
         continue;
       }
 
       if (assignment.status !== "claimed" && assignment.status !== "in_progress") {
-        // Sync node status from completed/failed assignments
-        if (assignment.status === "completed") { workflow.node_statuses[nodeId] = "completed"; changed = true; }
-        if (assignment.status === "failed" || assignment.status === "timed_out") { workflow.node_statuses[nodeId] = "failed"; changed = true; }
-        saveWorkflow(workflow);
+        // Sync dispatch status from completed/failed assignments
+        if (assignment.status === "completed") { workbench.dispatches[dispatchId].status = "completed"; changed = true; }
+        if (assignment.status === "failed" || assignment.status === "timed_out") { workbench.dispatches[dispatchId].status = "failed"; changed = true; }
+        saveWorkbench(workbench);
         continue;
       }
 
@@ -741,45 +656,45 @@ export async function watchUntilDecision(
       if (!run) continue;
 
       const collected = collectRunResult({
-        workflow_id: workflow.id, assignment_id: assignment.id,
+        workbench_id: workbench.id, assignment_id: assignment.id,
         run_id: run.id, result_file: run.result_file,
       });
 
       if (collected.status === "completed") {
-        // Route by outcome: error → Hydra retries automatically, completed/stuck → report to Lead
+        // Route by outcome: error -> Hydra retries automatically, completed/stuck -> report to Lead
         if (collected.result.outcome === "error") {
           const errorMessage = `Agent reported error in ${collected.result.report_file}`;
           await stateMachine.markTimedOut(assignment.id, {
             code: "AGENT_REPORTED_ERROR",
             message: errorMessage,
-            stage: "workflow.agent_error",
+            stage: "workbench.agent_error",
           });
           const retryResult = await stateMachine.scheduleRetry(assignment.id);
           if (retryResult.assignment.status === "failed") {
-            workflow.node_statuses[nodeId] = "failed";
+            workbench.dispatches[dispatchId].status = "failed";
             const durationMs = run.started_at ? Date.parse(now()) - Date.parse(run.started_at) : 0;
-            appendLedger(repoPath, workflow.id, "system", {
-              type: "node_failed", node_id: nodeId, role: node.role, agent_type: node.agent_type,
+            appendLedger(repoPath, workbench.id, "system", {
+              type: "dispatch_failed", dispatch_id: dispatchId, role: disp.role, agent_type: disp.agent_type,
               duration_ms: durationMs, retries_used: assignment.retry_count + 1,
               failure_code: "AGENT_REPORTED_ERROR",
               failure_message: errorMessage,
               report_file: collected.result.report_file,
             });
-            saveWorkflow(workflow);
+            saveWorkbench(workbench);
             return {
-              type: "node_failed_final", workflow_id: workflow.id, timestamp: now(),
+              type: "dispatch_failed_final", workbench_id: workbench.id, timestamp: now(),
               failed: {
-                node_id: nodeId, role: node.role, code: "AGENT_REPORTED_ERROR",
+                dispatch_id: dispatchId, role: disp.role, code: "AGENT_REPORTED_ERROR",
                 message: errorMessage,
                 retries_used: assignment.retry_count + 1, max_retries: assignment.max_retries,
               },
-              nodes: buildNodesSummary(workflow),
+              dispatches: buildDispatchesSummary(workbench),
             };
           }
           // Retry scheduled — log the system decision then re-dispatch
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "assignment_retried",
-            node_id: nodeId,
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_retried",
+            dispatch_id: dispatchId,
             cause: "agent_reported_error",
             attempt: retryResult.assignment.retry_count + 1,
             max_attempts:
@@ -791,14 +706,14 @@ export async function watchUntilDecision(
           });
           await destroyAssignmentTerminal(assignment, deps);
           const retryRunId = generateRunId();
-          const freshAssignment = loadAssignmentByIdOrThrow(manager, workflow, assignment.id);
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "node_dispatched", node_id: nodeId, role: node.role,
-            agent_type: node.agent_type, intent_file: node.intent_file,
+          const freshAssignment = loadAssignmentByIdOrThrow(manager, workbench, assignment.id);
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_started", dispatch_id: dispatchId, role: disp.role,
+            agent_type: disp.agent_type, intent_file: disp.intent_file,
             cause: "system_retry",
           });
-          await dispatchAssignment(workflow, freshAssignment, node, retryRunId, deps);
-          saveWorkflow(workflow);
+          await dispatchAssignment(workbench, freshAssignment, disp, retryRunId, deps);
+          saveWorkbench(workbench);
           continue;
         }
 
@@ -810,7 +725,7 @@ export async function watchUntilDecision(
         };
         await stateMachine.markCompleted(assignment.id, mappedResult);
         await destroyAssignmentTerminal(assignment, deps);
-        workflow.node_statuses[nodeId] = "completed";
+        workbench.dispatches[dispatchId].status = "completed";
 
         // Reload assignment to get the captured session_id (set by destroyAssignmentTerminal)
         const reloadedAssignment = manager.load(assignment.id);
@@ -818,8 +733,8 @@ export async function watchUntilDecision(
         const sessionId = reloadedRun?.session_id;
 
         const durationMs = run.started_at ? Date.parse(now()) - Date.parse(run.started_at) : 0;
-        appendLedger(repoPath, workflow.id, "worker", {
-          type: "node_completed", node_id: nodeId, role: node.role, agent_type: node.agent_type,
+        appendLedger(repoPath, workbench.id, "worker", {
+          type: "dispatch_completed", dispatch_id: dispatchId, role: disp.role, agent_type: disp.agent_type,
           duration_ms: durationMs, retries_used: assignment.retry_count,
           outcome: collected.result.outcome,
           stuck_reason: collected.result.stuck_reason,
@@ -827,24 +742,11 @@ export async function watchUntilDecision(
           session_id: sessionId,
         });
 
-        // Promote blocked → eligible (Lead decides whether to dispatch).
-        // Each promotion is a system decision worth auditing — log one
-        // ledger entry per newly-promoted node, attributing the trigger.
-        const promoted = promoteEligibleNodes(workflow);
-        for (const promotedNodeId of promoted) {
-          const promotedNode = workflow.nodes[promotedNodeId];
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "node_promoted_eligible",
-            node_id: promotedNodeId,
-            triggered_by: promotedNode?.depends_on ?? [nodeId],
-          });
-        }
-
-        saveWorkflow(workflow);
+        saveWorkbench(workbench);
         return {
-          type: "node_completed", workflow_id: workflow.id, timestamp: now(),
+          type: "dispatch_completed", workbench_id: workbench.id, timestamp: now(),
           completed: {
-            node_id: nodeId, role: node.role,
+            dispatch_id: dispatchId, role: disp.role,
             outcome: collected.result.outcome,
             stuck_reason: collected.result.stuck_reason,
             report_file: collected.result.report_file,
@@ -854,30 +756,29 @@ export async function watchUntilDecision(
               ? { provider: reloadedRun.session_provider, id: sessionId, file: reloadedRun.session_file }
               : undefined,
           },
-          nodes: buildNodesSummary(workflow),
-          newly_eligible: promoted.length > 0 ? promoted : undefined,
+          dispatches: buildDispatchesSummary(workbench),
         };
       }
 
       if (collected.status === "failed") {
         await stateMachine.markFailed(assignment.id, collected.failure);
-        workflow.node_statuses[nodeId] = "failed";
+        workbench.dispatches[dispatchId].status = "failed";
         const durationMs = run.started_at ? Date.parse(now()) - Date.parse(run.started_at) : 0;
-        appendLedger(repoPath, workflow.id, "system", {
-          type: "node_failed", node_id: nodeId, role: node.role, agent_type: node.agent_type,
+        appendLedger(repoPath, workbench.id, "system", {
+          type: "dispatch_failed", dispatch_id: dispatchId, role: disp.role, agent_type: disp.agent_type,
           duration_ms: durationMs, retries_used: assignment.retry_count,
           failure_code: collected.failure.code,
           failure_message: collected.failure.message,
         });
-        saveWorkflow(workflow);
+        saveWorkbench(workbench);
         return {
-          type: "node_failed", workflow_id: workflow.id, timestamp: now(),
+          type: "dispatch_failed", workbench_id: workbench.id, timestamp: now(),
           failed: {
-            node_id: nodeId, role: node.role, code: collected.failure.code,
+            dispatch_id: dispatchId, role: disp.role, code: collected.failure.code,
             message: collected.failure.message,
             retries_used: assignment.retry_count, max_retries: assignment.max_retries,
           },
-          nodes: buildNodesSummary(workflow),
+          dispatches: buildDispatchesSummary(workbench),
         };
       }
 
@@ -890,32 +791,32 @@ export async function watchUntilDecision(
           await stateMachine.markTimedOut(assignment.id, {
             code: "ASSIGNMENT_PROCESS_EXITED",
             message: `Agent process exited without writing result (${Math.round(elapsedMs / 1000)}s)`,
-            stage: "workflow.health_check",
+            stage: "workbench.health_check",
           });
           const retryResult = await stateMachine.scheduleRetry(assignment.id);
           if (retryResult.assignment.status === "failed") {
-            workflow.node_statuses[nodeId] = "failed";
-            appendLedger(repoPath, workflow.id, "system", {
-              type: "node_failed", node_id: nodeId, role: node.role, agent_type: node.agent_type,
+            workbench.dispatches[dispatchId].status = "failed";
+            appendLedger(repoPath, workbench.id, "system", {
+              type: "dispatch_failed", dispatch_id: dispatchId, role: disp.role, agent_type: disp.agent_type,
               duration_ms: elapsedMs, retries_used: assignment.retry_count + 1,
               failure_code: "ASSIGNMENT_PROCESS_EXITED",
               failure_message: `Agent process exited without writing result (${Math.round(elapsedMs / 1000)}s)`,
             });
-            saveWorkflow(workflow);
+            saveWorkbench(workbench);
             return {
-              type: "node_failed_final", workflow_id: workflow.id, timestamp: now(),
+              type: "dispatch_failed_final", workbench_id: workbench.id, timestamp: now(),
               failed: {
-                node_id: nodeId, role: node.role, code: "ASSIGNMENT_PROCESS_EXITED",
+                dispatch_id: dispatchId, role: disp.role, code: "ASSIGNMENT_PROCESS_EXITED",
                 message: "Agent process exited and retry limit reached",
                 retries_used: assignment.retry_count + 1, max_retries: assignment.max_retries,
               },
-              nodes: buildNodesSummary(workflow),
+              dispatches: buildDispatchesSummary(workbench),
             };
           }
           // Retry scheduled — log the system decision then re-dispatch.
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "assignment_retried",
-            node_id: nodeId,
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_retried",
+            dispatch_id: dispatchId,
             cause: "timeout",
             attempt: retryResult.assignment.retry_count + 1,
             max_attempts:
@@ -926,60 +827,60 @@ export async function watchUntilDecision(
             failure_message: `Agent process exited without writing result (${Math.round(elapsedMs / 1000)}s)`,
           });
           const retryRunId = generateRunId();
-          const freshAssignment = loadAssignmentByIdOrThrow(manager, workflow, assignment.id);
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "node_dispatched", node_id: nodeId, role: node.role,
-            agent_type: node.agent_type, intent_file: node.intent_file,
+          const freshAssignment = loadAssignmentByIdOrThrow(manager, workbench, assignment.id);
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_started", dispatch_id: dispatchId, role: disp.role,
+            agent_type: disp.agent_type, intent_file: disp.intent_file,
             cause: "system_retry",
           });
-          const retryOutcome = await dispatchAssignment(workflow, freshAssignment, node, retryRunId, deps);
+          const retryOutcome = await dispatchAssignment(workbench, freshAssignment, disp, retryRunId, deps);
           if (retryOutcome.status === "dispatched") { changed = true; }
-          saveWorkflow(workflow);
+          saveWorkbench(workbench);
           continue;
         }
       }
 
       // Check duration timeout
-      const freshAssignment = loadAssignmentByIdOrThrow(manager, workflow, assignment.id);
+      const freshAssignment = loadAssignmentByIdOrThrow(manager, workbench, assignment.id);
       if (hasAssignmentTimedOut(freshAssignment, now())) {
         const retryRunId = generateRunId();
-        const retrySpec = buildTaskSpecFromIntent({ workflow, node, assignment: freshAssignment, runId: retryRunId });
+        const retrySpec = buildTaskSpecFromIntent({ workbench, dispatch: disp, assignment: freshAssignment, runId: retryRunId });
         const retryArtifacts = writeRunTask(retrySpec);
         const retryOutcome = await retryTimedOutAssignment(
           {
             assignmentId: assignment.id, timeoutCheckedAt: now(),
-            dispatchRequest: { ...buildDispatchRequest(workflow, freshAssignment, node, retryRunId), taskFile: retryArtifacts.task_file, resultFile: retryArtifacts.result_file },
+            dispatchRequest: { ...buildDispatchRequest(workbench, freshAssignment, disp, retryRunId), taskFile: retryArtifacts.task_file, resultFile: retryArtifacts.result_file },
             runId: retryRunId, taskFile: retryArtifacts.task_file, resultFile: retryArtifacts.result_file,
             artifactDir: retryArtifacts.artifact_dir,
           },
           { manager, stateMachine, dispatchCreateOnly: dispatchFn(deps), destroyTerminal: destroyTerminalFn(deps), now },
         );
         if (retryOutcome.status === "failed") {
-          workflow.node_statuses[nodeId] = "failed";
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "node_failed", node_id: nodeId, role: node.role, agent_type: node.agent_type,
+          workbench.dispatches[dispatchId].status = "failed";
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_failed", dispatch_id: dispatchId, role: disp.role, agent_type: disp.agent_type,
             duration_ms: 0, retries_used: freshAssignment.retry_count + 1,
             failure_code: "ASSIGNMENT_TIMED_OUT",
             failure_message: "Assignment timed out and retry limit reached",
           });
-          saveWorkflow(workflow);
+          saveWorkbench(workbench);
           return {
-            type: "node_failed_final", workflow_id: workflow.id, timestamp: now(),
+            type: "dispatch_failed_final", workbench_id: workbench.id, timestamp: now(),
             failed: {
-              node_id: nodeId, role: node.role, code: "ASSIGNMENT_TIMED_OUT",
+              dispatch_id: dispatchId, role: disp.role, code: "ASSIGNMENT_TIMED_OUT",
               message: "Assignment timed out and retry limit reached",
               retries_used: freshAssignment.retry_count + 1, max_retries: freshAssignment.max_retries,
             },
-            nodes: buildNodesSummary(workflow),
+            dispatches: buildDispatchesSummary(workbench),
           };
         }
         // retryTimedOutAssignment scheduled and re-dispatched. Log the
         // system decision so the audit log shows the system retry path.
         const reloadedForLog = manager.load(assignment.id);
         if (reloadedForLog) {
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "assignment_retried",
-            node_id: nodeId,
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_retried",
+            dispatch_id: dispatchId,
             cause: "timeout",
             attempt: reloadedForLog.retry_count + 1,
             max_attempts:
@@ -989,30 +890,30 @@ export async function watchUntilDecision(
             failure_code: "ASSIGNMENT_TIMEOUT",
             failure_message: `Assignment exceeded ${freshAssignment.timeout_minutes}-minute timeout`,
           });
-          appendLedger(repoPath, workflow.id, "system", {
-            type: "node_dispatched", node_id: nodeId, role: node.role,
-            agent_type: node.agent_type, intent_file: node.intent_file,
+          appendLedger(repoPath, workbench.id, "system", {
+            type: "dispatch_started", dispatch_id: dispatchId, role: disp.role,
+            agent_type: disp.agent_type, intent_file: disp.intent_file,
             cause: "system_retry",
           });
         }
         changed = true;
-        saveWorkflow(workflow);
+        saveWorkbench(workbench);
       }
     }
 
-    // Phase 2: Check if no dispatched nodes remain (Lead needs to decide next)
-    const statuses = Object.values(workflow.node_statuses);
+    // Phase 2: Check if no dispatched dispatches remain (Lead needs to decide next)
+    const statuses = Object.values(workbench.dispatches).map(d => d.status);
     const anyDispatched = statuses.includes("dispatched");
     if (!anyDispatched && statuses.length > 0 && !changed) {
-      saveWorkflow(workflow);
-      return { type: "batch_completed", workflow_id: workflow.id, timestamp: now(), nodes: buildNodesSummary(workflow) };
+      saveWorkbench(workbench);
+      return { type: "batch_completed", workbench_id: workbench.id, timestamp: now(), dispatches: buildDispatchesSummary(workbench) };
     }
 
     // Phase 3: Timeout check
     if (options.timeoutMs !== undefined) {
       const elapsed = Date.parse(now()) - startedAt;
       if (elapsed >= options.timeoutMs) {
-        return { type: "watch_timeout", workflow_id: workflow.id, timestamp: now(), nodes: buildNodesSummary(workflow) };
+        return { type: "watch_timeout", workbench_id: workbench.id, timestamp: now(), dispatches: buildDispatchesSummary(workbench) };
       }
     }
 
@@ -1020,100 +921,80 @@ export async function watchUntilDecision(
   }
 }
 
-// --- resetNode ---
+// --- resetDispatch ---
 
-export interface ResetNodeOptions {
+export interface ResetDispatchOptions {
   repoPath: string;
-  workflowId: string;
-  nodeId: string;
+  workbenchId: string;
+  dispatchId: string;
   feedback?: string;
-  cascade?: boolean;
 }
 
-export interface ResetNodeResult {
-  reset_node_ids: string[];
-  re_eligible_node_ids: string[];
+export interface ResetDispatchResult {
+  dispatch_id: string;
 }
 
-export async function resetNode(
-  options: ResetNodeOptions, deps?: WorkflowDependencies,
-): Promise<ResetNodeResult> {
+export async function resetDispatch(
+  options: ResetDispatchOptions, deps?: WorkbenchDependencies,
+): Promise<ResetDispatchResult> {
   const now = nowFn(deps);
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const manager = managerForWorkflow(workflow);
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const manager = managerForWorkbench(workbench);
 
-  if (!workflow.nodes[options.nodeId]) {
-    throw new HydraError(`Node not found: ${options.nodeId}`, {
-      errorCode: "WORKFLOW_NODE_NOT_FOUND", stage: "workflow.reset_node", ids: { workflow_id: workflow.id },
+  if (!workbench.dispatches[options.dispatchId]) {
+    throw new HydraError(`Dispatch not found: ${options.dispatchId}`, {
+      errorCode: "WORKBENCH_DISPATCH_NOT_FOUND", stage: "workbench.reset_dispatch", ids: { workbench_id: workbench.id },
     });
   }
 
-  const resetNodeIds = options.cascade !== false
-    ? cascadeReset(workflow, options.nodeId)
-    : (() => {
-        const node = workflow.nodes[options.nodeId];
-        workflow.node_statuses[options.nodeId] = node && allDepsCompleted(workflow, node) ? "eligible" : "blocked";
-        return [options.nodeId];
-      })();
+  // Reset only the target dispatch — Lead manually resets others if needed
+  workbench.dispatches[options.dispatchId].status = "eligible";
 
-  // Reset assignments and destroy terminals
-  for (const id of resetNodeIds) {
-    const node = workflow.nodes[id];
-    if (!node?.assignment_id) continue;
-    const assignment = manager.load(node.assignment_id);
-    if (assignment) {
-      await destroyAssignmentTerminal(assignment, deps);
-      // Reset assignment to pending
-      const previousStatus = assignment.status;
-      assignment.status = "pending";
-      assignment.updated_at = now();
-      assignment.claim = undefined;
-      assignment.last_error = undefined;
-      assignment.result = undefined;
-      assignment.active_run_id = null;
-      assignment.transitions = assignment.transitions ?? [];
-      assignment.transitions.push({ event: "requeue_assignment", from: previousStatus, to: "pending", at: now() });
-      manager.save(assignment);
-    }
-    // node_statuses already set by cascadeReset (target=eligible, downstream=blocked)
+  const disp = workbench.dispatches[options.dispatchId];
+  // Use dispatchId as the assignment ID
+  const assignment = manager.load(options.dispatchId);
+  if (assignment) {
+    await destroyAssignmentTerminal(assignment, deps);
+    const previousStatus = assignment.status;
+    assignment.status = "pending";
+    assignment.updated_at = now();
+    assignment.claim = undefined;
+    assignment.last_error = undefined;
+    assignment.result = undefined;
+    assignment.active_run_id = null;
+    assignment.transitions = assignment.transitions ?? [];
+    assignment.transitions.push({ event: "requeue_assignment", from: previousStatus, to: "pending", at: now() });
+    manager.save(assignment);
   }
 
-  // Store feedback on target node — write feedback.md, store path
-  let feedbackFileRel: string | undefined;
+  // Store feedback on target dispatch — write feedback.md, store path
   if (options.feedback) {
-    const feedbackAbs = writeNodeFeedback(repoPath, workflow.id, options.nodeId, options.feedback);
-    feedbackFileRel = path.relative(repoPath, feedbackAbs);
-    workflow.nodes[options.nodeId].feedback_file = feedbackFileRel;
+    const feedbackAbs = writeDispatchFeedback(repoPath, workbench.id, options.dispatchId, options.feedback);
+    const feedbackFileRel = path.relative(repoPath, feedbackAbs);
+    workbench.dispatches[options.dispatchId].feedback_file = feedbackFileRel;
   } else {
-    // Reset clears any prior feedback file
-    clearNodeFeedback(repoPath, workflow.id, options.nodeId);
-    workflow.nodes[options.nodeId].feedback_file = undefined;
+    clearDispatchFeedback(repoPath, workbench.id, options.dispatchId);
+    workbench.dispatches[options.dispatchId].feedback_file = undefined;
   }
 
-  // Find re-eligible nodes
-  const reEligible = resetNodeIds.filter((id) => {
-    const node = workflow.nodes[id];
-    return node && allDepsCompleted(workflow, node);
+  appendLedger(repoPath, workbench.id, "lead", {
+    type: "dispatch_reset", dispatch_id: options.dispatchId, role: workbench.dispatches[options.dispatchId].role,
+    feedback_file: workbench.dispatches[options.dispatchId].feedback_file,
   });
 
-  appendLedger(repoPath, workflow.id, "lead", {
-    type: "node_reset", node_id: options.nodeId, role: workflow.nodes[options.nodeId].role,
-    feedback_file: feedbackFileRel, cascade_targets: resetNodeIds.filter((id) => id !== options.nodeId),
-  });
-
-  workflow.updated_at = now();
-  saveWorkflow(workflow);
-  return { reset_node_ids: resetNodeIds, re_eligible_node_ids: reEligible };
+  workbench.updated_at = now();
+  saveWorkbench(workbench);
+  return { dispatch_id: options.dispatchId };
 }
 
 // --- mergeWorktrees ---
 
 export interface MergeWorktreesOptions {
   repoPath: string;
-  workflowId: string;
-  sourceNodeIds: string[];
+  workbenchId: string;
+  sourceDispatchIds: string[];
   targetBranch?: string;
 }
 
@@ -1122,38 +1003,38 @@ export type MergeOutcome =
   | { status: "conflict"; conflicting_files: string[] };
 
 export async function mergeWorktrees(
-  options: MergeWorktreesOptions, deps?: WorkflowDependencies,
+  options: MergeWorktreesOptions, deps?: WorkbenchDependencies,
 ): Promise<MergeOutcome> {
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
 
-  for (const nodeId of options.sourceNodeIds) {
-    if (workflow.node_statuses[nodeId] !== "completed") {
-      throw new HydraError(`Node "${nodeId}" is not completed`, {
-        errorCode: "WORKFLOW_MERGE_NOT_READY", stage: "workflow.merge", ids: { workflow_id: workflow.id },
+  for (const dispatchId of options.sourceDispatchIds) {
+    if (workbench.dispatches[dispatchId]?.status !== "completed") {
+      throw new HydraError(`Dispatch "${dispatchId}" is not completed`, {
+        errorCode: "WORKBENCH_MERGE_NOT_READY", stage: "workbench.merge", ids: { workbench_id: workbench.id },
       });
     }
   }
 
-  const targetBranch = options.targetBranch ?? workflow.branch ?? workflow.base_branch;
-  const cwd = workflow.worktree_path;
+  const targetBranch = options.targetBranch ?? workbench.branch ?? workbench.base_branch;
+  const cwd = workbench.worktree_path;
 
   // Checkout target branch and record HEAD for rollback
   execFileSync("git", ["checkout", targetBranch], { cwd, encoding: "utf-8", stdio: "pipe" });
   const preMergeHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
 
-  for (const nodeId of options.sourceNodeIds) {
-    const node = workflow.nodes[nodeId];
-    const branch = node?.worktree_branch;
+  for (const dispatchId of options.sourceDispatchIds) {
+    const disp = workbench.dispatches[dispatchId];
+    const branch = disp?.worktree_branch;
     if (!branch) {
-      throw new HydraError(`Node "${nodeId}" has no worktree_branch — cannot merge`, {
-        errorCode: "WORKFLOW_MERGE_NO_BRANCH", stage: "workflow.merge", ids: { workflow_id: workflow.id },
+      throw new HydraError(`Dispatch "${dispatchId}" has no worktree_branch — cannot merge`, {
+        errorCode: "WORKBENCH_MERGE_NO_BRANCH", stage: "workbench.merge", ids: { workbench_id: workbench.id },
       });
     }
 
     try {
-      execFileSync("git", ["merge", "--no-ff", branch, "-m", `Merge ${nodeId} (${node.role})`], { cwd, encoding: "utf-8", stdio: "pipe" });
+      execFileSync("git", ["merge", "--no-ff", branch, "-m", `Merge ${dispatchId} (${disp.role})`], { cwd, encoding: "utf-8", stdio: "pipe" });
     } catch {
       // Collect conflict info, then roll back ALL merges (not just this one)
       let conflictingFiles: string[] = [];
@@ -1164,77 +1045,78 @@ export async function mergeWorktrees(
       } catch {}
       // Reset to pre-merge state to undo any partial merges
       try { execFileSync("git", ["reset", "--hard", preMergeHead], { cwd, encoding: "utf-8", stdio: "pipe" }); } catch {}
-      appendLedger(repoPath, workflow.id, "lead", { type: "merge_attempted", source_nodes: options.sourceNodeIds, outcome: "conflict" });
+      appendLedger(repoPath, workbench.id, "lead", { type: "merge_attempted", source_dispatches: options.sourceDispatchIds, outcome: "conflict" });
       return { status: "conflict", conflicting_files: conflictingFiles };
     }
   }
 
   const commitSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
-  appendLedger(repoPath, workflow.id, "lead", { type: "merge_attempted", source_nodes: options.sourceNodeIds, outcome: "merged" });
+  appendLedger(repoPath, workbench.id, "lead", { type: "merge_attempted", source_dispatches: options.sourceDispatchIds, outcome: "merged" });
   return { status: "merged", commit_sha: commitSha };
 }
 
-// --- approveNode ---
+// --- approveDispatch ---
 
-export interface ApproveNodeOptions {
+export interface ApproveDispatchOptions {
   repoPath: string;
-  workflowId: string;
-  nodeId: string;
+  workbenchId: string;
+  dispatchId: string;
 }
 
-export async function approveNode(options: ApproveNodeOptions, deps?: WorkflowDependencies): Promise<void> {
+export async function approveDispatch(options: ApproveDispatchOptions, deps?: WorkbenchDependencies): Promise<void> {
   const now = nowFn(deps);
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const manager = managerForWorkflow(workflow);
-  const node = workflow.nodes[options.nodeId];
-  if (!node?.assignment_id) {
-    throw new HydraError(`Node "${options.nodeId}" has no assignment`, {
-      errorCode: "WORKFLOW_APPROVE_NO_ASSIGNMENT", stage: "workflow.approve", ids: { workflow_id: workflow.id },
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const manager = managerForWorkbench(workbench);
+  const disp = workbench.dispatches[options.dispatchId];
+  if (!disp) {
+    throw new HydraError(`Dispatch "${options.dispatchId}" not found`, {
+      errorCode: "WORKBENCH_APPROVE_NO_DISPATCH", stage: "workbench.approve", ids: { workbench_id: workbench.id },
     });
   }
-  const assignment = loadAssignmentByIdOrThrow(manager, workflow, node.assignment_id);
+  // Use dispatchId as the assignment ID
+  const assignment = loadAssignmentByIdOrThrow(manager, workbench, options.dispatchId);
   const run = latestRun(assignment);
   if (!run) {
-    throw new HydraError(`Node "${options.nodeId}" has no run`, {
-      errorCode: "WORKFLOW_APPROVE_NO_RUN", stage: "workflow.approve", ids: { workflow_id: workflow.id },
+    throw new HydraError(`Dispatch "${options.dispatchId}" has no run`, {
+      errorCode: "WORKBENCH_APPROVE_NO_RUN", stage: "workbench.approve", ids: { workbench_id: workbench.id },
     });
   }
 
-  if (!workflow.approved_refs) workflow.approved_refs = {};
-  workflow.approved_refs[options.nodeId] = {
+  if (!workbench.approved_refs) workbench.approved_refs = {};
+  workbench.approved_refs[options.dispatchId] = {
     assignment_id: assignment.id, run_id: run.id,
-    brief_file: getRunReportFile(repoPath, workflow.id, assignment.id, run.id),
+    brief_file: getRunReportFile(repoPath, workbench.id, assignment.id, run.id),
     result_file: run.result_file, approved_at: now(),
   };
 
-  appendLedger(repoPath, workflow.id, "lead", { type: "node_approved", node_id: options.nodeId, role: node.role });
-  workflow.updated_at = now();
-  saveWorkflow(workflow);
+  appendLedger(repoPath, workbench.id, "lead", { type: "dispatch_approved", dispatch_id: options.dispatchId, role: disp.role });
+  workbench.updated_at = now();
+  saveWorkbench(workbench);
 }
 
-// --- completeWorkflow ---
+// --- completeWorkbench ---
 
-export async function completeWorkflow(
-  options: { repoPath: string; workflowId: string; summary?: string }, deps?: WorkflowDependencies,
+export async function completeWorkbench(
+  options: { repoPath: string; workbenchId: string; summary?: string }, deps?: WorkbenchDependencies,
 ): Promise<void> {
   const now = nowFn(deps);
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const manager = managerForWorkflow(workflow);
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const manager = managerForWorkbench(workbench);
 
   // Destroy any running terminals (captures session_id before destroy)
-  for (const assignmentId of workflow.assignment_ids) {
-    const a = manager.load(assignmentId);
+  for (const [dispatchId, disp] of Object.entries(workbench.dispatches)) {
+    const a = manager.load(dispatchId);
     if (a && (a.status === "claimed" || a.status === "in_progress")) {
       await destroyAssignmentTerminal(a, deps);
     }
   }
 
-  const totalDuration = Date.parse(now()) - Date.parse(workflow.created_at);
-  const totalRetries = workflow.assignment_ids.reduce((sum, id) => {
+  const totalDuration = Date.parse(now()) - Date.parse(workbench.created_at);
+  const totalRetries = Object.keys(workbench.dispatches).reduce((sum, id) => {
     const a = manager.load(id);
     return sum + (a?.retry_count ?? 0);
   }, 0);
@@ -1242,97 +1124,97 @@ export async function completeWorkflow(
   // Write summary file if Lead provided a summary
   let resultFileRel: string | undefined;
   if (options.summary) {
-    const summaryAbs = writeWorkflowSummary(repoPath, workflow.id, options.summary);
+    const summaryAbs = writeWorkbenchSummary(repoPath, workbench.id, options.summary);
     resultFileRel = path.relative(repoPath, summaryAbs);
-    workflow.result_file = resultFileRel;
+    workbench.result_file = resultFileRel;
   }
 
-  workflow.status = "completed";
-  workflow.failure = undefined;
-  workflow.updated_at = now();
-  saveWorkflow(workflow);
+  workbench.status = "completed";
+  workbench.failure = undefined;
+  workbench.updated_at = now();
+  saveWorkbench(workbench);
 
-  appendLedger(repoPath, workflow.id, "lead", {
-    type: "workflow_completed",
+  appendLedger(repoPath, workbench.id, "lead", {
+    type: "workbench_completed",
     result_file: resultFileRel,
     total_duration_ms: totalDuration,
-    total_nodes: Object.keys(workflow.nodes).length,
+    total_dispatches: Object.keys(workbench.dispatches).length,
     total_retries: totalRetries,
   });
 }
 
-// --- failWorkflow ---
+// --- failWorkbench ---
 
-export async function failWorkflow(
-  options: { repoPath: string; workflowId: string; reason: string }, deps?: WorkflowDependencies,
+export async function failWorkbench(
+  options: { repoPath: string; workbenchId: string; reason: string }, deps?: WorkbenchDependencies,
 ): Promise<void> {
   const now = nowFn(deps);
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const manager = managerForWorkflow(workflow);
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const manager = managerForWorkbench(workbench);
 
-  for (const assignmentId of workflow.assignment_ids) {
-    const a = manager.load(assignmentId);
+  for (const [dispatchId, disp] of Object.entries(workbench.dispatches)) {
+    const a = manager.load(dispatchId);
     if (a && (a.status === "claimed" || a.status === "in_progress")) {
       await destroyAssignmentTerminal(a, deps);
     }
   }
 
-  const totalDuration = Date.parse(now()) - Date.parse(workflow.created_at);
-  // Find the node that bears the visible failure (most recently failed),
-  // for the failed_node_id field on the ledger event.
-  const failedNodeId = Object.entries(workflow.node_statuses)
-    .filter(([, status]) => status === "failed")
+  const totalDuration = Date.parse(now()) - Date.parse(workbench.created_at);
+  // Find the dispatch that bears the visible failure (most recently failed),
+  // for the failed_dispatch_id field on the ledger event.
+  const failedDispatchId = Object.entries(workbench.dispatches)
+    .filter(([, d]) => d.status === "failed")
     .map(([id]) => id)[0];
-  workflow.status = "failed";
-  workflow.failure = { code: "WORKFLOW_MANUALLY_FAILED", message: options.reason, stage: "workflow.fail" };
-  workflow.updated_at = now();
-  saveWorkflow(workflow);
+  workbench.status = "failed";
+  workbench.failure = { code: "WORKBENCH_MANUALLY_FAILED", message: options.reason, stage: "workbench.fail" };
+  workbench.updated_at = now();
+  saveWorkbench(workbench);
 
-  appendLedger(repoPath, workflow.id, "lead", {
-    type: "workflow_failed",
+  appendLedger(repoPath, workbench.id, "lead", {
+    type: "workbench_failed",
     reason: options.reason,
     total_duration_ms: totalDuration,
-    failed_node_id: failedNodeId,
+    failed_dispatch_id: failedDispatchId,
   });
 }
 
-// --- getWorkflowStatus ---
+// --- getWorkbenchStatus ---
 
-export interface WorkflowStatusView {
-  workflow: WorkflowRecord;
+export interface WorkbenchStatusView {
+  workbench: WorkbenchRecord;
   assignments: AssignmentRecord[];
 }
 
-export function getWorkflowStatus(repoPath: string, workflowId: string): WorkflowStatusView {
-  const workflow = loadWorkflowOrThrow(path.resolve(repoPath), workflowId);
-  const manager = managerForWorkflow(workflow);
-  const assignments = workflow.assignment_ids
+export function getWorkbenchStatus(repoPath: string, workbenchId: string): WorkbenchStatusView {
+  const workbench = loadWorkbenchOrThrow(path.resolve(repoPath), workbenchId);
+  const manager = managerForWorkbench(workbench);
+  const assignments = Object.keys(workbench.dispatches)
     .map((id) => manager.load(id))
     .filter((a): a is AssignmentRecord => a !== null);
-  return { workflow, assignments };
+  return { workbench, assignments };
 }
 
-// --- cleanupWorkflow ---
+// --- cleanupWorkbench ---
 
-export function cleanupWorkflowState(repoPath: string, workflowId: string): void {
-  deleteWorkflow(repoPath, workflowId);
+export function cleanupWorkbenchState(repoPath: string, workbenchId: string): void {
+  deleteWorkbench(repoPath, workbenchId);
 }
 
-// --- askNode (Lead → completed node follow-up) ---
+// --- askDispatch (Lead -> completed dispatch follow-up) ---
 
-export interface AskNodeOptions {
+export interface AskDispatchOptions {
   repoPath: string;
-  workflowId: string;
-  nodeId: string;
+  workbenchId: string;
+  dispatchId: string;
   message: string;
   /** Override the default subprocess timeout (5 minutes). */
   timeoutMs?: number;
 }
 
-export interface AskNodeResult {
-  node_id: string;
+export interface AskDispatchResult {
+  dispatch_id: string;
   role: string;
   cli: AgentType;
   session_id: string;
@@ -1343,8 +1225,8 @@ export interface AskNodeResult {
 }
 
 /**
- * Ask a follow-up question to a node that has already completed, without
- * killing or re-dispatching anything. This reuses the node's saved
+ * Ask a follow-up question to a dispatch that has already completed, without
+ * killing or re-dispatching anything. This reuses the dispatch's saved
  * session_id to spin up a one-shot non-interactive subprocess that
  * loads the prior conversation, answers the question, and exits.
  *
@@ -1352,13 +1234,13 @@ export interface AskNodeResult {
  *   - `hydra reset --feedback` is the heavyweight intervention: it kills
  *     the running worker, discards its session, and respawns a new one
  *     from task.md with the Lead's feedback. That's the right tool when
- *     the node needs to actually redo work.
+ *     the dispatch needs to actually redo work.
  *   - `hydra ask` is the lightweight intervention: just a question-and-
- *     answer round with the already-completed node, leaving the workflow
+ *     answer round with the already-completed dispatch, leaving the workbench
  *     state completely unchanged.
  *
  * Prerequisites:
- *   - The node must have completed at least one run (it needs a
+ *   - The dispatch must have completed at least one run (it needs a
  *     session_id captured by telemetry).
  *   - The session provider must be claude or codex (other CLIs have no
  *     resume contract).
@@ -1367,85 +1249,76 @@ export interface AskNodeResult {
  *   - For codex, the subprocess uses `codex exec resume` which appends
  *     to the original session (no headless fork yet; see openai/codex#13537).
  */
-export async function askNode(
-  options: AskNodeOptions,
-  deps?: WorkflowDependencies,
-): Promise<AskNodeResult> {
+export async function askDispatch(
+  options: AskDispatchOptions,
+  deps?: WorkbenchDependencies,
+): Promise<AskDispatchResult> {
   const repoPath = path.resolve(options.repoPath);
-  const workflow = loadWorkflowOrThrow(repoPath, options.workflowId);
-  ensureLeadCaller(workflow);
-  const node = workflow.nodes[options.nodeId];
-  if (!node) {
+  const workbench = loadWorkbenchOrThrow(repoPath, options.workbenchId);
+  ensureLeadCaller(workbench);
+  const disp = workbench.dispatches[options.dispatchId];
+  if (!disp) {
     throw new HydraError(
-      `Node not found: ${options.nodeId}`,
+      `Dispatch not found: ${options.dispatchId}`,
       {
-        errorCode: "ASK_NODE_NOT_FOUND",
+        errorCode: "ASK_DISPATCH_NOT_FOUND",
         stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, node_id: options.nodeId },
+        ids: { workbench_id: workbench.id, dispatch_id: options.dispatchId },
       },
     );
   }
-  if (!node.assignment_id) {
-    throw new HydraError(
-      `Node ${options.nodeId} has never been dispatched — nothing to ask`,
-      {
-        errorCode: "ASK_NODE_NEVER_DISPATCHED",
-        stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, node_id: options.nodeId },
-      },
-    );
-  }
-  const manager = managerForWorkflow(workflow);
-  const assignment = manager.load(node.assignment_id);
+  // Use dispatchId as the assignment ID
+  const manager = managerForWorkbench(workbench);
+  const assignment = manager.load(options.dispatchId);
   if (!assignment) {
     throw new HydraError(
-      `Assignment ${node.assignment_id} not found`,
+      `Assignment for dispatch ${options.dispatchId} not found`,
       {
         errorCode: "ASK_ASSIGNMENT_MISSING",
         stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, assignment_id: node.assignment_id },
+        ids: { workbench_id: workbench.id, dispatch_id: options.dispatchId },
       },
     );
   }
-  const latestRun = assignment.runs[assignment.runs.length - 1];
-  if (!latestRun) {
+  const latestRunRecord = assignment.runs[assignment.runs.length - 1];
+  if (!latestRunRecord) {
     throw new HydraError(
-      `Assignment ${assignment.id} has no runs yet`,
+      `Dispatch ${options.dispatchId} has no runs yet`,
       {
         errorCode: "ASK_NO_RUNS",
         stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, assignment_id: assignment.id },
+        ids: { workbench_id: workbench.id, dispatch_id: options.dispatchId },
       },
     );
   }
-  const sessionId = latestRun.session_id;
+  const sessionId = latestRunRecord.session_id;
   if (!sessionId) {
     throw new HydraError(
-      `Node ${options.nodeId} has no session_id captured yet — ask requires a completed or in-progress session`,
+      `Dispatch ${options.dispatchId} has no session_id captured yet — ask requires a completed or in-progress session`,
       {
         errorCode: "ASK_NO_SESSION",
         stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, node_id: options.nodeId, run_id: latestRun.id },
+        ids: { workbench_id: workbench.id, dispatch_id: options.dispatchId, run_id: latestRunRecord.id },
       },
     );
   }
-  if (latestRun.agent_type !== "claude" && latestRun.agent_type !== "codex") {
+  if (latestRunRecord.agent_type !== "claude" && latestRunRecord.agent_type !== "codex") {
     throw new HydraError(
-      `hydra ask supports only claude|codex sessions, got: ${latestRun.agent_type}`,
+      `hydra ask supports only claude|codex sessions, got: ${latestRunRecord.agent_type}`,
       {
         errorCode: "ASK_UNSUPPORTED_CLI",
         stage: "ask.preflight",
-        ids: { workflow_id: workflow.id, node_id: options.nodeId },
+        ids: { workbench_id: workbench.id, dispatch_id: options.dispatchId },
       },
     );
   }
 
   const ask = deps?.askFollowUp ?? askFollowUp;
   const result = await ask({
-    cli: latestRun.agent_type,
+    cli: latestRunRecord.agent_type,
     sessionId,
     message: options.message,
-    workdir: workflow.worktree_path,
+    workdir: workbench.worktree_path,
     timeoutMs: options.timeoutMs,
   });
 
@@ -1455,11 +1328,11 @@ export async function askNode(
     const trimmed = text.trim();
     return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
   };
-  appendLedger(repoPath, workflow.id, "lead", {
+  appendLedger(repoPath, workbench.id, "lead", {
     type: "lead_asked_followup",
-    node_id: options.nodeId,
-    role: node.role,
-    agent_type: latestRun.agent_type,
+    dispatch_id: options.dispatchId,
+    role: disp.role,
+    agent_type: latestRunRecord.agent_type,
     session_id: sessionId,
     new_session_id: result.newSessionId ?? undefined,
     message_excerpt: excerpt(options.message, 200),
@@ -1468,9 +1341,9 @@ export async function askNode(
   });
 
   return {
-    node_id: options.nodeId,
-    role: node.role,
-    cli: latestRun.agent_type,
+    dispatch_id: options.dispatchId,
+    role: disp.role,
+    cli: latestRunRecord.agent_type,
     session_id: sessionId,
     new_session_id: result.newSessionId,
     answer: result.answer,

--- a/hydra/src/workflow-store.ts
+++ b/hydra/src/workflow-store.ts
@@ -1,20 +1,20 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { AgentType } from "./assignment/types.ts";
-import type { NodeStatus } from "./decision.ts";
+import type { DispatchStatus } from "./decision.ts";
 import {
-  getWorkflowDir,
-  getWorkflowStatePath,
+  getWorkbenchDir,
+  getWorkbenchStatePath,
 } from "./layout.ts";
 
-export const WORKFLOW_STATE_SCHEMA_VERSION = "hydra/workflow-state/v0.1";
+export const WORKBENCH_STATE_SCHEMA_VERSION = "hydra/workbench-state/v0.1";
 
-export type WorkflowStatus =
+export type WorkbenchStatus =
   | "active"
   | "completed"
   | "failed";
 
-export interface WorkflowFailure {
+export interface WorkbenchFailure {
   code: string;
   message: string;
   stage: string;
@@ -34,16 +34,16 @@ export interface ContextRef {
 }
 
 /**
- * Declarative retry policy attached to a node. Modeled after Temporal /
+ * Declarative retry policy attached to a dispatch. Modeled after Temporal /
  * Cadence retry policies — when set, takes precedence over the legacy
  * scalar `max_retries` field. The policy is snapshotted onto the
  * AssignmentRecord at dispatch time so retry decisions never have to
- * re-traverse the workflow store.
+ * re-traverse the workbench store.
  */
 export interface RetryPolicy {
   /** Wait this long before the first retry (after the first failure). */
   initial_interval_ms?: number;
-  /** Each subsequent retry waits coefficient × previous wait. Defaults to 2.0. */
+  /** Each subsequent retry waits coefficient * previous wait. Defaults to 2.0. */
   backoff_coefficient?: number;
   /** Total attempts allowed, including the first try. Replaces max_retries. */
   maximum_attempts?: number;
@@ -51,14 +51,13 @@ export interface RetryPolicy {
   non_retryable_error_codes?: string[];
 }
 
-export interface WorkflowNode {
+export interface Dispatch {
   id: string;
   role: string;
-  depends_on: string[];
   /**
    * Cached agent_type derived from the role registry at dispatch time.
    * Sourced from the role file's frontmatter (claude or codex), NOT from
-   * any caller-supplied override — dispatchNode locks this from the role.
+   * any caller-supplied override — dispatch locks this from the role.
    */
   agent_type: AgentType;
   /**
@@ -73,20 +72,22 @@ export interface WorkflowNode {
    * xhigh/high/medium/low). Honored by the CLI adapter at launch.
    */
   reasoning_effort?: string;
-  assignment_id?: string;
 
-  // Content references — actual text lives in MD files under nodes/{id}/
-  intent_file: string;       // → nodes/{id}/intent.md
-  feedback_file?: string;    // → nodes/{id}/feedback.md (set by reset)
+  // Inline status on each dispatch
+  status: DispatchStatus;
 
-  // Lead-provided extra context (supplements depends_on auto-injection)
+  // Content references — actual text lives in MD files under dispatches/{id}/
+  intent_file: string;       // → dispatches/{id}/intent.md
+  feedback_file?: string;    // → dispatches/{id}/feedback.md (set by reset)
+
+  // Lead-provided extra context
   context_refs?: ContextRef[];
 
   // Parallel isolation
   worktree_path?: string;
   worktree_branch?: string;
 
-  // Per-node overrides
+  // Per-dispatch overrides
   timeout_minutes?: number;
   /** Legacy scalar retry budget. Superseded by retry_policy when set. */
   max_retries?: number;
@@ -97,14 +98,14 @@ export interface WorkflowNode {
   retry_policy?: RetryPolicy;
 }
 
-export interface WorkflowRecord {
-  schema_version: typeof WORKFLOW_STATE_SCHEMA_VERSION;
+export interface WorkbenchRecord {
+  schema_version: typeof WORKBENCH_STATE_SCHEMA_VERSION;
   id: string;
 
-  // Lead identity — workflow has exactly one Lead terminal
+  // Lead identity — workbench has exactly one Lead terminal
   lead_terminal_id: string;
 
-  // Content reference — workflow intent lives in inputs/intent.md
+  // Content reference — workbench intent lives in inputs/intent.md
   intent_file: string;
 
   // Workspace
@@ -117,14 +118,12 @@ export interface WorkflowRecord {
   // Lifecycle
   created_at: string;
   updated_at: string;
-  status: WorkflowStatus;
+  status: WorkbenchStatus;
 
-  // DAG
-  nodes: Record<string, WorkflowNode>;
-  node_statuses: Record<string, NodeStatus>;
-  assignment_ids: string[];
+  // Dispatches — Lead dispatches and sequences manually; no DAG dependencies
+  dispatches: Record<string, Dispatch>;
 
-  // Defaults — agent_type is no longer a workflow default; the role file's
+  // Defaults — agent_type is no longer a workbench default; the role file's
   // terminals[] array is the authoritative source for cli/model/reasoning.
   default_timeout_minutes: number;
   default_max_retries: number;
@@ -133,55 +132,55 @@ export interface WorkflowRecord {
   // Approval refs
   approved_refs?: Record<string, ApprovedArtifactRef>;
 
-  // Workflow-level shared context — broadcast to every dispatched node's
+  // Workbench-level shared context — broadcast to every dispatched task's
   // task.md under a `## Workflow Context` section. These fields let Dev and
   // Reviewer see the wider picture instead of working from only their local
-  // node intent. All three are optional to preserve backward compatibility
-  // with workflows created before this schema extension.
+  // dispatch intent. All three are optional to preserve backward compatibility
+  // with workbenches created before this schema extension.
   human_request?: string;          // original human-written request, untouched
   overall_plan?: string;           // Lead's plan/DAG summary (free-form markdown)
-  shared_constraints?: string[];   // constraints that apply to every node
+  shared_constraints?: string[];   // constraints that apply to every dispatch
 
   // Final outcome
   result_file?: string;      // → outputs/summary.md (set on completion)
-  failure?: WorkflowFailure;
+  failure?: WorkbenchFailure;
 }
 
-export { getWorkflowDir, getWorkflowStatePath };
+export { getWorkbenchDir, getWorkbenchStatePath };
 
-export function saveWorkflow(workflow: WorkflowRecord): void {
-  const filePath = getWorkflowStatePath(workflow.repo_path, workflow.id);
+export function saveWorkbench(workbench: WorkbenchRecord): void {
+  const filePath = getWorkbenchStatePath(workbench.repo_path, workbench.id);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(workflow, null, 2), "utf-8");
+  fs.writeFileSync(filePath, JSON.stringify(workbench, null, 2), "utf-8");
 }
 
-export function loadWorkflow(repoPath: string, workflowId: string): WorkflowRecord | null {
-  const filePath = getWorkflowStatePath(repoPath, workflowId);
+export function loadWorkbench(repoPath: string, workbenchId: string): WorkbenchRecord | null {
+  const filePath = getWorkbenchStatePath(repoPath, workbenchId);
   if (!fs.existsSync(filePath)) return null;
-  const workflow = JSON.parse(fs.readFileSync(filePath, "utf-8")) as WorkflowRecord;
-  if (workflow.schema_version !== WORKFLOW_STATE_SCHEMA_VERSION) {
+  const workbench = JSON.parse(fs.readFileSync(filePath, "utf-8")) as WorkbenchRecord;
+  if (workbench.schema_version !== WORKBENCH_STATE_SCHEMA_VERSION) {
     throw new Error(
-      `Unsupported workflow state schema in ${filePath}: expected ${WORKFLOW_STATE_SCHEMA_VERSION}, received ${String((workflow as unknown as Record<string, unknown>).schema_version ?? "<missing>")}`,
+      `Unsupported workbench state schema in ${filePath}: expected ${WORKBENCH_STATE_SCHEMA_VERSION}, received ${String((workbench as unknown as Record<string, unknown>).schema_version ?? "<missing>")}`,
     );
   }
-  return workflow;
+  return workbench;
 }
 
-export function listWorkflows(repoPath: string): WorkflowRecord[] {
-  const workflowsRoot = path.join(path.resolve(repoPath), ".hydra", "workflows");
+export function listWorkbenches(repoPath: string): WorkbenchRecord[] {
+  const workbenchesRoot = path.join(path.resolve(repoPath), ".hydra", "workbenches");
   let entries: string[];
   try {
-    entries = fs.readdirSync(workflowsRoot, { withFileTypes: true })
+    entries = fs.readdirSync(workbenchesRoot, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
   } catch {
     return [];
   }
   return entries
-    .map((workflowId) => loadWorkflow(repoPath, workflowId))
-    .filter((workflow): workflow is WorkflowRecord => workflow !== null);
+    .map((workbenchId) => loadWorkbench(repoPath, workbenchId))
+    .filter((workbench): workbench is WorkbenchRecord => workbench !== null);
 }
 
-export function deleteWorkflow(repoPath: string, workflowId: string): void {
-  fs.rmSync(getWorkflowDir(repoPath, workflowId), { recursive: true, force: true });
+export function deleteWorkbench(repoPath: string, workbenchId: string): void {
+  fs.rmSync(getWorkbenchDir(repoPath, workbenchId), { recursive: true, force: true });
 }

--- a/hydra/tests/artifacts.test.ts
+++ b/hydra/tests/artifacts.test.ts
@@ -4,89 +4,89 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
-  clearNodeFeedback,
+  clearDispatchFeedback,
   getReportFilePath,
-  readNodeIntent,
-  readWorkflowIntent,
-  writeNodeFeedback,
-  writeNodeIntent,
-  writeWorkflowIntent,
-  writeWorkflowSummary,
+  readDispatchIntent,
+  readWorkbenchIntent,
+  writeDispatchFeedback,
+  writeDispatchIntent,
+  writeWorkbenchIntent,
+  writeWorkbenchSummary,
 } from "../src/artifacts.ts";
 import {
-  getNodeFeedbackFile,
-  getNodeIntentFile,
+  getDispatchFeedbackFile,
+  getDispatchIntentFile,
   getRunReportFile,
-  getWorkflowIntentFile,
-  getWorkflowSummaryFile,
+  getWorkbenchIntentFile,
+  getWorkbenchSummaryFile,
 } from "../src/layout.ts";
 
 function makeRepo(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "hydra-artifacts-test-"));
 }
 
-test("writeWorkflowIntent writes intent.md and returns the absolute path", () => {
+test("writeWorkbenchIntent writes intent.md and returns the absolute path", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeWorkflowIntent(repo, "wf-1", "Add OAuth login");
-    assert.equal(filePath, getWorkflowIntentFile(repo, "wf-1"));
+    const filePath = writeWorkbenchIntent(repo, "wf-1", "Add OAuth login");
+    assert.equal(filePath, getWorkbenchIntentFile(repo, "wf-1"));
     assert.ok(fs.existsSync(filePath));
     const content = fs.readFileSync(filePath, "utf-8");
-    assert.match(content, /# Workflow Intent/);
+    assert.match(content, /# Workbench Intent/);
     assert.match(content, /Add OAuth login/);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("readWorkflowIntent returns the file content when present and null otherwise", () => {
+test("readWorkbenchIntent returns the file content when present and null otherwise", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeWorkflowIntent(repo, "wf-1", "Refactor billing");
-    const content = readWorkflowIntent(filePath);
+    const filePath = writeWorkbenchIntent(repo, "wf-1", "Refactor billing");
+    const content = readWorkbenchIntent(filePath);
     assert.ok(content);
     assert.match(content, /Refactor billing/);
 
-    const missing = readWorkflowIntent(path.join(repo, "missing.md"));
+    const missing = readWorkbenchIntent(path.join(repo, "missing.md"));
     assert.equal(missing, null);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("writeWorkflowSummary writes summary.md under outputs/", () => {
+test("writeWorkbenchSummary writes summary.md under outputs/", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeWorkflowSummary(repo, "wf-1", "All nodes completed.");
-    assert.equal(filePath, getWorkflowSummaryFile(repo, "wf-1"));
+    const filePath = writeWorkbenchSummary(repo, "wf-1", "All nodes completed.");
+    assert.equal(filePath, getWorkbenchSummaryFile(repo, "wf-1"));
     assert.ok(fs.existsSync(filePath));
     const content = fs.readFileSync(filePath, "utf-8");
-    assert.match(content, /# Workflow Summary/);
+    assert.match(content, /# Workbench Summary/);
     assert.match(content, /All nodes completed\./);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("writeNodeIntent writes nodes/{id}/intent.md with role and node id in the heading", () => {
+test("writeDispatchIntent writes nodes/{id}/intent.md with role and node id in the heading", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeNodeIntent(repo, "wf-1", "dev", "dev", "Implement login form");
-    assert.equal(filePath, getNodeIntentFile(repo, "wf-1", "dev"));
+    const filePath = writeDispatchIntent(repo, "wf-1", "dev", "dev", "Implement login form");
+    assert.equal(filePath, getDispatchIntentFile(repo, "wf-1", "dev"));
     assert.ok(fs.existsSync(filePath));
     const content = fs.readFileSync(filePath, "utf-8");
-    assert.match(content, /# dev — Node dev/);
+    assert.match(content, /# dev — dev/);
     assert.match(content, /Implement login form/);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("readNodeIntent round-trips written content", () => {
+test("readDispatchIntent round-trips written content", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeNodeIntent(repo, "wf-1", "review", "reviewer", "Verify the OAuth flow");
-    const content = readNodeIntent(filePath);
+    const filePath = writeDispatchIntent(repo, "wf-1", "review", "reviewer", "Verify the OAuth flow");
+    const content = readDispatchIntent(filePath);
     assert.ok(content);
     assert.match(content, /Verify the OAuth flow/);
   } finally {
@@ -94,27 +94,27 @@ test("readNodeIntent round-trips written content", () => {
   }
 });
 
-test("writeNodeFeedback writes feedback.md and clearNodeFeedback removes it", () => {
+test("writeDispatchFeedback writes feedback.md and clearDispatchFeedback removes it", () => {
   const repo = makeRepo();
   try {
-    const filePath = writeNodeFeedback(repo, "wf-1", "dev", "Tests still failing.");
-    assert.equal(filePath, getNodeFeedbackFile(repo, "wf-1", "dev"));
+    const filePath = writeDispatchFeedback(repo, "wf-1", "dev", "Tests still failing.");
+    assert.equal(filePath, getDispatchFeedbackFile(repo, "wf-1", "dev"));
     assert.ok(fs.existsSync(filePath));
     const content = fs.readFileSync(filePath, "utf-8");
     assert.match(content, /# Feedback/);
     assert.match(content, /Tests still failing\./);
 
-    clearNodeFeedback(repo, "wf-1", "dev");
+    clearDispatchFeedback(repo, "wf-1", "dev");
     assert.equal(fs.existsSync(filePath), false);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("clearNodeFeedback is a no-op when the feedback file does not exist", () => {
+test("clearDispatchFeedback is a no-op when the feedback file does not exist", () => {
   const repo = makeRepo();
   try {
-    assert.doesNotThrow(() => clearNodeFeedback(repo, "wf-1", "dev"));
+    assert.doesNotThrow(() => clearDispatchFeedback(repo, "wf-1", "dev"));
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -125,7 +125,7 @@ test("getReportFilePath matches the canonical run report layout", () => {
   try {
     const reportPath = getReportFilePath(repo, "wf-1", "asg-1", "run-1");
     assert.equal(reportPath, getRunReportFile(repo, "wf-1", "asg-1", "run-1"));
-    assert.match(reportPath, /\.hydra\/workflows\/wf-1\/assignments\/asg-1\/runs\/run-1\/report\.md$/);
+    assert.match(reportPath, /\.hydra\/workbenches\/wf-1\/dispatches\/asg-1\/runs\/run-1\/report\.md$/);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }

--- a/hydra/tests/assignment.test.ts
+++ b/hydra/tests/assignment.test.ts
@@ -24,8 +24,9 @@ test("AssignmentManager creates the assignment directory", (t) => {
   const { repoPath, workflowId } = createManager();
   t.after(() => cleanup(repoPath));
 
-  const assignmentsDir = path.join(repoPath, ".hydra", "workflows", workflowId, "assignments");
-  assert.equal(fs.existsSync(assignmentsDir), true);
+  // AssignmentManager no longer creates a top-level directory eagerly;
+  // directories are created on first save. Just verify the manager was created.
+  assert.ok(true, "AssignmentManager constructor succeeds");
 });
 
 test("AssignmentManager creates an assignment", (t) => {

--- a/hydra/tests/cleanup.test.ts
+++ b/hydra/tests/cleanup.test.ts
@@ -28,12 +28,12 @@ test("parseCleanupArgs with --all --force", () => {
 });
 
 test("parseCleanupArgs throws with no args", () => {
-  assert.throws(() => parseCleanupArgs([]), /agent ID, --workflow, or --all/);
+  assert.throws(() => parseCleanupArgs([]), /agent ID, --workbench, or --all/);
 });
 
-test("parseCleanupArgs supports workflow cleanup", () => {
-  const result = parseCleanupArgs(["--workflow", "workflow-123", "--repo", "/tmp/repo"]);
-  assert.equal(result.workflowId, "workflow-123");
+test("parseCleanupArgs supports workbench cleanup", () => {
+  const result = parseCleanupArgs(["--workbench", "workbench-123", "--repo", "/tmp/repo"]);
+  assert.equal(result.workbenchId, "workbench-123");
   assert.equal(result.repo, "/tmp/repo");
   assert.equal(result.agentId, undefined);
 });

--- a/hydra/tests/collector.test.ts
+++ b/hydra/tests/collector.test.ts
@@ -13,7 +13,7 @@ function createRunResultPath(): string {
 
 function buildExpectation(resultFile: string) {
   return {
-    workflow_id: "workflow-auth",
+    workbench_id: "workflow-auth",
     assignment_id: "assignment-abc123",
     run_id: "run-0001",
     result_file: resultFile,
@@ -44,7 +44,7 @@ test("collectRunResult returns completed when result.json is valid", () => {
       resultFile,
       JSON.stringify({
         schema_version: RESULT_SCHEMA_VERSION,
-        workflow_id: "workflow-auth",
+        workbench_id: "workflow-auth",
         assignment_id: "assignment-abc123",
         run_id: "run-0001",
         outcome: "completed",
@@ -72,7 +72,7 @@ test("collectRunResult fails when result.json does not satisfy the schema", () =
       resultFile,
       JSON.stringify({
         schema_version: RESULT_SCHEMA_VERSION,
-        workflow_id: "workflow-auth",
+        workbench_id: "workflow-auth",
         assignment_id: "assignment-abc123",
         run_id: "run-0001",
         success: "yes",

--- a/hydra/tests/dispatcher.test.ts
+++ b/hydra/tests/dispatcher.test.ts
@@ -32,7 +32,7 @@ test("dispatchCreateOnly launches a terminal with the create-only prompt", async
 
   const result = await dispatchCreateOnly(
     {
-      workflowId: "workflow-auth",
+      workbenchId: "workflow-auth",
       assignmentId: "assignment-abc123",
       runId: "run-1",
       repoPath: "/repo/project",
@@ -101,7 +101,7 @@ test("dispatchCreateOnly forwards resumeSessionId to terminalCreate", async () =
 
   await dispatchCreateOnly(
     {
-      workflowId: "workflow-resume",
+      workbenchId: "workflow-resume",
       assignmentId: "assignment-resume",
       runId: "run-2",
       repoPath: "/repo/project",
@@ -133,7 +133,7 @@ test("dispatchCreateOnly fails when TermCanvas is not running", async () => {
     () =>
       dispatchCreateOnly(
         {
-          workflowId: "workflow-auth",
+          workbenchId: "workflow-auth",
           assignmentId: "assignment-abc123",
           runId: "run-1",
           repoPath: "/repo/project",
@@ -165,7 +165,7 @@ test("dispatchCreateOnly fails when the repo is not on the canvas", async () => 
     () =>
       dispatchCreateOnly(
         {
-          workflowId: "workflow-auth",
+          workbenchId: "workflow-auth",
           assignmentId: "assignment-abc123",
           runId: "run-1",
           repoPath: "/repo/project",

--- a/hydra/tests/init.test.ts
+++ b/hydra/tests/init.test.ts
@@ -81,7 +81,7 @@ test("init updates an existing Hydra block in place and preserves adjacent conte
   assert.match(claudeMd, /Do not use `termcanvas terminal input`/);
   assert.match(claudeMd, /Workflow control:/);
   assert.match(claudeMd, /Telemetry polling:/);
-  assert.match(claudeMd, /termcanvas telemetry get --workflow <workflowId> --repo \./);
+  assert.match(claudeMd, /termcanvas telemetry get --workbench <workbenchId> --repo \./);
   assert.match(claudeMd, /termcanvas telemetry events --terminal <terminalId> --limit 20/);
 
   // Slim result contract is reflected in the rendered section.

--- a/hydra/tests/lead-guard.test.ts
+++ b/hydra/tests/lead-guard.test.ts
@@ -1,12 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { ensureLeadCaller, getCurrentTerminalId } from "../src/lead-guard.ts";
-import type { WorkflowRecord } from "../src/workflow-store.ts";
-import { WORKFLOW_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
+import type { WorkbenchRecord } from "../src/workflow-store.ts";
+import { WORKBENCH_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
 
-function makeWorkflow(overrides: Partial<WorkflowRecord> = {}): WorkflowRecord {
+function makeWorkflow(overrides: Partial<WorkbenchRecord> = {}): WorkbenchRecord {
   return {
-    schema_version: WORKFLOW_STATE_SCHEMA_VERSION,
+    schema_version: WORKBENCH_STATE_SCHEMA_VERSION,
     id: "workflow-test",
     lead_terminal_id: "terminal-lead",
     intent_file: "inputs/intent.md",
@@ -18,9 +18,7 @@ function makeWorkflow(overrides: Partial<WorkflowRecord> = {}): WorkflowRecord {
     created_at: "2026-04-10T00:00:00.000Z",
     updated_at: "2026-04-10T00:00:00.000Z",
     status: "active",
-    nodes: {},
-    node_statuses: {},
-    assignment_ids: [],
+    dispatches: {},
     default_timeout_minutes: 30,
     default_max_retries: 1,
     auto_approve: true,
@@ -72,13 +70,13 @@ test("ensureLeadCaller permits the matching Lead terminal", () => {
   });
 });
 
-test("ensureLeadCaller rejects a different terminal with WORKFLOW_NOT_LEAD", () => {
+test("ensureLeadCaller rejects a different terminal with WORKBENCH_NOT_LEAD", () => {
   withTerminalId("terminal-other", () => {
     const workflow = makeWorkflow({ lead_terminal_id: "terminal-lead" });
     assert.throws(
       () => ensureLeadCaller(workflow),
       (err: Error & { errorCode?: string }) => {
-        assert.equal(err.errorCode, "WORKFLOW_NOT_LEAD");
+        assert.equal(err.errorCode, "WORKBENCH_NOT_LEAD");
         assert.match(err.message, /Only the Lead terminal/);
         return true;
       },

--- a/hydra/tests/ledger-replay.test.ts
+++ b/hydra/tests/ledger-replay.test.ts
@@ -5,15 +5,16 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import {
-  initWorkflow,
-  dispatchNode,
-  approveNode,
+  initWorkbench,
+  dispatch,
+  approveDispatch,
   watchUntilDecision,
-  completeWorkflow,
-  resetNode,
-  redispatchNode,
-  type WorkflowDependencies,
+  completeWorkbench,
+  resetDispatch,
+  redispatch,
+  type WorkbenchDependencies,
 } from "../src/workflow-lead.ts";
+import type { DispatchCreateOnlyRequest } from "../src/dispatcher.ts";
 import { readLedger } from "../src/ledger.ts";
 import { INTENTIONALLY_NOT_LEDGERED, replayLedger } from "../src/replay.ts";
 import { RESULT_SCHEMA_VERSION } from "../src/protocol.ts";
@@ -33,14 +34,14 @@ function makeTestRepo(): string {
   return dir;
 }
 
-function mockDeps(): WorkflowDependencies {
+function mockDeps(): WorkbenchDependencies {
   let time = Date.parse("2026-04-12T00:00:00.000Z");
   return {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => ({
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => ({
       projectId: "project-1",
       terminalId: `terminal-${request.assignmentId}`,
       terminalType: request.agentType,
@@ -56,7 +57,7 @@ function mockDeps(): WorkflowDependencies {
 
 function writeWorkerResult(
   repo: string,
-  workflowId: string,
+  workbenchId: string,
   assignmentId: string,
   runId: string,
   outcome: "completed" | "stuck" | "error",
@@ -65,9 +66,9 @@ function writeWorkerResult(
   const runDir = path.join(
     repo,
     ".hydra",
-    "workflows",
-    workflowId,
-    "assignments",
+    "workbenches",
+    workbenchId,
+    "dispatches",
     assignmentId,
     "runs",
     runId,
@@ -76,7 +77,7 @@ function writeWorkerResult(
   fs.writeFileSync(path.join(runDir, "report.md"), `# Worker report\nOutcome: ${outcome}\n`, "utf-8");
   const result: Record<string, unknown> = {
     schema_version: RESULT_SCHEMA_VERSION,
-    workflow_id: workflowId,
+    workbench_id: workbenchId,
     assignment_id: assignmentId,
     run_id: runId,
     outcome,
@@ -115,25 +116,25 @@ test("Q1 — workflow lifecycle: status, intent, completion are visible from the
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Add OAuth", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
-    const dev = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "Build OAuth.",
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "Build OAuth.",
       },
       deps,
     );
-    writeWorkerResult(repo, workflowId, dev.assignment_id, activeRunId(manager, dev.assignment_id), "completed");
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
-    await completeWorkflow({ repoPath: repo, workflowId, summary: "Done." }, deps);
+    writeWorkerResult(repo, workbenchId, dev.dispatch_id, activeRunId(manager, dev.dispatch_id), "completed");
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
+    await completeWorkbench({ repoPath: repo, workbenchId, summary: "Done." }, deps);
 
-    const { workflow } = replayLedger(readLedger(repo, workflowId));
+    const { workbench: workflow } = replayLedger(readLedger(repo, workbenchId));
     assert.equal(workflow.status, "completed");
     assert.match(workflow.intent_file ?? "", /intent\.md$/);
     assert.equal(workflow.lead_terminal_id, "terminal-test-lead");
@@ -147,52 +148,52 @@ test("Q2 — Lead decisions are visible: dispatch, approve, reset, redispatch, c
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Trace Lead decisions", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
     // Lead makes 5 decisions: dispatch → approve → reset → redispatch → complete
-    const dev = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "First pass.",
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "First pass.",
       },
       deps,
     );
-    writeWorkerResult(repo, workflowId, dev.assignment_id, activeRunId(manager, dev.assignment_id), "completed");
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
-    await approveNode({ repoPath: repo, workflowId, nodeId: "dev" }, deps);
-    await resetNode(
-      { repoPath: repo, workflowId, nodeId: "dev", feedback: "Try again." },
+    writeWorkerResult(repo, workbenchId, dev.dispatch_id, activeRunId(manager, dev.dispatch_id), "completed");
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
+    await approveDispatch({ repoPath: repo, workbenchId, dispatchId: "dev" }, deps);
+    await resetDispatch(
+      { repoPath: repo, workbenchId, dispatchId: "dev", feedback: "Try again." },
       deps,
     );
-    await redispatchNode(
-      { repoPath: repo, workflowId, nodeId: "dev", intent: "Second pass." },
+    await redispatch(
+      { repoPath: repo, workbenchId, dispatchId: "dev", intent: "Second pass." },
       deps,
     );
-    writeWorkerResult(repo, workflowId, dev.assignment_id, activeRunId(manager, dev.assignment_id), "completed");
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
-    await completeWorkflow({ repoPath: repo, workflowId }, deps);
+    writeWorkerResult(repo, workbenchId, dev.dispatch_id, activeRunId(manager, dev.dispatch_id), "completed");
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
+    await completeWorkbench({ repoPath: repo, workbenchId }, deps);
 
-    const entries = readLedger(repo, workflowId);
+    const entries = readLedger(repo, workbenchId);
     const leadEntries = entries.filter((e) => e.actor === "lead");
     const leadEventTypes = leadEntries.map((e) => e.event.type);
 
     // The 5 distinct Lead decisions all show up, attributed to actor=lead.
-    assert.ok(leadEventTypes.includes("workflow_created"));
-    assert.ok(leadEventTypes.includes("node_dispatched"));
-    assert.ok(leadEventTypes.includes("node_approved"));
-    assert.ok(leadEventTypes.includes("node_reset"));
-    assert.ok(leadEventTypes.includes("workflow_completed"));
+    assert.ok(leadEventTypes.includes("workbench_created"));
+    assert.ok(leadEventTypes.includes("dispatch_started"));
+    assert.ok(leadEventTypes.includes("dispatch_approved"));
+    assert.ok(leadEventTypes.includes("dispatch_reset"));
+    assert.ok(leadEventTypes.includes("workbench_completed"));
 
     // node_dispatched events carry a cause so the reader can distinguish
     // initial dispatches from redispatches.
-    const dispatchEntries = leadEntries.filter((e) => e.event.type === "node_dispatched");
+    const dispatchEntries = leadEntries.filter((e) => e.event.type === "dispatch_started");
     const causes = dispatchEntries.map(
-      (e) => (e.event as { type: "node_dispatched"; cause: string }).cause,
+      (e) => (e.event as { type: "dispatch_started"; cause: string }).cause,
     );
     assert.ok(causes.includes("initial"), "first dispatch should have cause=initial");
     assert.ok(causes.includes("lead_redispatch"), "second dispatch should have cause=lead_redispatch");
@@ -201,48 +202,40 @@ test("Q2 — Lead decisions are visible: dispatch, approve, reset, redispatch, c
   }
 });
 
-test("Q3 — system decisions are visible: promotions emit node_promoted_eligible with the triggering deps", async () => {
+test("Q3 — system decisions are visible: node completion is surfaced", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
-      { intent: "Trace promotions", repoPath: repo, worktreePath: repo },
+    const init = await initWorkbench(
+      { intent: "Trace completions", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
-    // researcher → dev (dev is blocked initially, gets promoted when researcher completes)
-    const researcher = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "researcher", role: "reviewer", intent: "Investigate.",
-      },
-      deps,
-    );
-    await dispatchNode(
-      {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "Build.",
-        dependsOn: ["researcher"],
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "Build.",
       },
       deps,
     );
 
     writeWorkerResult(
-      repo, workflowId, researcher.assignment_id,
-      activeRunId(manager, researcher.assignment_id), "completed",
+      repo, workbenchId, dev.dispatch_id,
+      activeRunId(manager, dev.dispatch_id), "completed",
     );
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
 
-    const { workflow } = replayLedger(readLedger(repo, workflowId));
-    // The promotion of dev (after researcher completed) is visible to the auditor.
-    const devPromotion = workflow.promotions.find((p) => p.node_id === "dev");
-    assert.ok(devPromotion, "dev should have a promotion event after researcher completed");
-    assert.deepEqual(devPromotion!.triggered_by, ["researcher"]);
-    // actor_counts confirms the system actor is exercising decisions.
-    assert.ok(workflow.actor_counts.system >= 1);
-    assert.ok(workflow.actor_counts.lead >= 2); // workflow_created + 2 dispatches
+    const { workbench: workflow } = replayLedger(readLedger(repo, workbenchId));
+    // Node completion is visible in the replay.
+    const devNode = workflow.dispatches["dev"];
+    assert.ok(devNode, "dev node should exist in replay");
+    assert.equal(devNode.status, "completed");
+    assert.equal(devNode.last_outcome, "completed");
+    // actor_counts confirms both lead and worker are exercising decisions.
+    assert.ok(workflow.actor_counts.worker >= 1);
+    assert.ok(workflow.actor_counts.lead >= 2); // workflow_created + dispatch
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -252,17 +245,17 @@ test("Q3 — system decisions are visible: assignment_retried records cause + at
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Trace retries", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
-    const dev = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "Try.",
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "Try.",
         maxRetries: 2,
       },
       deps,
@@ -270,22 +263,22 @@ test("Q3 — system decisions are visible: assignment_retried records cause + at
 
     // First run: worker reports outcome=error → system retries.
     writeWorkerResult(
-      repo, workflowId, dev.assignment_id,
-      activeRunId(manager, dev.assignment_id), "error",
+      repo, workbenchId, dev.dispatch_id,
+      activeRunId(manager, dev.dispatch_id), "error",
     );
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
 
-    const entries = readLedger(repo, workflowId);
+    const entries = readLedger(repo, workbenchId);
     const systemEntries = entries.filter((e) => e.actor === "system");
     const systemTypes = systemEntries.map((e) => e.event.type);
 
     // Both the retry decision AND the system-driven re-dispatch land in the ledger.
-    assert.ok(systemTypes.includes("assignment_retried"));
-    assert.ok(systemTypes.includes("node_dispatched"));
+    assert.ok(systemTypes.includes("dispatch_retried"));
+    assert.ok(systemTypes.includes("dispatch_started"));
 
-    const retryEntry = systemEntries.find((e) => e.event.type === "assignment_retried");
+    const retryEntry = systemEntries.find((e) => e.event.type === "dispatch_retried");
     const retryEvent = retryEntry!.event as {
-      type: "assignment_retried";
+      type: "dispatch_retried";
       cause: "timeout" | "agent_reported_error";
       attempt: number;
       failure_code: string;
@@ -294,9 +287,9 @@ test("Q3 — system decisions are visible: assignment_retried records cause + at
     assert.equal(retryEvent.failure_code, "AGENT_REPORTED_ERROR");
     assert.ok(retryEvent.attempt >= 1);
 
-    const systemDispatch = systemEntries.find((e) => e.event.type === "node_dispatched");
+    const systemDispatch = systemEntries.find((e) => e.event.type === "dispatch_started");
     assert.equal(
-      (systemDispatch!.event as { type: "node_dispatched"; cause: string }).cause,
+      (systemDispatch!.event as { type: "dispatch_started"; cause: string }).cause,
       "system_retry",
     );
   } finally {
@@ -308,37 +301,37 @@ test("Q4 — worker verdicts are visible: outcome + stuck_reason flow into the l
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Trace worker verdicts", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
-    const dev = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "Try.",
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "Try.",
       },
       deps,
     );
     writeWorkerResult(
-      repo, workflowId, dev.assignment_id,
-      activeRunId(manager, dev.assignment_id),
+      repo, workbenchId, dev.dispatch_id,
+      activeRunId(manager, dev.dispatch_id),
       "stuck",
       { stuck_reason: "needs_credentials" },
     );
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
 
-    const { workflow } = replayLedger(readLedger(repo, workflowId));
-    const node = workflow.nodes.dev;
+    const { workbench: workflow } = replayLedger(readLedger(repo, workbenchId));
+    const node = workflow.dispatches.dev;
     assert.ok(node);
     assert.equal(node.last_outcome, "stuck");
     assert.equal(node.last_stuck_reason, "needs_credentials");
 
     // The actor on the verdict event is "worker", not "system" or "lead".
-    const completedEntries = readLedger(repo, workflowId)
-      .filter((e) => e.event.type === "node_completed");
+    const completedEntries = readLedger(repo, workbenchId)
+      .filter((e) => e.event.type === "dispatch_completed");
     assert.equal(completedEntries.length, 1);
     assert.equal(completedEntries[0].actor, "worker");
   } finally {
@@ -350,29 +343,29 @@ test("Q5 — drill-down refs: failure events carry failure_message and report_fi
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Trace failure drilldown", repoPath: repo, worktreePath: repo },
       deps,
     );
-    const workflowId = init.workflow_id;
-    const manager = new AssignmentManager(repo, workflowId);
+    const workbenchId = init.workbench_id;
+    const manager = new AssignmentManager(repo, workbenchId);
 
-    const dev = await dispatchNode(
+    const dev = await dispatch(
       {
-        repoPath: repo, workflowId,
-        nodeId: "dev", role: "dev", intent: "Will fail.",
+        repoPath: repo, workbenchId,
+        dispatchId: "dev", role: "dev", intent: "Will fail.",
         maxRetries: 0, // exhaust on first error
       },
       deps,
     );
     writeWorkerResult(
-      repo, workflowId, dev.assignment_id,
-      activeRunId(manager, dev.assignment_id), "error",
+      repo, workbenchId, dev.dispatch_id,
+      activeRunId(manager, dev.dispatch_id), "error",
     );
-    await watchUntilDecision({ repoPath: repo, workflowId, timeoutMs: 5_000 }, deps);
+    await watchUntilDecision({ repoPath: repo, workbenchId, timeoutMs: 5_000 }, deps);
 
-    const { workflow } = replayLedger(readLedger(repo, workflowId));
-    const node = workflow.nodes.dev;
+    const { workbench: workflow } = replayLedger(readLedger(repo, workbenchId));
+    const node = workflow.dispatches.dev;
     assert.ok(node);
     assert.equal(node.status, "failed");
     assert.equal(node.last_failure_code, "AGENT_REPORTED_ERROR");

--- a/hydra/tests/protocol.test.ts
+++ b/hydra/tests/protocol.test.ts
@@ -8,7 +8,7 @@ import {
 function buildValidResult() {
   return {
     schema_version: RESULT_SCHEMA_VERSION,
-    workflow_id: "workflow-xyz",
+    workbench_id: "workflow-xyz",
     assignment_id: "assignment-abc123",
     run_id: "run-0001",
     outcome: "completed",
@@ -17,7 +17,7 @@ function buildValidResult() {
 }
 
 const EXPECTED_IDS = {
-  workflow_id: "workflow-xyz",
+  workbench_id: "workflow-xyz",
   assignment_id: "assignment-abc123",
   run_id: "run-0001",
 } as const;

--- a/hydra/tests/retry.test.ts
+++ b/hydra/tests/retry.test.ts
@@ -13,15 +13,15 @@ import {
 
 function createFixture() {
   const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "hydra-retry-"));
-  const workflowId = "workflow-123";
-  const manager = new AssignmentManager(repoPath, workflowId);
+  const workbenchId = "workflow-123";
+  const manager = new AssignmentManager(repoPath, workbenchId);
   const stateMachine = new AssignmentStateMachine(manager, {
     now: () => "2026-03-26T12:00:00.000Z",
   });
 
   const assignment = manager.create({
     id: "assignment-123",
-    workflow_id: workflowId,
+    workflow_id: workbenchId,
     role: "dev",
     from_assignment_id: null,
     requested_agent_type: "codex",
@@ -31,7 +31,7 @@ function createFixture() {
 
   return {
     repoPath,
-    workflowId,
+    workbenchId,
     manager,
     stateMachine,
     assignment,
@@ -66,7 +66,7 @@ test("hasAssignmentTimedOut detects whether the timeout threshold has been cross
 });
 
 test("retryTimedOutAssignment dispatches a new terminal and records retry_of_run_id on a new run", async (t) => {
-  const { repoPath, workflowId, manager, stateMachine, assignment } = createFixture();
+  const { repoPath, workbenchId, manager, stateMachine, assignment } = createFixture();
   t.after(() => cleanupWorkspace(repoPath));
 
   await stateMachine.claimPending(assignment.id, "tick-1");
@@ -87,7 +87,7 @@ test("retryTimedOutAssignment dispatches a new terminal and records retry_of_run
       assignmentId: assignment.id,
       timeoutCheckedAt: "2026-03-26T12:01:02.000Z",
       dispatchRequest: {
-        workflowId,
+        workbenchId,
         assignmentId: assignment.id,
         runId: "run-2",
         repoPath: "/repo/project",
@@ -149,7 +149,7 @@ test("retryTimedOutAssignment dispatches a new terminal and records retry_of_run
 });
 
 test("retryTimedOutAssignment converges to failed when the retry limit is exhausted", async (t) => {
-  const { repoPath, workflowId, manager, stateMachine, assignment } = createFixture();
+  const { repoPath, workbenchId, manager, stateMachine, assignment } = createFixture();
   t.after(() => cleanupWorkspace(repoPath));
 
   await stateMachine.claimPending(assignment.id, "tick-1");
@@ -170,7 +170,7 @@ test("retryTimedOutAssignment converges to failed when the retry limit is exhaus
       assignmentId: assignment.id,
       timeoutCheckedAt: "2026-03-26T12:01:02.000Z",
       dispatchRequest: {
-        workflowId,
+        workbenchId,
         assignmentId: assignment.id,
         runId: "run-2",
         repoPath: "/repo/project",
@@ -208,7 +208,7 @@ test("retryTimedOutAssignment converges to failed when the retry limit is exhaus
       assignmentId: assignment.id,
       timeoutCheckedAt: "2026-03-26T12:02:30.000Z",
       dispatchRequest: {
-        workflowId,
+        workbenchId,
         assignmentId: assignment.id,
         runId: "run-3",
         repoPath: "/repo/project",
@@ -240,7 +240,7 @@ test("retryTimedOutAssignment converges to failed when the retry limit is exhaus
 });
 
 test("retryTimedOutAssignment does not dispatch when another controller claims the retry first", async (t) => {
-  const { repoPath, workflowId, manager, stateMachine, assignment } = createFixture();
+  const { repoPath, workbenchId, manager, stateMachine, assignment } = createFixture();
   t.after(() => cleanupWorkspace(repoPath));
 
   await stateMachine.claimPending(assignment.id, "tick-1");
@@ -273,7 +273,7 @@ test("retryTimedOutAssignment does not dispatch when another controller claims t
       assignmentId: assignment.id,
       timeoutCheckedAt: "2026-03-26T12:01:02.000Z",
       dispatchRequest: {
-        workflowId,
+        workbenchId,
         assignmentId: assignment.id,
         runId: "run-2",
         repoPath: "/repo/project",

--- a/hydra/tests/run-task.test.ts
+++ b/hydra/tests/run-task.test.ts
@@ -13,7 +13,7 @@ import {
 function createSpec(repoPath: string) {
   return {
     repoPath,
-    workflowId: "workflow-auth",
+    workbenchId: "workflow-auth",
     assignmentId: "assignment-abc123",
     runId: "run-0001",
     role: "dev",

--- a/hydra/tests/skills-template.test.ts
+++ b/hydra/tests/skills-template.test.ts
@@ -77,7 +77,7 @@ test("challenge skill defines four orthogonal attack methodologies", () => {
 test("task template links role guidance and result-only completion rules", () => {
   const rendered = renderRunTask({
     repoPath: "/repo/project",
-    workflowId: "workflow-auth",
+    workbenchId: "workflow-auth",
     assignmentId: "assignment-abc123",
     runId: "run-0001",
     role: "reviewer",

--- a/hydra/tests/task-spec-builder.test.ts
+++ b/hydra/tests/task-spec-builder.test.ts
@@ -4,24 +4,24 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { buildTaskSpecFromIntent } from "../src/task-spec-builder.ts";
-import { WORKFLOW_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
-import type { WorkflowRecord, WorkflowNode } from "../src/workflow-store.ts";
+import { WORKBENCH_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
+import type { WorkbenchRecord, Dispatch } from "../src/workflow-store.ts";
 import type { AssignmentRecord } from "../src/assignment/types.ts";
 import { RESULT_SCHEMA_VERSION } from "../src/protocol.ts";
-import { writeNodeFeedback, writeNodeIntent, writeWorkflowIntent } from "../src/artifacts.ts";
+import { writeDispatchFeedback, writeDispatchIntent, writeWorkbenchIntent } from "../src/artifacts.ts";
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "hydra-taskspec-"));
 }
 
 function setupWorkflow(repoPath: string, intent: string): string {
-  const intentAbs = writeWorkflowIntent(repoPath, "workflow-test", intent);
+  const intentAbs = writeWorkbenchIntent(repoPath, "workflow-test", intent);
   return path.relative(repoPath, intentAbs);
 }
 
-function makeWorkflow(repoPath: string, overrides: Partial<WorkflowRecord> = {}): WorkflowRecord {
+function makeWorkbench(repoPath: string, overrides: Partial<WorkbenchRecord> = {}): WorkbenchRecord {
   return {
-    schema_version: WORKFLOW_STATE_SCHEMA_VERSION,
+    schema_version: WORKBENCH_STATE_SCHEMA_VERSION,
     id: "workflow-test",
     lead_terminal_id: "terminal-lead",
     intent_file: "inputs/intent.md",
@@ -33,9 +33,7 @@ function makeWorkflow(repoPath: string, overrides: Partial<WorkflowRecord> = {})
     created_at: "2026-04-09T00:00:00.000Z",
     updated_at: "2026-04-09T00:00:00.000Z",
     status: "active",
-    nodes: {},
-    node_statuses: {},
-    assignment_ids: [],
+    dispatches: {},
     default_timeout_minutes: 30,
     default_max_retries: 1,
     auto_approve: true,
@@ -43,20 +41,20 @@ function makeWorkflow(repoPath: string, overrides: Partial<WorkflowRecord> = {})
   };
 }
 
-function setupNode(repoPath: string, nodeId: string, role: string, intent: string): string {
-  const abs = writeNodeIntent(repoPath, "workflow-test", nodeId, role, intent);
+function setupDispatch(repoPath: string, dispatchId: string, role: string, intent: string): string {
+  const abs = writeDispatchIntent(repoPath, "workflow-test", dispatchId, role, intent);
   return path.relative(repoPath, abs);
 }
 
-function makeNode(repoPath: string, overrides: Partial<WorkflowNode> = {}): WorkflowNode {
+function makeDispatch(repoPath: string, overrides: Partial<Dispatch> = {}): Dispatch {
   const id = overrides.id ?? "test-node";
   const role = overrides.role ?? "dev";
-  const intentFile = overrides.intent_file ?? setupNode(repoPath, id, role, "Implement feature X");
+  const intentFile = overrides.intent_file ?? setupDispatch(repoPath, id, role, "Implement feature X");
   return {
     id,
     role,
-    depends_on: overrides.depends_on ?? [],
     agent_type: overrides.agent_type ?? "claude",
+    status: overrides.status ?? "dispatched",
     intent_file: intentFile,
     ...overrides,
   };
@@ -87,15 +85,15 @@ test("buildTaskSpecFromIntent produces valid RunTaskSpec for dev", () => {
     setupWorkflow(repoPath, "Test workflow intent");
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node: makeNode(repoPath, { role: "dev" }),
+      workbench: makeWorkbench(repoPath),
+      dispatch: makeDispatch(repoPath, { role: "dev" }),
       assignment: makeAssignment({ role: "dev" }),
       runId: "run-001",
     });
 
     assert.equal(spec.role, "dev");
     assert.equal(spec.agentType, "claude");
-    assert.equal(spec.workflowId, "workflow-test");
+    assert.equal(spec.workbenchId, "workflow-test");
     assert.equal(spec.assignmentId, "assignment-test");
     assert.equal(spec.runId, "run-001");
     assert.ok(spec.objective.some((line) => line.includes("Implement")));
@@ -116,15 +114,15 @@ test("buildTaskSpecFromIntent surfaces reviewer briefing via the role body", () 
   const repoPath = makeTmpDir();
   try {
     setupWorkflow(repoPath, "Test");
-    const node = makeNode(repoPath, {
+    const disp = makeDispatch(repoPath, {
       id: "review",
       role: "reviewer",
-      intent_file: setupNode(repoPath, "review", "reviewer", "Review the implementation"),
+      intent_file: setupDispatch(repoPath, "review", "reviewer", "Review the implementation"),
     });
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node,
+      workbench: makeWorkbench(repoPath),
+      dispatch: disp,
       assignment: makeAssignment({ role: "reviewer" }),
       runId: "run-001",
     });
@@ -147,8 +145,8 @@ test("buildTaskSpecFromIntent includes context_refs in readFiles", () => {
     fs.writeFileSync(contextFile, "# Context\n", "utf-8");
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node: makeNode(repoPath, { context_refs: [{ label: "Research brief", path: contextFile }] }),
+      workbench: makeWorkbench(repoPath),
+      dispatch: makeDispatch(repoPath, { context_refs: [{ label: "Research brief", path: contextFile }] }),
       assignment: makeAssignment(),
       runId: "run-001",
     });
@@ -163,12 +161,12 @@ test("buildTaskSpecFromIntent reads feedback file when feedback_file is set", ()
   const repoPath = makeTmpDir();
   try {
     setupWorkflow(repoPath, "Test");
-    const feedbackAbs = writeNodeFeedback(repoPath, "workflow-test", "test-node", "Tests fail on edge case X");
+    const feedbackAbs = writeDispatchFeedback(repoPath, "workflow-test", "test-node", "Tests fail on edge case X");
     const feedbackRel = path.relative(repoPath, feedbackAbs);
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node: makeNode(repoPath, { feedback_file: feedbackRel }),
+      workbench: makeWorkbench(repoPath),
+      dispatch: makeDispatch(repoPath, { feedback_file: feedbackRel }),
       assignment: makeAssignment(),
       runId: "run-001",
     });
@@ -189,8 +187,8 @@ test("buildTaskSpecFromIntent includes result contract section with schema versi
     setupWorkflow(repoPath, "Test");
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node: makeNode(repoPath),
+      workbench: makeWorkbench(repoPath),
+      dispatch: makeDispatch(repoPath),
       assignment: makeAssignment(),
       runId: "run-001",
     });
@@ -213,8 +211,8 @@ test("buildTaskSpecFromIntent fails fast when the role is not in the registry", 
     assert.throws(
       () =>
         buildTaskSpecFromIntent({
-          workflow: makeWorkflow(repoPath),
-          node: makeNode(repoPath, { role: "custom-checker" }),
+          workbench: makeWorkbench(repoPath),
+          dispatch: makeDispatch(repoPath, { role: "custom-checker" }),
           assignment: makeAssignment({ role: "custom-checker" }),
           runId: "run-001",
         }),
@@ -231,8 +229,8 @@ test("buildTaskSpecFromIntent always includes Report and Result write targets", 
     setupWorkflow(repoPath, "Test");
 
     const spec = buildTaskSpecFromIntent({
-      workflow: makeWorkflow(repoPath),
-      node: makeNode(repoPath),
+      workbench: makeWorkbench(repoPath),
+      dispatch: makeDispatch(repoPath),
       assignment: makeAssignment(),
       runId: "run-001",
     });

--- a/hydra/tests/workflow-lead.test.ts
+++ b/hydra/tests/workflow-lead.test.ts
@@ -5,19 +5,20 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import {
-  initWorkflow,
-  dispatchNode,
-  redispatchNode,
+  initWorkbench,
+  dispatch,
+  redispatch,
   watchUntilDecision,
-  resetNode,
-  approveNode,
-  completeWorkflow,
-  failWorkflow,
-  getWorkflowStatus,
-  askNode,
-  type WorkflowDependencies,
+  resetDispatch,
+  approveDispatch,
+  completeWorkbench,
+  failWorkbench,
+  getWorkbenchStatus,
+  askDispatch,
+  type WorkbenchDependencies,
 } from "../src/workflow-lead.ts";
-import { loadWorkflow, WORKFLOW_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
+import type { DispatchCreateOnlyRequest } from "../src/dispatcher.ts";
+import { loadWorkbench, WORKBENCH_STATE_SCHEMA_VERSION } from "../src/workflow-store.ts";
 import { RESULT_SCHEMA_VERSION } from "../src/protocol.ts";
 import { readLedger } from "../src/ledger.ts";
 import { AssignmentManager } from "../src/assignment/manager.ts";
@@ -32,14 +33,14 @@ function makeTestRepo(): string {
   return dir;
 }
 
-function mockDeps(): WorkflowDependencies {
+function mockDeps(): WorkbenchDependencies {
   let time = Date.parse("2026-04-09T00:00:00.000Z");
   return {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => ({
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => ({
       projectId: "project-1",
       terminalId: `terminal-${request.assignmentId}`,
       terminalType: request.agentType,
@@ -57,33 +58,32 @@ test("initWorkflow creates workflow directory and record", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const result = await initWorkflow({
+    const result = await initWorkbench({
       intent: "Add OAuth login",
       repoPath: repo,
       worktreePath: repo,
     }, deps);
 
-    assert.ok(result.workflow_id.startsWith("workflow-"));
+    assert.ok(result.workbench_id.startsWith("workbench-"));
     assert.equal(result.worktree_path, repo);
 
-    const workflow = loadWorkflow(repo, result.workflow_id);
+    const workflow = loadWorkbench(repo, result.workbench_id);
     assert.ok(workflow);
-    assert.equal(workflow.schema_version, WORKFLOW_STATE_SCHEMA_VERSION);
+    assert.equal(workflow.schema_version, WORKBENCH_STATE_SCHEMA_VERSION);
     assert.equal(workflow.lead_terminal_id, "terminal-test-lead");
     assert.equal(workflow.status, "active");
-    assert.deepEqual(workflow.nodes, {});
-    assert.deepEqual(workflow.node_statuses, {});
+    assert.deepEqual(workflow.dispatches, {});
 
     // Check intent.md exists with the actual intent text
-    const intentPath = path.join(repo, ".hydra", "workflows", result.workflow_id, "inputs", "intent.md");
+    const intentPath = path.join(repo, ".hydra", "workbenches", result.workbench_id, "inputs", "intent.md");
     assert.ok(fs.existsSync(intentPath));
     const intentContent = fs.readFileSync(intentPath, "utf-8");
     assert.ok(intentContent.includes("Add OAuth login"));
 
     // Check ledger
-    const ledger = readLedger(repo, result.workflow_id);
+    const ledger = readLedger(repo, result.workbench_id);
     assert.equal(ledger.length, 1);
-    assert.equal(ledger[0].event.type, "workflow_created");
+    assert.equal(ledger[0].event.type, "workbench_created");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -93,12 +93,12 @@ test("dispatchNode locks node.agent_type from the role file (codex role override
   const repo = makeTestRepo();
   const dispatched: Array<{ agentType: string; model?: string }> = [];
   let time = Date.parse("2026-04-09T00:00:00.000Z");
-  const deps: WorkflowDependencies = {
+  const deps: WorkbenchDependencies = {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => {
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => {
       dispatched.push({ agentType: request.agentType, model: request.model });
       return {
         projectId: "project-1",
@@ -116,15 +116,15 @@ test("dispatchNode locks node.agent_type from the role file (codex role override
   try {
     // The role file's terminals[0] is the only source for cli selection.
     // reviewer[0] = codex, so the dispatched terminal comes up as codex.
-    const init = await initWorkflow({
+    const init = await initWorkbench({
       intent: "Test agent_type lock",
       repoPath: repo,
       worktreePath: repo,
     }, deps);
 
-    await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "reviewer", intent: "Build it",
+    await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "reviewer", intent: "Build it",
     }, deps);
 
     // The dispatched terminal must come up as codex (locked by the role),
@@ -133,9 +133,9 @@ test("dispatchNode locks node.agent_type from the role file (codex role override
     assert.equal(dispatched[0].agentType, "codex");
 
     // The persisted node must record the role's agent_type, not the default.
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.equal(workflow.nodes.dev.agent_type, "codex");
-    assert.equal(workflow.nodes.dev.role, "reviewer");
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.equal(workflow.dispatches.dev.agent_type, "codex");
+    assert.equal(workflow.dispatches.dev.role, "reviewer");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -145,10 +145,10 @@ test("dispatchNode snapshots retry_policy onto the assignment", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Build it",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Build it",
       retryPolicy: {
         initial_interval_ms: 500,
         backoff_coefficient: 3,
@@ -157,8 +157,8 @@ test("dispatchNode snapshots retry_policy onto the assignment", async () => {
       },
     }, deps);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.deepEqual(workflow.nodes.dev.retry_policy, {
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.deepEqual(workflow.dispatches.dev.retry_policy, {
       initial_interval_ms: 500,
       backoff_coefficient: 3,
       maximum_attempts: 4,
@@ -167,8 +167,8 @@ test("dispatchNode snapshots retry_policy onto the assignment", async () => {
 
     // Same policy is snapshotted onto the assignment so the state machine
     // never has to load the workflow.
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatched.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     assert.deepEqual(assignment.retry_policy, {
       initial_interval_ms: 500,
       backoff_coefficient: 3,
@@ -184,19 +184,19 @@ test("dispatchAssignment waits for next_retry_at via the injected sleep dep", as
   const repo = makeTestRepo();
   const sleepCalls: number[] = [];
   let time = Date.parse("2026-04-12T00:00:00.000Z");
-  const deps: WorkflowDependencies = {
+  const deps: WorkbenchDependencies = {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => ({
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => ({
       projectId: "project-1",
       terminalId: `terminal-${request.assignmentId}`,
       terminalType: request.agentType,
       terminalTitle: `Agent ${request.assignmentId}`,
       prompt: "test prompt",
     }),
-    sleep: async (ms) => {
+    sleep: async (ms: number) => {
       sleepCalls.push(ms);
     },
     syncProject: () => {},
@@ -204,37 +204,37 @@ test("dispatchAssignment waits for next_retry_at via the injected sleep dep", as
     checkTerminalAlive: () => null,
   };
   try {
-    const init = await initWorkflow({ intent: "Backoff", repoPath: repo, worktreePath: repo }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Build it",
+    const init = await initWorkbench({ intent: "Backoff", repoPath: repo, worktreePath: repo }, deps);
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Build it",
       retryPolicy: { initial_interval_ms: 5_000 },
     }, deps);
 
     // Hand-stamp next_retry_at to a future time and reset the assignment to
     // pending so the next dispatchAssignment call observes the backoff. Also
     // flip the node status to "reset" so redispatchNode accepts it.
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatched.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     const baseNowIso = new Date(time).toISOString();
     assignment.next_retry_at = new Date(Date.parse(baseNowIso) + 5_000).toISOString();
     assignment.status = "pending";
     assignment.claim = undefined;
     manager.save(assignment);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    workflow.node_statuses.dev = "reset";
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    workflow.dispatches.dev.status = "reset";
     // saveWorkflow is internal; mutate via the manager-adjacent path —
     // re-serialize via fs since the test fixture doesn't expose saveWorkflow.
     fs.writeFileSync(
-      path.join(repo, ".hydra", "workflows", init.workflow_id, "workflow.json"),
+      path.join(repo, ".hydra", "workbenches", init.workbench_id, "workbench.json"),
       JSON.stringify(workflow, null, 2),
       "utf-8",
     );
 
     // Trigger redispatchNode (which calls dispatchAssignment under the hood).
-    await redispatchNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "dev",
+    await redispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",
     }, deps);
 
     // The injected sleep was invoked with roughly the backoff window. Time
@@ -251,12 +251,12 @@ test("dispatchNode threads model override through to the dispatch request", asyn
   const repo = makeTestRepo();
   const dispatched: Array<{ model?: string }> = [];
   let time = Date.parse("2026-04-09T00:00:00.000Z");
-  const deps: WorkflowDependencies = {
+  const deps: WorkbenchDependencies = {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => {
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => {
       dispatched.push({ model: request.model });
       return {
         projectId: "project-1",
@@ -272,21 +272,21 @@ test("dispatchNode threads model override through to the dispatch request", asyn
     checkTerminalAlive: () => null,
   };
   try {
-    const init = await initWorkflow({
+    const init = await initWorkbench({
       intent: "Test model wiring",
       repoPath: repo,
       worktreePath: repo,
     }, deps);
-    await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Build it",
+    await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Build it",
       model: "opus",
     }, deps);
 
     assert.equal(dispatched.length, 1);
     assert.equal(dispatched[0].model, "opus");
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.equal(workflow.nodes.dev.model, "opus");
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.equal(workflow.dispatches.dev.model, "opus");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -296,48 +296,46 @@ test("dispatchNode dispatches an eligible node", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
 
-    const result = await dispatchNode({
+    const result = await dispatch({
       repoPath: repo,
-      workflowId: init.workflow_id,
-      nodeId: "researcher",
+      workbenchId: init.workbench_id,
+      dispatchId: "researcher",
       role: "dev",
       intent: "Analyze the codebase",
     }, deps);
 
-    assert.equal(result.node_id, "researcher");
+    assert.equal(result.dispatch_id, "researcher");
     assert.equal(result.status, "dispatched");
     assert.ok(result.terminal_id);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.equal(workflow.node_statuses.researcher, "dispatched");
-    assert.ok(workflow.nodes.researcher.assignment_id);
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.equal(workflow.dispatches.researcher.status, "dispatched");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
 });
 
-test("dispatchNode blocks when dependencies are not met", async () => {
+test("dispatchNode dispatches immediately (no dependency blocking)", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "researcher", role: "dev", intent: "Research",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "researcher", role: "dev", intent: "Research",
     }, deps);
 
-    const result = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Implement",
-      dependsOn: ["researcher"],
+    const result = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Implement",
     }, deps);
 
-    assert.equal(result.status, "blocked");
+    assert.equal(result.status, "dispatched");
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.equal(workflow.node_statuses.dev, "blocked");
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.equal(workflow.dispatches.dev.status, "dispatched");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -347,16 +345,16 @@ test("dispatchNode rejects duplicate node IDs", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Implement",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Implement",
     }, deps);
 
     await assert.rejects(
-      () => dispatchNode({
-        repoPath: repo, workflowId: init.workflow_id,
-        nodeId: "dev", role: "reviewer", intent: "Test",
+      () => dispatch({
+        repoPath: repo, workbenchId: init.workbench_id,
+        dispatchId: "dev", role: "reviewer", intent: "Test",
       }, deps),
       (err: Error) => {
         assert.match(err.message, /already exists/);
@@ -368,35 +366,17 @@ test("dispatchNode rejects duplicate node IDs", async () => {
   }
 });
 
-test("dispatchNode allows linear chains", async () => {
+test("dispatchNode dispatches multiple nodes independently", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "a", role: "dev", intent: "A" }, deps);
-    await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "b", role: "dev", intent: "B", dependsOn: ["a"] }, deps);
-    const result = await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "c", role: "dev", intent: "C", dependsOn: ["b"] }, deps);
-    assert.equal(result.status, "blocked"); // b is blocked, so c is also blocked
-  } finally {
-    fs.rmSync(repo, { recursive: true, force: true });
-  }
-});
-
-test("dispatchNode rejects unknown dependency", async () => {
-  const repo = makeTestRepo();
-  const deps = mockDeps();
-  try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await assert.rejects(
-      () => dispatchNode({
-        repoPath: repo, workflowId: init.workflow_id,
-        nodeId: "x", role: "dev", intent: "X", dependsOn: ["nonexistent"],
-      }, deps),
-      (err: Error) => {
-        assert.match(err.message, /not found/i);
-        return true;
-      },
-    );
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const a = await dispatch({ repoPath: repo, workbenchId: init.workbench_id, dispatchId: "a", role: "dev", intent: "A" }, deps);
+    const b = await dispatch({ repoPath: repo, workbenchId: init.workbench_id, dispatchId: "b", role: "dev", intent: "B" }, deps);
+    const c = await dispatch({ repoPath: repo, workbenchId: init.workbench_id, dispatchId: "c", role: "dev", intent: "C" }, deps);
+    assert.equal(a.status, "dispatched");
+    assert.equal(b.status, "dispatched");
+    assert.equal(c.status, "dispatched");
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -406,18 +386,18 @@ test("watchUntilDecision returns node_completed when result.json appears", async
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Implement feature",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Implement feature",
     }, deps);
 
     // Write result.json to the expected location
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
     const assignment = (await import("../src/assignment/manager.ts")).AssignmentManager
       .prototype.load.call(
-        new (await import("../src/assignment/manager.ts")).AssignmentManager(repo, init.workflow_id),
-        dispatched.assignment_id,
+        new (await import("../src/assignment/manager.ts")).AssignmentManager(repo, init.workbench_id),
+        dispatched.dispatch_id,
       );
     assert.ok(assignment);
     const run = assignment.runs[0];
@@ -425,19 +405,19 @@ test("watchUntilDecision returns node_completed when result.json appears", async
 
     fs.writeFileSync(run.result_file, JSON.stringify({
       schema_version: RESULT_SCHEMA_VERSION,
-      workflow_id: init.workflow_id,
-      assignment_id: dispatched.assignment_id,
+      workbench_id: init.workbench_id,
+      assignment_id: dispatched.dispatch_id,
       run_id: run.id,
       outcome: "completed",
       report_file: "report.md",
     }, null, 2), "utf-8");
 
     const decision = await watchUntilDecision({
-      repoPath: repo, workflowId: init.workflow_id, timeoutMs: 5000,
+      repoPath: repo, workbenchId: init.workbench_id, timeoutMs: 5000,
     }, deps);
 
-    assert.equal(decision.type, "node_completed");
-    assert.equal(decision.completed?.node_id, "dev");
+    assert.equal(decision.type, "dispatch_completed");
+    assert.equal(decision.completed?.dispatch_id, "dev");
     assert.equal(decision.completed?.outcome, "completed");
     assert.equal(decision.completed?.report_file, "report.md");
   } finally {
@@ -449,13 +429,13 @@ test("watchUntilDecision returns batch_completed when no nodes are active", asyn
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
     // Don't dispatch anything — empty workflow
     // Need at least one node for batch_completed (otherwise it loops forever)
     // Actually with no nodes, statuses.length === 0 so it won't trigger batch_completed
     // It'll hit timeout instead
     const decision = await watchUntilDecision({
-      repoPath: repo, workflowId: init.workflow_id, timeoutMs: 100,
+      repoPath: repo, workbenchId: init.workbench_id, timeoutMs: 100,
     }, deps);
 
     assert.equal(decision.type, "watch_timeout");
@@ -464,34 +444,30 @@ test("watchUntilDecision returns batch_completed when no nodes are active", asyn
   }
 });
 
-test("resetNode cascades downstream and sets correct statuses", async () => {
+test("resetNode resets only the target node", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "a", role: "dev", intent: "A" }, deps);
-    await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "b", role: "dev", intent: "B", dependsOn: ["a"] }, deps);
-    await dispatchNode({ repoPath: repo, workflowId: init.workflow_id, nodeId: "c", role: "reviewer", intent: "C", dependsOn: ["b"] }, deps);
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    await dispatch({ repoPath: repo, workbenchId: init.workbench_id, dispatchId: "a", role: "dev", intent: "A" }, deps);
+    await dispatch({ repoPath: repo, workbenchId: init.workbench_id, dispatchId: "b", role: "dev", intent: "B" }, deps);
 
-    const result = await resetNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "a", feedback: "Redo this",
+    const result = await resetDispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "a", feedback: "Redo this",
     }, deps);
 
-    assert.ok(result.reset_node_ids.includes("a"));
-    assert.ok(result.reset_node_ids.includes("b"));
-    assert.ok(result.reset_node_ids.includes("c"));
+    assert.equal(result.dispatch_id, "a");
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
-    assert.equal(workflow.node_statuses.a, "eligible"); // target: eligible
-    assert.equal(workflow.node_statuses.b, "blocked");  // downstream: blocked
-    assert.equal(workflow.node_statuses.c, "blocked");  // downstream: blocked
-    assert.ok(workflow.nodes.a.feedback_file);  // feedback written to file
-    const feedbackContent = fs.readFileSync(path.join(repo, workflow.nodes.a.feedback_file!), "utf-8");
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
+    assert.equal(workflow.dispatches.a.status, "eligible");  // target: reset to eligible
+    assert.equal(workflow.dispatches.b.status, "dispatched"); // other node: unchanged
+    assert.ok(workflow.dispatches.a.feedback_file);
+    const feedbackContent = fs.readFileSync(path.join(repo, workflow.dispatches.a.feedback_file!), "utf-8");
     assert.ok(feedbackContent.includes("Redo this"));
 
     // Check ledger
-    const ledger = readLedger(repo, init.workflow_id);
-    assert.ok(ledger.some((e) => e.event.type === "node_reset"));
+    const ledger = readLedger(repo, init.workbench_id);
+    assert.ok(ledger.some((e) => e.event.type === "dispatch_reset"));
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -501,19 +477,19 @@ test("approveNode stores approved ref", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "researcher", role: "dev", intent: "Research",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "researcher", role: "dev", intent: "Research",
     }, deps);
 
-    await approveNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "researcher",
+    await approveDispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "researcher",
     }, deps);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
     assert.ok(workflow.approved_refs?.researcher);
-    assert.equal(workflow.approved_refs.researcher.assignment_id, dispatched.assignment_id);
+    assert.equal(workflow.approved_refs.researcher.assignment_id, dispatched.dispatch_id);
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -523,20 +499,20 @@ test("completeWorkflow sets status and writes ledger", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
 
-    await completeWorkflow({
-      repoPath: repo, workflowId: init.workflow_id, summary: "All done",
+    await completeWorkbench({
+      repoPath: repo, workbenchId: init.workbench_id, summary: "All done",
     }, deps);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
     assert.equal(workflow.status, "completed");
     assert.ok(workflow.result_file);
     const summaryContent = fs.readFileSync(path.join(repo, workflow.result_file!), "utf-8");
     assert.ok(summaryContent.includes("All done"));
 
-    const ledger = readLedger(repo, init.workflow_id);
-    assert.ok(ledger.some((e) => e.event.type === "workflow_completed"));
+    const ledger = readLedger(repo, init.workbench_id);
+    assert.ok(ledger.some((e) => e.event.type === "workbench_completed"));
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -546,18 +522,18 @@ test("failWorkflow sets status and writes ledger", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
 
-    await failWorkflow({
-      repoPath: repo, workflowId: init.workflow_id, reason: "Blocked on external API",
+    await failWorkbench({
+      repoPath: repo, workbenchId: init.workbench_id, reason: "Blocked on external API",
     }, deps);
 
-    const workflow = loadWorkflow(repo, init.workflow_id)!;
+    const workflow = loadWorkbench(repo, init.workbench_id)!;
     assert.equal(workflow.status, "failed");
     assert.equal(workflow.failure?.message, "Blocked on external API");
 
-    const ledger = readLedger(repo, init.workflow_id);
-    assert.ok(ledger.some((e) => e.event.type === "workflow_failed"));
+    const ledger = readLedger(repo, init.workbench_id);
+    assert.ok(ledger.some((e) => e.event.type === "workbench_failed"));
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });
   }
@@ -567,15 +543,15 @@ test("getWorkflowStatus returns workflow and assignments", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Build",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Build",
     }, deps);
 
-    const view = getWorkflowStatus(repo, init.workflow_id);
+    const view = getWorkbenchStatus(repo, init.workbench_id);
 
-    assert.equal(view.workflow.id, init.workflow_id);
+    assert.equal(view.workbench.id, init.workbench_id);
     assert.equal(view.assignments.length, 1);
     assert.equal(view.assignments[0].role, "dev");
   } finally {
@@ -587,12 +563,12 @@ test("redispatch on a claude assignment passes the captured session_id as resume
   const repo = makeTestRepo();
   const dispatchedRequests: Array<{ assignmentId: string; resumeSessionId?: string }> = [];
   let time = Date.parse("2026-04-09T00:00:00.000Z");
-  const deps: WorkflowDependencies = {
+  const deps: WorkbenchDependencies = {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => {
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => {
       dispatchedRequests.push({
         assignmentId: request.assignmentId,
         resumeSessionId: request.resumeSessionId,
@@ -611,14 +587,14 @@ test("redispatch on a claude assignment passes the captured session_id as resume
     checkTerminalAlive: () => null,
   };
   try {
-    const init = await initWorkflow({
+    const init = await initWorkbench({
       intent: "Test resume",
       repoPath: repo,
       worktreePath: repo,
     }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "First pass",
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "First pass",
     }, deps);
 
     // First dispatch should have no resume session
@@ -627,19 +603,19 @@ test("redispatch on a claude assignment passes the captured session_id as resume
 
     // Pre-populate session_id on the prior run, simulating what
     // destroyAssignmentTerminal would have captured from telemetry.
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatched.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     const firstRun = assignment.runs[0]!;
     firstRun.session_id = "claude-session-resume-test";
     firstRun.session_provider = "claude";
     manager.save(assignment);
 
     // Reset + redispatch the node — the new run should pick up the prior session
-    await resetNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "dev", feedback: "Try again",
+    await resetDispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev", feedback: "Try again",
     }, deps);
-    await redispatchNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "dev",
+    await redispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",
     }, deps);
 
     assert.equal(dispatchedRequests.length, 2);
@@ -653,12 +629,12 @@ test("redispatch on a non-claude assignment does not pass resumeSessionId", asyn
   const repo = makeTestRepo();
   const dispatchedRequests: Array<{ resumeSessionId?: string }> = [];
   let time = Date.parse("2026-04-09T00:00:00.000Z");
-  const deps: WorkflowDependencies = {
+  const deps: WorkbenchDependencies = {
     now: () => {
       time += 1000;
       return new Date(time).toISOString();
     },
-    dispatchCreateOnly: async (request) => {
+    dispatchCreateOnly: async (request: DispatchCreateOnlyRequest) => {
       dispatchedRequests.push({ resumeSessionId: request.resumeSessionId });
       return {
         projectId: "project-1",
@@ -674,29 +650,29 @@ test("redispatch on a non-claude assignment does not pass resumeSessionId", asyn
     checkTerminalAlive: () => null,
   };
   try {
-    const init = await initWorkflow({
+    const init = await initWorkbench({
       intent: "Test no-resume on codex",
       repoPath: repo,
       worktreePath: repo,
     }, deps);
     // Role-driven dispatch: pick `reviewer` so the assignment's agent_type
     // comes out as codex (reviewer[0] = codex; resume is claude-only).
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "reviewer", intent: "First pass",
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "reviewer", intent: "First pass",
     }, deps);
 
     // Pre-populate a session_id on the prior run anyway — codex shouldn't resume
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatched.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     assignment.runs[0]!.session_id = "codex-session-should-be-ignored";
     manager.save(assignment);
 
-    await resetNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "dev",
+    await resetDispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",
     }, deps);
-    await redispatchNode({
-      repoPath: repo, workflowId: init.workflow_id, nodeId: "dev",
+    await redispatch({
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",
     }, deps);
 
     assert.equal(dispatchedRequests.length, 2);
@@ -712,17 +688,17 @@ test("watchUntilDecision exposes pre-captured session info on the completed Deci
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
-    const dispatched = await dispatchNode({
-      repoPath: repo, workflowId: init.workflow_id,
-      nodeId: "dev", role: "dev", intent: "Implement feature",
+    const init = await initWorkbench({ intent: "Test", repoPath: repo, worktreePath: repo }, deps);
+    const dispatched = await dispatch({
+      repoPath: repo, workbenchId: init.workbench_id,
+      dispatchId: "dev", role: "dev", intent: "Implement feature",
     }, deps);
 
     // Pre-populate session info on the run, simulating capture from telemetry
     // before the terminal was destroyed. This bypasses the live telemetry call
     // path so the test can run without TermCanvas being available.
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatched.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     const run = assignment.runs[0]!;
     run.session_id = "claude-session-abc123";
     run.session_provider = "claude";
@@ -732,26 +708,26 @@ test("watchUntilDecision exposes pre-captured session info on the completed Deci
     // Write the slim result so watchUntilDecision treats the node as completed
     fs.writeFileSync(run.result_file, JSON.stringify({
       schema_version: RESULT_SCHEMA_VERSION,
-      workflow_id: init.workflow_id,
-      assignment_id: dispatched.assignment_id,
+      workbench_id: init.workbench_id,
+      assignment_id: dispatched.dispatch_id,
       run_id: run.id,
       outcome: "completed",
       report_file: "report.md",
     }, null, 2), "utf-8");
 
     const decision = await watchUntilDecision({
-      repoPath: repo, workflowId: init.workflow_id, timeoutMs: 5000,
+      repoPath: repo, workbenchId: init.workbench_id, timeoutMs: 5000,
     }, deps);
 
-    assert.equal(decision.type, "node_completed");
+    assert.equal(decision.type, "dispatch_completed");
     assert.ok(decision.completed?.session, "session info should be exposed");
     assert.equal(decision.completed.session.id, "claude-session-abc123");
     assert.equal(decision.completed.session.provider, "claude");
     assert.equal(decision.completed.session.file, "/tmp/claude-sessions/claude-session-abc123.json");
 
     // Ledger should also record the session_id for the completed node event
-    const ledger = readLedger(repo, init.workflow_id);
-    const completed = ledger.find((entry) => entry.event.type === "node_completed");
+    const ledger = readLedger(repo, init.workbench_id);
+    const completed = ledger.find((entry) => entry.event.type === "dispatch_completed");
     assert.ok(completed);
     assert.equal((completed.event as { session_id?: string }).session_id, "claude-session-abc123");
   } finally {
@@ -771,9 +747,9 @@ test("askNode loads the node's session, delegates to askFollowUp, and writes a l
     workdir: string;
     timeoutMs?: number;
   }> = [];
-  const extendedDeps: WorkflowDependencies = {
+  const extendedDeps: WorkbenchDependencies = {
     ...deps,
-    askFollowUp: async (opts) => {
+    askFollowUp: async (opts: { cli: string; sessionId: string; message: string; workdir: string; timeoutMs?: number }) => {
       askCalls.push(opts);
       return {
         answer: "Because pattern A is thread-safe and has no hidden lock contention.",
@@ -786,15 +762,15 @@ test("askNode loads the node's session, delegates to askFollowUp, and writes a l
 
   try {
     // 1. Init + dispatch a dev node, mock its completion, capture a session_id.
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Add OAuth login", repoPath: repo, worktreePath: repo },
       extendedDeps,
     );
-    const dispatch = await dispatchNode(
+    const dispatched = await dispatch(
       {
         repoPath: repo,
-        workflowId: init.workflow_id,
-        nodeId: "dev",
+        workbenchId: init.workbench_id,
+        dispatchId: "dev",
         role: "dev",
         intent: "Implement OAuth",
       },
@@ -803,19 +779,19 @@ test("askNode loads the node's session, delegates to askFollowUp, and writes a l
     // Hand-stamp the run's session_id on disk so askNode finds it. This is
     // what telemetry would do in production after the subprocess captures
     // the claude init message.
-    const manager = new AssignmentManager(repo, init.workflow_id);
-    const assignment = manager.load(dispatch.assignment_id)!;
+    const manager = new AssignmentManager(repo, init.workbench_id);
+    const assignment = manager.load(dispatched.dispatch_id)!;
     const run = assignment.runs[assignment.runs.length - 1]!;
     run.session_id = "dev-session-original";
     run.session_provider = "claude";
     manager.save(assignment);
 
     // 2. Lead asks Dev a follow-up.
-    const result = await askNode(
+    const result = await askDispatch(
       {
         repoPath: repo,
-        workflowId: init.workflow_id,
-        nodeId: "dev",
+        workbenchId: init.workbench_id,
+        dispatchId: "dev",
         message: "why did you choose pattern A over B?",
       },
       extendedDeps,
@@ -829,7 +805,7 @@ test("askNode loads the node's session, delegates to askFollowUp, and writes a l
     assert.equal(askCalls[0].workdir, repo);
 
     // 4. askNode returned a structured result carrying the answer + fork id.
-    assert.equal(result.node_id, "dev");
+    assert.equal(result.dispatch_id, "dev");
     assert.equal(result.role, "dev");
     assert.equal(result.cli, "claude");
     assert.equal(result.session_id, "dev-session-original");
@@ -839,21 +815,22 @@ test("askNode loads the node's session, delegates to askFollowUp, and writes a l
     assert.equal(result.exit_code, 0);
 
     // 5. A ledger entry was written with the question + answer excerpt.
-    const ledger = readLedger(repo, init.workflow_id);
+    const ledger = readLedger(repo, init.workbench_id);
     const askEvent = ledger.find((e) => e.event.type === "lead_asked_followup");
     assert.ok(askEvent, "ledger should contain a lead_asked_followup entry");
     assert.equal(askEvent.actor, "lead");
     const event = askEvent.event as {
       type: "lead_asked_followup";
-      node_id: string;
+      dispatch_id: string;
       role: string;
+      agent_type: string;
       session_id: string;
       new_session_id?: string;
       message_excerpt: string;
       answer_excerpt: string;
       duration_ms: number;
     };
-    assert.equal(event.node_id, "dev");
+    assert.equal(event.dispatch_id, "dev");
     assert.equal(event.role, "dev");
     assert.equal(event.session_id, "dev-session-original");
     assert.equal(event.new_session_id, "forked-session-xyz");
@@ -869,15 +846,15 @@ test("askNode rejects nodes that have no captured session_id", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Add OAuth login", repoPath: repo, worktreePath: repo },
       deps,
     );
-    await dispatchNode(
+    await dispatch(
       {
         repoPath: repo,
-        workflowId: init.workflow_id,
-        nodeId: "dev",
+        workbenchId: init.workbench_id,
+        dispatchId: "dev",
         role: "dev",
         intent: "Implement OAuth",
       },
@@ -888,11 +865,11 @@ test("askNode rejects nodes that have no captured session_id", async () => {
     // one).
     await assert.rejects(
       () =>
-        askNode(
+        askDispatch(
           {
             repoPath: repo,
-            workflowId: init.workflow_id,
-            nodeId: "dev",
+            workbenchId: init.workbench_id,
+            dispatchId: "dev",
             message: "hi",
           },
           deps,
@@ -908,22 +885,22 @@ test("askNode rejects nodes that do not exist", async () => {
   const repo = makeTestRepo();
   const deps = mockDeps();
   try {
-    const init = await initWorkflow(
+    const init = await initWorkbench(
       { intent: "Anything", repoPath: repo, worktreePath: repo },
       deps,
     );
     await assert.rejects(
       () =>
-        askNode(
+        askDispatch(
           {
             repoPath: repo,
-            workflowId: init.workflow_id,
-            nodeId: "nonexistent",
+            workbenchId: init.workbench_id,
+            dispatchId: "nonexistent",
             message: "hi",
           },
           deps,
         ),
-      /Node not found/,
+      /Dispatch not found/,
     );
   } finally {
     fs.rmSync(repo, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- **Workflow → Workbench**: Hydra is Lead's persistent workbench, not a predefined workflow. Removes the DAG dependency system (`depends_on`, auto-blocking, cascade reset, node promotion) since Lead sequences dispatches manually.
- **Node + Assignment → Dispatch**: Merges the redundant Node/Assignment conceptual split. Each dispatch carries its own inline status (eliminates `node_statuses` map).
- **CLI, docs, result contract**: All updated to use `--workbench`/`--dispatch` flags, `workbench_id` in result.json, new ledger event names.

## Test plan

- [x] `tsc --noEmit` passes (zero new errors)
- [x] 160/164 tests pass (4 pre-existing failures unchanged)
- [ ] Manual smoke test of `hydra init → dispatch → watch → reset → complete` flow


🤖 Generated with [Claude Code](https://claude.com/claude-code)