### PR TITLE
fix(hydra): review fixes for harness engineering PR

### DIFF
--- a/hydra/src/roles/builtin/dev.md
+++ b/hydra/src/roles/builtin/dev.md
@@ -24,8 +24,8 @@ Dev owns implementation. You do not own verification testing — that is handled
 
 Before writing result.json, verify each of these passes. If any fails, fix your implementation — not the check.
 
-- `tsc --noEmit` passes with zero errors.
-- All existing tests pass (`npm test` or equivalent). You do not write new tests, but you must not break existing ones.
+- The repo's build or typecheck command passes with zero errors (e.g., `tsc --noEmit`, `cargo check`, `go build ./...` — use whatever the project already has).
+- All existing tests pass (use the repo's test command). You do not write new tests, but you must not break existing ones.
 - No `console.log` debugging statements remain in your diff.
 - Every changed line in your diff traces back to a specific requirement in the intent. If you changed something the intent did not ask for, revert it or justify it in report.md.
 

--- a/hydra/src/roles/builtin/janitor.md
+++ b/hydra/src/roles/builtin/janitor.md
@@ -52,7 +52,7 @@ When operating within a Hydra workbench context, also analyze:
 - Reset patterns: which dispatches were reset, with what feedback themes.
 - Time patterns: which roles or task types tend to take longest.
 
-Source this data from `.hydra/workbenches/*/ledger.jsonl` and `**/result.json` files.
+Source this data from `.hydra/workbenches/*/ledger.jsonl` and `.hydra/workbenches/**/result.json` files only. Do not scan result.json files outside Hydra's run directories.
 
 ## Report format
 


### PR DESCRIPTION
## Summary

Two fixes from PR review that were committed after #132 was already merged:

- **dev.md**: Replace hardcoded `tsc --noEmit` with repo-agnostic guidance — the builtin dev role should not assume TypeScript
- **janitor.md**: Scope `result.json` scanning to `.hydra/workbenches/**/` only — avoids picking up unrelated fixtures with the same filename

## Test plan

- [ ] `npx tsx --test tests/role-loader.test.ts` — roles still load
- [ ] `npx tsx --test tests/task-spec-builder.test.ts` — spec builder unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)