### PR TITLE
feat(updater): blockmap-based differential downloads for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
           for zip in out/*.zip; do
             npx better-blockmap --input "$zip" --output "${zip}.blockmap" --compression gzip --detect-zip-boundary
           done
+          node scripts/update-mac-yml.js
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Optimize macOS ZIPs for differential updates
+        if: matrix.platform == 'mac'
+        run: |
+          npx @indutny/rezip-electron optimize out/*.zip
+          for zip in out/*.zip; do
+            npx better-blockmap --input "$zip" --output "${zip}.blockmap" --compression gzip --detect-zip-boundary
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -81,6 +89,7 @@ jobs:
           path: |
             out/*.dmg
             out/*.zip
+            out/*.blockmap
             out/*.AppImage
             out/*.deb
             out/*.exe

--- a/electron/mac-updater.ts
+++ b/electron/mac-updater.ts
@@ -9,11 +9,15 @@ import {
   createReadStream,
   writeFileSync,
   readFileSync,
+  copyFileSync,
+  openSync,
+  closeSync,
   accessSync,
   constants,
 } from "fs";
 import { join, resolve, dirname } from "path";
 import { createHash } from "crypto";
+import { gunzipSync } from "zlib";
 import { spawn, execFile } from "child_process";
 import type { BrowserWindow } from "electron";
 import { sendToWindow } from "./window-events";
@@ -23,11 +27,38 @@ const GITHUB_REPO = "termcanvas";
 const MAX_DOWNLOAD_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 2000;
 const INSTALL_WAIT_TIMEOUT_S = 30;
+const RANGE_REQUEST_COOLDOWN_INTERVAL = 100;
+const RANGE_REQUEST_COOLDOWN_MS = 1000;
 
 interface ReleaseFile {
   url: string;
   sha512: string;
   size: number;
+}
+
+// ── Blockmap types (matches builder-util-runtime/blockMapApi) ──
+
+interface BlockMapFile {
+  name: string;
+  offset: number;
+  checksums: string[];
+  sizes: number[];
+}
+
+interface BlockMap {
+  version: "1" | "2";
+  files: BlockMapFile[];
+}
+
+const enum OperationKind {
+  COPY = 0,
+  DOWNLOAD = 1,
+}
+
+interface Operation {
+  kind: OperationKind;
+  start: number;
+  end: number;
 }
 
 interface ReleaseInfo {
@@ -184,6 +215,239 @@ function extractZip(zipPath: string, destDir: string): Promise<void> {
   });
 }
 
+// ── Blockmap differential download helpers ──
+
+function getCacheDir(): string {
+  return join(app.getPath("userData"), "update-cache");
+}
+
+function getCachedZipPath(): string {
+  return join(getCacheDir(), "update.zip");
+}
+
+function getCachedBlockMapPath(): string {
+  return join(getCacheDir(), "current.blockmap");
+}
+
+function fetchBuffer(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const request = net.request(url);
+    const chunks: Buffer[] = [];
+    request.on("response", (response) => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`HTTP ${response.statusCode} from ${url}`));
+        return;
+      }
+      response.on("data", (chunk) => chunks.push(chunk as Buffer));
+      response.on("end", () => resolve(Buffer.concat(chunks)));
+      response.on("error", reject);
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+async function fetchBlockMap(url: string): Promise<BlockMap> {
+  const data = await fetchBuffer(url);
+  if (data.length === 0) throw new Error(`Empty blockmap from ${url}`);
+  return JSON.parse(gunzipSync(data).toString()) as BlockMap;
+}
+
+/**
+ * Download a byte range from a URL. Handles GitHub's 302 redirect to S3.
+ * Returns the resolved CDN URL so callers can skip redirects on subsequent requests.
+ */
+function downloadRange(
+  url: string,
+  start: number,
+  end: number,
+): Promise<{ data: Buffer; resolvedUrl: string }> {
+  return new Promise((resolve, reject) => {
+    const request = net.request({ url, redirect: "manual" });
+    request.setHeader("Range", `bytes=${start}-${end - 1}`);
+
+    let resolvedUrl = url;
+
+    request.on("redirect", (_status, _method, redirectUrl) => {
+      resolvedUrl = redirectUrl;
+      request.followRedirect();
+    });
+
+    request.on("response", (response) => {
+      if (response.statusCode >= 400) {
+        reject(new Error(`HTTP ${response.statusCode} on range request`));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk) => chunks.push(chunk as Buffer));
+      response.on("end", () =>
+        resolve({ data: Buffer.concat(chunks), resolvedUrl }),
+      );
+      response.on("error", reject);
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+/**
+ * Port of electron-updater's downloadPlanBuilder.computeOperations.
+ * Compares old and new blockmaps block-by-block, returning a list of
+ * COPY (reuse from old file) and DOWNLOAD (fetch from new file) operations.
+ */
+function computeOperations(
+  oldBlockMap: BlockMap,
+  newBlockMap: BlockMap,
+): Operation[] {
+  if (oldBlockMap.version !== newBlockMap.version) {
+    throw new Error(
+      `Blockmap version mismatch (${oldBlockMap.version} vs ${newBlockMap.version})`,
+    );
+  }
+
+  const newFile = newBlockMap.files[0];
+  const oldFile = oldBlockMap.files.find((f) => f.name === newFile.name);
+  if (!oldFile) throw new Error(`No file "${newFile.name}" in old blockmap`);
+
+  // Build checksum → offset/size maps for old file
+  const checksumToOldOffset = new Map<string, number>();
+  const checksumToOldSize = new Map<string, number>();
+  let offset = oldFile.offset;
+  for (let i = 0; i < oldFile.checksums.length; i++) {
+    const cs = oldFile.checksums[i];
+    if (!checksumToOldOffset.has(cs)) {
+      checksumToOldOffset.set(cs, offset);
+      checksumToOldSize.set(cs, oldFile.sizes[i]);
+    }
+    offset += oldFile.sizes[i];
+  }
+
+  // Walk new file blocks, decide COPY or DOWNLOAD
+  const operations: Operation[] = [];
+  let last: Operation | null = null;
+  let newOffset = newFile.offset;
+
+  for (let i = 0; i < newFile.checksums.length; i++) {
+    const blockSize = newFile.sizes[i];
+    const checksum = newFile.checksums[i];
+    let oldOff = checksumToOldOffset.get(checksum);
+
+    // Checksum match but size mismatch → treat as changed
+    if (oldOff != null && checksumToOldSize.get(checksum) !== blockSize) {
+      oldOff = undefined;
+    }
+
+    if (oldOff === undefined) {
+      // DOWNLOAD from new file
+      if (last?.kind === OperationKind.DOWNLOAD && last.end === newOffset) {
+        last.end += blockSize;
+      } else {
+        last = { kind: OperationKind.DOWNLOAD, start: newOffset, end: newOffset + blockSize };
+        operations.push(last);
+      }
+    } else {
+      // COPY from old file
+      if (last?.kind === OperationKind.COPY && last.end === oldOff) {
+        last.end += blockSize;
+      } else {
+        last = { kind: OperationKind.COPY, start: oldOff, end: oldOff + blockSize };
+        operations.push(last);
+      }
+    }
+
+    newOffset += blockSize;
+  }
+
+  return operations;
+}
+
+/**
+ * Reconstruct a new ZIP by copying unchanged blocks from the old ZIP
+ * and downloading only changed blocks via HTTP Range requests.
+ */
+async function downloadDifferential(
+  oldZipPath: string,
+  oldBlockMap: BlockMap,
+  newBlockMap: BlockMap,
+  newFileUrl: string,
+  newFileSize: number,
+  onProgress: (percent: number) => void,
+  destPath: string,
+): Promise<void> {
+  const operations = computeOperations(oldBlockMap, newBlockMap);
+
+  let downloadSize = 0;
+  let copySize = 0;
+  for (const op of operations) {
+    const len = op.end - op.start;
+    if (op.kind === OperationKind.DOWNLOAD) downloadSize += len;
+    else copySize += len;
+  }
+
+  if (downloadSize + copySize !== newFileSize) {
+    throw new Error(
+      `Size mismatch: download=${downloadSize} + copy=${copySize} != expected=${newFileSize}`,
+    );
+  }
+
+  const oldFd = openSync(oldZipPath, "r");
+  const outStream = createWriteStream(destPath);
+  let downloaded = 0;
+  let resolvedUrl = newFileUrl;
+  let rangeCount = 0;
+
+  try {
+    for (const op of operations) {
+      if (op.kind === OperationKind.COPY) {
+        // Read from old ZIP and write to output
+        await new Promise<void>((res, rej) => {
+          const readStream = createReadStream("", {
+            fd: oldFd,
+            autoClose: false,
+            start: op.start,
+            end: op.end - 1,
+          });
+          readStream.on("error", rej);
+          readStream.pipe(outStream, { end: false });
+          readStream.once("end", res);
+        });
+      } else {
+        // Download range from remote
+        const result = await downloadRange(resolvedUrl, op.start, op.end);
+        resolvedUrl = result.resolvedUrl;
+
+        await new Promise<void>((res, rej) => {
+          const ok = outStream.write(result.data, (err) => {
+            if (err) rej(err);
+            else res();
+          });
+          if (!ok) {
+            outStream.once("drain", () => res());
+          }
+        });
+
+        downloaded += result.data.length;
+        onProgress(
+          downloadSize > 0
+            ? Math.min(100, (downloaded / downloadSize) * 100)
+            : 100,
+        );
+
+        // Rate limit: pause after every N range requests
+        if (++rangeCount % RANGE_REQUEST_COOLDOWN_INTERVAL === 0) {
+          await new Promise((r) => setTimeout(r, RANGE_REQUEST_COOLDOWN_MS));
+        }
+      }
+    }
+
+    await new Promise<void>((res, rej) => {
+      outStream.end((err: Error | null) => (err ? rej(err) : res()));
+    });
+  } finally {
+    closeSync(oldFd);
+  }
+}
+
 function getStagingDir(): string {
   return join(app.getPath("userData"), "pending-update");
 }
@@ -330,6 +594,7 @@ export class MacCustomUpdater {
       }
 
       const downloadUrl = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/v${release.version}/${zipFile.url}`;
+      const blockmapUrl = `${downloadUrl}.blockmap`;
 
       // Download into a temp dir so the existing pending update survives
       // if this download fails (network error, hash mismatch, etc.)
@@ -339,20 +604,60 @@ export class MacCustomUpdater {
       mkdirSync(tempDir, { recursive: true });
 
       const zipPath = join(tempDir, zipFile.url);
+      let usedDifferential = false;
 
-      await downloadWithRetry(
-        downloadUrl,
-        zipPath,
-        zipFile.size,
-        (percent) => {
-          sendToWindow(this.window, "updater:download-progress", { percent });
-        },
-      );
+      // Try differential download if we have a cached ZIP + blockmap
+      const cachedZip = getCachedZipPath();
+      const cachedBlockMap = getCachedBlockMapPath();
+      if (existsSync(cachedZip) && existsSync(cachedBlockMap)) {
+        try {
+          const oldBlockMap = JSON.parse(
+            gunzipSync(readFileSync(cachedBlockMap)).toString(),
+          ) as BlockMap;
+          const newBlockMapBuf = await fetchBuffer(blockmapUrl);
+          const newBlockMap = JSON.parse(
+            gunzipSync(newBlockMapBuf).toString(),
+          ) as BlockMap;
+
+          await downloadDifferential(
+            cachedZip,
+            oldBlockMap,
+            newBlockMap,
+            downloadUrl,
+            zipFile.size,
+            (percent) => {
+              sendToWindow(this.window, "updater:download-progress", {
+                percent,
+              });
+            },
+            zipPath,
+          );
+
+          usedDifferential = true;
+        } catch {
+          // Differential failed — fall through to full download
+          if (existsSync(zipPath)) rmSync(zipPath, { force: true });
+        }
+      }
+
+      if (!usedDifferential) {
+        await downloadWithRetry(
+          downloadUrl,
+          zipPath,
+          zipFile.size,
+          (percent) => {
+            sendToWindow(this.window, "updater:download-progress", { percent });
+          },
+        );
+      }
 
       const hash = await computeSha512(zipPath);
       if (hash !== zipFile.sha512) {
         throw new Error("SHA-512 verification failed — update is corrupted");
       }
+
+      // Cache the verified ZIP + its blockmap for next differential update
+      await this.updateCache(zipPath, blockmapUrl);
 
       const extractDir = join(tempDir, "extracted");
       await extractZip(zipPath, extractDir);
@@ -399,6 +704,25 @@ export class MacCustomUpdater {
       });
     } finally {
       this.downloading = false;
+    }
+  }
+
+  /**
+   * Cache the verified ZIP and its blockmap so the next update can use
+   * differential downloads. Runs best-effort — failures don't block the update.
+   */
+  private async updateCache(
+    zipPath: string,
+    blockmapUrl: string,
+  ): Promise<void> {
+    try {
+      const cacheDir = getCacheDir();
+      mkdirSync(cacheDir, { recursive: true });
+      copyFileSync(zipPath, getCachedZipPath());
+      const blockmapData = await fetchBuffer(blockmapUrl);
+      writeFileSync(getCachedBlockMapPath(), blockmapData);
+    } catch {
+      // Non-critical — next update will fall back to full download
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termcanvas",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termcanvas",
-      "version": "0.27.5",
+      "version": "0.27.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -35,6 +35,7 @@
         "termcanvas": "dist-cli/termcanvas.js"
       },
       "devDependencies": {
+        "@indutny/rezip-electron": "^3.0.2",
         "@tailwindcss/vite": "^4.2.1",
         "@types/adm-zip": "^0.5.8",
         "@types/react": "^19.2.14",
@@ -44,6 +45,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "better-blockmap": "^2.0.1",
         "electron": "^41.0.2",
         "electron-builder": "^26.8.1",
         "tailwindcss": "^4.2.1",
@@ -2625,6 +2627,60 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@indutny/inflate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@indutny/inflate/-/inflate-1.0.5.tgz",
+      "integrity": "sha512-dZObKXR6i2uQnHmXLyGEpQh/+AHwBQI4pbCRYQaI7qd6krNrN8a8GksoPSg/C6mSpjWsfXMBYpHiwnl5l/B5Jg==",
+      "dev": true
+    },
+    "node_modules/@indutny/rezip-electron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@indutny/rezip-electron/-/rezip-electron-3.0.2.tgz",
+      "integrity": "sha512-h0Y+bFkVSalOYfprzUGUdwsB0A9JJ7g7XZAsUInMxIn8SnRa1xPFmAdHks/Q9gCCOA+THHaDo/SF54+dUTHR6Q==",
+      "dev": true,
+      "dependencies": {
+        "@indutny/inflate": "^1.0.4",
+        "@indutny/yazl": "^2.7.0",
+        "better-blockmap": "^2.0.1",
+        "commander": "^12.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "yauzl": "^3.1.0"
+      },
+      "bin": {
+        "rezip-electron": "bin/rezip-electron.js"
+      }
+    },
+    "node_modules/@indutny/rezip-electron/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@indutny/rezip-electron/node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@indutny/yazl": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@indutny/yazl/-/yazl-2.7.0.tgz",
+      "integrity": "sha512-6igFZsYj7BVSTIJ8qhWvsPp0adMY62IJe4xHwQTpoMvbFlalRdpYXsL9wDaAiwt76CtyPlcT7SBNBEKkDbcQyg==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -5364,6 +5420,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-blockmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/better-blockmap/-/better-blockmap-2.0.1.tgz",
+      "integrity": "sha512-vT2IsQtDcZTrY7zCzitMPShUhxjiegVhheW/qG/lObk70tsjLDg93cw3+Vi8PlG+7CaF8Re2GLpDtc7emP89LQ==",
+      "dev": true,
+      "dependencies": {
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "better-blockmap": "bin/blockmap.js"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7124,6 +7192,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
     },
     "node_modules/geist": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@indutny/rezip-electron": "^3.0.2",
     "@tailwindcss/vite": "^4.2.1",
     "@types/adm-zip": "^0.5.8",
     "@types/react": "^19.2.14",
@@ -73,6 +74,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "better-blockmap": "^2.0.1",
     "electron": "^41.0.2",
     "electron-builder": "^26.8.1",
     "tailwindcss": "^4.2.1",

--- a/scripts/update-mac-yml.js
+++ b/scripts/update-mac-yml.js
@@ -1,0 +1,62 @@
+/**
+ * After rezip-electron optimizes macOS ZIPs, the SHA-512 hashes and file
+ * sizes in latest-mac.yml are stale. This script recomputes them so the
+ * updater's integrity check passes.
+ */
+const fs = require("fs");
+const crypto = require("crypto");
+const path = require("path");
+
+const ymlPath = path.join("out", "latest-mac.yml");
+if (!fs.existsSync(ymlPath)) process.exit(0);
+
+const zipInfo = {};
+for (const f of fs.readdirSync("out").filter((n) => n.endsWith(".zip"))) {
+  const buf = fs.readFileSync(path.join("out", f));
+  zipInfo[f] = {
+    sha512: crypto.createHash("sha512").update(buf).digest("base64"),
+    size: buf.length,
+  };
+}
+
+const lines = fs.readFileSync(ymlPath, "utf8").split("\n");
+let currentZip = null;
+
+for (let i = 0; i < lines.length; i++) {
+  // Match file entry:  "  - url: Foo.zip" or "    url: Foo.zip"
+  const urlMatch = lines[i].match(/^(\s*(?:-\s+)?url:\s*)(.+\.zip)\s*$/);
+  if (urlMatch && zipInfo[urlMatch[2]]) {
+    currentZip = urlMatch[2];
+    continue;
+  }
+
+  if (currentZip) {
+    const shaMatch = lines[i].match(/^(\s+sha512:\s*)\S+/);
+    if (shaMatch) {
+      lines[i] = shaMatch[1] + zipInfo[currentZip].sha512;
+      continue;
+    }
+    const sizeMatch = lines[i].match(/^(\s+size:\s*)\d+/);
+    if (sizeMatch) {
+      lines[i] = sizeMatch[1] + zipInfo[currentZip].size;
+      currentZip = null;
+      continue;
+    }
+  }
+
+  // Top-level "path:" identifies which zip the top-level sha512 refers to
+  const pathMatch = lines[i].match(/^path:\s*(.+\.zip)\s*$/);
+  if (pathMatch && zipInfo[pathMatch[1]]) {
+    // Update the top-level sha512 (next or nearby line starting with "sha512:")
+    for (let j = i + 1; j < lines.length; j++) {
+      const topSha = lines[j].match(/^(sha512:\s*)\S+/);
+      if (topSha) {
+        lines[j] = topSha[1] + zipInfo[pathMatch[1]].sha512;
+        break;
+      }
+    }
+  }
+}
+
+fs.writeFileSync(ymlPath, lines.join("\n"));
+console.log("Updated latest-mac.yml with post-rezip hashes");


### PR DESCRIPTION
## Summary
- **Differential downloads**: macOS custom updater now caches the verified ZIP and its blockmap after each download. On subsequent updates, it compares old/new blockmaps to identify changed blocks and downloads only those via HTTP Range requests, reconstructing the full ZIP locally. Falls back to full download if differential fails at any step.
- **CI optimization**: macOS ZIPs are re-compressed with `rezip-electron` (aligns deflate boundaries per sub-file) and blockmaps are regenerated with `better-blockmap --detect-zip-boundary`. Blockmap files are now uploaded alongside ZIP artifacts.
- Expected improvement: **~120MB → ~3-5MB** for typical app-code-only updates.

## Test plan
- [ ] First update (no cache): full download, ZIP + blockmap cached afterward
- [ ] Second update (cache exists): differential download, verify SHA-512 of reconstructed ZIP
- [ ] Differential failure (corrupt cache): falls back to full download silently
- [ ] CI: verify `.blockmap` files appear in release artifacts alongside ZIPs
- [ ] `tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)