### PR TITLE
refactor(hydra): code review cleanup and scan command

### DIFF
--- a/electron/telemetry-service.ts
+++ b/electron/telemetry-service.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { AssignmentManager } from "../hydra/src/assignment/manager.ts";
 import type { AssignmentRecord } from "../hydra/src/assignment/types.ts";
-import { validateSubAgentResult } from "../hydra/src/protocol.ts";
-import { loadWorkflow, type WorkflowRecord } from "../hydra/src/workflow-store.ts";
+import { validateRunResult } from "../hydra/src/protocol.ts";
+import { loadWorkbench, type WorkbenchRecord } from "../hydra/src/workflow-store.ts";
 import { getProcessSnapshot } from "./process-detector.ts";
 import { parseSessionTelemetryLine } from "./session-watcher.ts";
 import type {
@@ -918,7 +918,7 @@ export class TelemetryService {
     repoPath: string,
     workflowId: string,
   ): WorkflowTelemetrySnapshot | null {
-    const workflow = loadWorkflow(repoPath, workflowId);
+    const workflow = loadWorkbench(repoPath, workflowId);
     if (!workflow) return null;
 
     // Find the currently dispatched node's assignment
@@ -1281,8 +1281,8 @@ export class TelemetryService {
     if (resultExists) {
       try {
         const raw = JSON.parse(fs.readFileSync(run.result_file, "utf-8"));
-        validateSubAgentResult(raw, {
-          workflow_id: workflowId,
+        validateRunResult(raw, {
+          workbench_id: workflowId,
           assignment_id: assignment.id,
           run_id: run.id,
         });

--- a/hydra/src/assignment/manager.ts
+++ b/hydra/src/assignment/manager.ts
@@ -71,6 +71,18 @@ export class AssignmentManager {
     return parsed;
   }
 
+  /**
+   * Low-level status override that bypasses the state machine. Does not
+   * acquire the file lock, validate the transition, or append to
+   * transitions[]. Exists for two reasons:
+   *
+   *   1. Test scaffolding — tests that need an assignment in a specific
+   *      status without replaying the full claim→in_progress→… sequence.
+   *   2. Emergency recovery — if a stale lock or schema migration leaves
+   *      an assignment in an unreachable state, this is the escape hatch.
+   *
+   * Production workflow code must use AssignmentStateMachine instead.
+   */
   updateStatus(assignmentId: string, status: AssignmentStatus): void {
     const assignment = this.load(assignmentId);
     if (!assignment) throw new Error(`Assignment not found: ${assignmentId}`);

--- a/hydra/src/assignment/state-machine.ts
+++ b/hydra/src/assignment/state-machine.ts
@@ -378,7 +378,7 @@ export class AssignmentStateMachine {
         stage: "assignment.transition",
         ids: {
           assignment_id: assignment.id,
-          workflow_id: assignment.workflow_id,
+          workbench_id: assignment.workbench_id,
         },
       },
     );

--- a/hydra/src/assignment/types.ts
+++ b/hydra/src/assignment/types.ts
@@ -1,4 +1,4 @@
-import type { SubAgentOutcome } from "../protocol.ts";
+import type { RunOutcome } from "../protocol.ts";
 import type { RetryPolicy } from "../workflow-store.ts";
 
 export const ASSIGNMENT_STATE_SCHEMA_VERSION = "hydra/assignment-state/v0.1";
@@ -68,7 +68,7 @@ export interface AssignmentRun {
 }
 
 export interface AssignmentResult {
-  outcome: SubAgentOutcome;
+  outcome: RunOutcome;
   report_file: string;
   completed_at?: string;
 }
@@ -76,13 +76,11 @@ export interface AssignmentResult {
 export interface AssignmentRecord {
   schema_version: typeof ASSIGNMENT_STATE_SCHEMA_VERSION;
   id: string;
-  workflow_id: string;
+  workbench_id: string;
   created_at: string;
   updated_at: string;
-  workspace_root?: string;
   worktree_path?: string;
   role: AssignmentRole;
-  from_assignment_id: string | null;
   requested_agent_type: AgentType;
   status: AssignmentStatus;
   status_updated_at?: string;

--- a/hydra/src/cleanup.ts
+++ b/hydra/src/cleanup.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { loadAgent, listAgents, deleteAgent } from "./store.ts";
 import { isTermCanvasRunning, terminalDestroy, terminalStatus } from "./termcanvas.ts";
 import { AssignmentManager } from "./assignment/manager.ts";
-import { deleteWorkbench, loadWorkbench } from "./workflow-store.ts";
+import { loadWorkbench } from "./workflow-store.ts";
 
 export interface CleanupArgs {
   agentId?: string;
@@ -195,8 +195,10 @@ function cleanupWorkbench(workbenchId: string, repo: string, force: boolean): vo
     }
   }
 
-  deleteWorkbench(repo, workbenchId);
-  console.log(`Cleaned up workbench ${workbenchId}.`);
+  // Workbench state files (.hydra/workbenches/<wid>/) are preserved for
+  // audit and historical reference. Only runtime resources (terminals,
+  // worktrees, branches) are cleaned up.
+  console.log(`Cleaned up resources for workbench ${workbenchId}. State files preserved.`);
 }
 
 export async function cleanup(args: string[]): Promise<void> {

--- a/hydra/src/cli-commands.ts
+++ b/hydra/src/cli-commands.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { readLedger, type LeadAssessment, type LedgerEntry, type LedgerEvent } from "./ledger.ts";
 import { listRoles } from "./roles/loader.ts";
@@ -47,6 +48,19 @@ function listFlag(args: string[], flag: string): string[] {
   return raw.split(",").map((s) => s.trim()).filter(Boolean);
 }
 
+/**
+ * Resolve intent from either --intent <text> or --intent-file <path>.
+ * Errors if both or neither are provided.
+ */
+function resolveIntent(args: string[]): string {
+  const inline = optionalFlag(args, "--intent");
+  const file = optionalFlag(args, "--intent-file");
+  if (inline && file) throw new Error("Provide either --intent or --intent-file, not both");
+  if (file) return fs.readFileSync(file, "utf-8");
+  if (inline) return inline;
+  throw new Error("Missing required flag: --intent or --intent-file");
+}
+
 /** Collect every occurrence of a repeatable flag, in order. */
 function repeatableFlag(args: string[], flag: string): string[] {
   const values: string[] = [];
@@ -64,7 +78,8 @@ function repeatableFlag(args: string[], flag: string): string[] {
 export async function cliInit(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
     console.log("Usage: hydra init --intent <desc> --repo <path> [options]");
-    console.log("  --intent <desc>              Workbench intent (required)");
+    console.log("  --intent <desc>              Workbench intent (required, or use --intent-file)");
+    console.log("  --intent-file <path>         Read intent from file (mutually exclusive with --intent)");
     console.log("  --repo <path>                Repository path (required)");
     console.log("  --worktree <path>            Use existing worktree");
     console.log("  --timeout-minutes <n>        Default per-dispatch timeout");
@@ -81,7 +96,7 @@ export async function cliInit(args: string[]): Promise<void> {
 
   const sharedConstraints = repeatableFlag(args, "--shared-constraint");
   const result = await initWorkbench({
-    intent: requireFlag(args, "--intent"),
+    intent: resolveIntent(args),
     repoPath: requireFlag(args, "--repo"),
     worktreePath: optionalFlag(args, "--worktree"),
     defaultTimeoutMinutes: optionalNumber(args, "--timeout-minutes"),
@@ -102,7 +117,8 @@ export async function cliDispatch(args: string[]): Promise<void> {
     console.log("  --workbench <id>       Workbench ID (required)");
     console.log("  --dispatch <id>        Dispatch ID (required)");
     console.log("  --role <role>          Registered role name (required, e.g. dev)");
-    console.log("  --intent <desc>        Task intent (required)");
+    console.log("  --intent <desc>        Task intent (required, or use --intent-file)");
+    console.log("  --intent-file <path>   Read intent from file (mutually exclusive with --intent)");
     console.log("  --repo <path>          Repository path (required)");
     console.log("  --model <name>         Override the role's default model (e.g. opus)");
     console.log("  --context-ref <l:p>    Context ref as label:path (repeatable)");
@@ -143,7 +159,7 @@ export async function cliDispatch(args: string[]): Promise<void> {
     workbenchId: requireFlag(args, "--workbench"),
     dispatchId: requireFlag(args, "--dispatch"),
     role: requireFlag(args, "--role"),
-    intent: requireFlag(args, "--intent"),
+    intent: resolveIntent(args),
     model: optionalFlag(args, "--model"),
     contextRefs: contextRefs.length > 0 ? contextRefs : undefined,
     feedback: optionalFlag(args, "--feedback"),
@@ -267,7 +283,7 @@ export async function cliApprove(args: string[]): Promise<void> {
 
 export async function cliReset(args: string[]): Promise<void> {
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    console.log("Usage: hydra reset --workbench <id> --dispatch <id> --repo <path> [--feedback <text>]");
+    console.log("Usage: hydra reset --workbench <id> --dispatch <id> --repo <path> --feedback <text>");
     process.exit(0);
   }
 
@@ -275,7 +291,7 @@ export async function cliReset(args: string[]): Promise<void> {
     repoPath: requireFlag(args, "--repo"),
     workbenchId: requireFlag(args, "--workbench"),
     dispatchId: requireFlag(args, "--dispatch"),
-    feedback: optionalFlag(args, "--feedback"),
+    feedback: requireFlag(args, "--feedback"),
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/hydra/src/cli.ts
+++ b/hydra/src/cli.ts
@@ -1,4 +1,23 @@
 import { HydraError, writeFailureLog } from "./errors.ts";
+import {
+  cliInit,
+  cliDispatch,
+  cliWatch,
+  cliRedispatch,
+  cliApprove,
+  cliReset,
+  cliAsk,
+  cliMerge,
+  cliComplete,
+  cliFail,
+  cliStatus,
+  cliLedger,
+  cliListRoles,
+} from "./cli-commands.ts";
+import { list } from "./list.ts";
+import { spawn, injectScanDefaults } from "./spawn.ts";
+import { cleanup } from "./cleanup.ts";
+import { init as initRepo } from "./init.ts";
 
 const args = process.argv.slice(2);
 const [command, ...rest] = args;
@@ -25,6 +44,7 @@ function printUsage() {
   console.log("");
   console.log("Housekeeping:");
   console.log("  spawn      Create one direct isolated worker terminal");
+  console.log("  scan       Scan codebase for entropy (shortcut for spawn --role janitor)");
   console.log("  cleanup    Clean up workflow state and worktrees");
   console.log("  init-repo  Add hydra instructions to project CLAUDE.md");
 }
@@ -32,95 +52,64 @@ function printUsage() {
 async function main() {
   switch (command) {
     // --- Lead-driven workflow ---
-    case "init": {
-      const { cliInit } = await import("./cli-commands.js");
+    case "init":
       await cliInit(rest);
       break;
-    }
-    case "dispatch": {
-      const { cliDispatch } = await import("./cli-commands.js");
+    case "dispatch":
       await cliDispatch(rest);
       break;
-    }
-    case "watch": {
-      const { cliWatch } = await import("./cli-commands.js");
+    case "watch":
       await cliWatch(rest);
       break;
-    }
-    case "redispatch": {
-      const { cliRedispatch } = await import("./cli-commands.js");
+    case "redispatch":
       await cliRedispatch(rest);
       break;
-    }
-    case "approve": {
-      const { cliApprove } = await import("./cli-commands.js");
+    case "approve":
       await cliApprove(rest);
       break;
-    }
-    case "reset": {
-      const { cliReset } = await import("./cli-commands.js");
+    case "reset":
       await cliReset(rest);
       break;
-    }
-    case "ask": {
-      const { cliAsk } = await import("./cli-commands.js");
+    case "ask":
       await cliAsk(rest);
       break;
-    }
-    case "merge": {
-      const { cliMerge } = await import("./cli-commands.js");
+    case "merge":
       await cliMerge(rest);
       break;
-    }
-    case "complete": {
-      const { cliComplete } = await import("./cli-commands.js");
+    case "complete":
       await cliComplete(rest);
       break;
-    }
-    case "fail": {
-      const { cliFail } = await import("./cli-commands.js");
+    case "fail":
       await cliFail(rest);
       break;
-    }
 
     // --- Inspection ---
-    case "status": {
-      const { cliStatus } = await import("./cli-commands.js");
+    case "status":
       await cliStatus(rest);
       break;
-    }
-    case "ledger": {
-      const { cliLedger } = await import("./cli-commands.js");
+    case "ledger":
       await cliLedger(rest);
       break;
-    }
-    case "list": {
-      const { list } = await import("./list.js");
+    case "list":
       await list(rest);
       break;
-    }
-    case "list-roles": {
-      const { cliListRoles } = await import("./cli-commands.js");
+    case "list-roles":
       await cliListRoles(rest);
       break;
-    }
 
     // --- Housekeeping ---
-    case "spawn": {
-      const { spawn } = await import("./spawn.js");
+    case "spawn":
       await spawn(rest);
       break;
-    }
-    case "cleanup": {
-      const { cleanup } = await import("./cleanup.js");
+    case "scan":
+      await spawn(injectScanDefaults(rest));
+      break;
+    case "cleanup":
       await cleanup(rest);
       break;
-    }
-    case "init-repo": {
-      const { init } = await import("./init.js");
-      await init();
+    case "init-repo":
+      await initRepo();
       break;
-    }
 
     case "--help":
     case "-h":

--- a/hydra/src/collector.ts
+++ b/hydra/src/collector.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import {
-  validateSubAgentResult,
-  type SubAgentResult,
+  validateRunResult,
+  type RunResult,
 } from "./protocol.ts";
 
 export interface CollectorFailure {
@@ -24,7 +24,7 @@ export type CollectRunResult =
   | {
       status: "completed";
       advance: true;
-      result: SubAgentResult;
+      result: RunResult;
     };
 
 export interface RunResultExpectation {
@@ -48,7 +48,7 @@ export function collectRunResult(expectation: RunResultExpectation): CollectRunR
   }
 
   try {
-    const result = validateSubAgentResult(readJsonFile(expectation.result_file), expectation);
+    const result = validateRunResult(readJsonFile(expectation.result_file), expectation);
     return {
       status: "completed",
       advance: true,

--- a/hydra/src/decision.ts
+++ b/hydra/src/decision.ts
@@ -1,4 +1,4 @@
-import type { StuckReason, SubAgentOutcome } from "./protocol.ts";
+import type { StuckReason, RunOutcome } from "./protocol.ts";
 
 export type DispatchStatus =
   | "eligible"
@@ -17,7 +17,7 @@ export type DecisionPointType =
 export interface CompletedDispatchInfo {
   dispatch_id: string;
   role: string;
-  outcome: SubAgentOutcome;
+  outcome: RunOutcome;
   /**
    * Set when outcome === "stuck". Lets Lead route the intervention without
    * having to read report.md first. See StuckReason in protocol.ts for the

--- a/hydra/src/ledger.ts
+++ b/hydra/src/ledger.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { AgentType } from "./assignment/types.ts";
-import type { StuckReason, SubAgentOutcome } from "./protocol.ts";
+import type { StuckReason, RunOutcome } from "./protocol.ts";
 
 // --- Actor: who made the decision recorded in this entry ---
 //
@@ -57,7 +57,7 @@ export type LedgerEvent =
       agent_type: AgentType;
       duration_ms: number;
       retries_used: number;
-      outcome: SubAgentOutcome;
+      outcome: RunOutcome;
       stuck_reason?: StuckReason;
       report_file: string;
       session_id?: string;

--- a/hydra/src/protocol.ts
+++ b/hydra/src/protocol.ts
@@ -4,7 +4,7 @@ export const RESULT_SCHEMA_VERSION = "hydra/result/v0.1";
 
 // --- Outcome: machine-readable routing signal for Hydra ---
 
-export type SubAgentOutcome = "completed" | "stuck" | "error";
+export type RunOutcome = "completed" | "stuck" | "error";
 
 /**
  * When a worker reports outcome="stuck", `stuck_reason` tells Lead *why* it
@@ -31,13 +31,13 @@ export type StuckReason =
 // All human-readable content (summary, evidence, reflection, output
 // descriptions) lives in the `report.md` file referenced by `report_file`.
 
-export interface SubAgentResult {
+export interface RunResult {
   schema_version: typeof RESULT_SCHEMA_VERSION;
   workbench_id: string;
   assignment_id: string;
   run_id: string;
 
-  outcome: SubAgentOutcome;
+  outcome: RunOutcome;
   report_file: string;       // path to report.md (relative to result.json's dir or absolute)
 
   /**
@@ -83,14 +83,14 @@ function expectString(record: Record<string, unknown>, field: string, root: unkn
   return value;
 }
 
-const VALID_OUTCOMES = new Set<SubAgentOutcome>(["completed", "stuck", "error"]);
+const VALID_OUTCOMES = new Set<RunOutcome>(["completed", "stuck", "error"]);
 
-function validateOutcome(record: Record<string, unknown>, root: unknown): SubAgentOutcome {
+function validateOutcome(record: Record<string, unknown>, root: unknown): RunOutcome {
   const value = expectString(record, "outcome", root);
-  if (!VALID_OUTCOMES.has(value as SubAgentOutcome)) {
+  if (!VALID_OUTCOMES.has(value as RunOutcome)) {
     failValidation(`Invalid outcome: ${value}. Expected one of: ${[...VALID_OUTCOMES].join(", ")}`, root);
   }
-  return value as SubAgentOutcome;
+  return value as RunOutcome;
 }
 
 const VALID_STUCK_REASONS = new Set<StuckReason>([
@@ -102,7 +102,7 @@ const VALID_STUCK_REASONS = new Set<StuckReason>([
 
 function validateStuckReason(
   record: Record<string, unknown>,
-  outcome: SubAgentOutcome,
+  outcome: RunOutcome,
   root: unknown,
 ): StuckReason | undefined {
   const raw = record.stuck_reason;
@@ -127,10 +127,10 @@ function validateStuckReason(
 
 // --- Main validation ---
 
-export function validateSubAgentResult(
+export function validateRunResult(
   value: unknown,
-  expected: Pick<SubAgentResult, "workbench_id" | "assignment_id" | "run_id">,
-): SubAgentResult {
+  expected: Pick<RunResult, "workbench_id" | "assignment_id" | "run_id">,
+): RunResult {
   const record = expectRecord(value, "result", value);
   const schemaVersion = expectString(record, "schema_version", value);
   if (schemaVersion !== RESULT_SCHEMA_VERSION) {
@@ -141,7 +141,7 @@ export function validateSubAgentResult(
   }
 
   const outcome = validateOutcome(record, value);
-  const validated: SubAgentResult = {
+  const validated: RunResult = {
     schema_version: RESULT_SCHEMA_VERSION,
     workbench_id: expectString(record, "workbench_id", value),
     assignment_id: expectString(record, "assignment_id", value),

--- a/hydra/src/replay.ts
+++ b/hydra/src/replay.ts
@@ -1,6 +1,6 @@
 import type { DispatchStatus } from "./decision.ts";
 import type { LedgerActor, LedgerEntry } from "./ledger.ts";
-import type { StuckReason, SubAgentOutcome } from "./protocol.ts";
+import type { StuckReason, RunOutcome } from "./protocol.ts";
 import type { WorkbenchStatus } from "./workflow-store.ts";
 
 /**
@@ -36,7 +36,7 @@ export interface ReplayedDispatch {
   /** Total dispatches observed (initial + Lead redispatches + system retries). */
   dispatch_count: number;
   /** Most recent worker verdict, if the dispatch ever reported one. */
-  last_outcome?: SubAgentOutcome;
+  last_outcome?: RunOutcome;
   /** Sub-state Lead can route on when last_outcome === "stuck". */
   last_stuck_reason?: StuckReason;
   /** Most recent failure code, if the dispatch ever failed. */

--- a/hydra/src/spawn.ts
+++ b/hydra/src/spawn.ts
@@ -12,13 +12,15 @@ import { getRunResultFile } from "./layout.ts";
 import {
   AUTO_APPROVE_AGENT_TYPES,
   DEFAULT_AGENT_TYPE,
+  SUPPORTED_AGENT_TYPES,
   parseAgentTypeFlag,
-  resolveWorkerAgentType,
 } from "./agent-selection.ts";
+import { loadRole, type RoleTerminal } from "./roles/loader.ts";
 import type { AgentType } from "./assignment/types.ts";
 
 export interface SpawnArgs {
   task: string;
+  role?: string;
   workerType?: AgentType;
   repo: string;
   worktree?: string;
@@ -31,7 +33,8 @@ function printSpawnUsage(): never {
   console.log("");
   console.log("Options:");
   console.log("  --task <desc>        Task description for the sub-agent (required)");
-  console.log("  --worker-type <type> Worker agent type");
+  console.log("  --role <name>        Role from the registry (default: dev)");
+  console.log("  --worker-type <type> Override the role's CLI agent type");
   console.log(`  --type <type>        Alias for --worker-type (fallback default: ${DEFAULT_AGENT_TYPE})`);
   console.log("  --repo <path>        Path to the git repository (required)");
   console.log("  --worktree <path>    Use an existing worktree (read-only mode)");
@@ -53,6 +56,8 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
     const arg = args[i];
     if (arg === "--task" && i + 1 < args.length) {
       result.task = args[++i];
+    } else if (arg === "--role" && i + 1 < args.length) {
+      result.role = args[++i];
     } else if ((arg === "--worker-type" || arg === "--type") && i + 1 < args.length) {
       result.workerType = parseAgentTypeFlag(arg, args[++i]);
     } else if (arg === "--repo" && i + 1 < args.length) {
@@ -119,10 +124,49 @@ export function validateWorktreePath(repoPath: string, worktreePath: string): st
   return resolvedWorktree;
 }
 
+/**
+ * Inject default flags for `hydra scan`. Scan is a convenience alias for
+ * `hydra spawn --role janitor` with a default task.
+ */
+export function injectScanDefaults(args: string[]): string[] {
+  const result = [...args];
+  if (!result.includes("--role")) {
+    result.push("--role", "janitor");
+  }
+  if (!result.includes("--task")) {
+    result.push("--task", "Scan this repository for codebase entropy and produce a health report.");
+  }
+  return result;
+}
+
 export async function spawn(args: string[]): Promise<void> {
   const parsed = parseSpawnArgs(args);
   const repo = path.resolve(parsed.repo);
-  const workerType = resolveWorkerAgentType(parsed, process.env);
+
+  // Resolve role from registry. Fail fast if the role doesn't exist.
+  const roleName = parsed.role ?? "dev";
+  const role = loadRole(roleName, repo);
+
+  // Pick the first terminal whose CLI is a supported agent type.
+  const supportedSet = new Set<string>(SUPPORTED_AGENT_TYPES);
+  let chosenTerminal: RoleTerminal | undefined;
+  for (const terminal of role.terminals) {
+    if (supportedSet.has(terminal.cli)) {
+      chosenTerminal = terminal;
+      break;
+    }
+    console.error(`hydra: role "${roleName}" terminal cli="${terminal.cli}" is not a supported agent type, trying next`);
+  }
+  if (!chosenTerminal) {
+    throw new Error(
+      `Role "${roleName}" has no terminal with a supported CLI (tried: ${role.terminals.map(t => t.cli).join(", ")})`,
+    );
+  }
+
+  // User --type overrides role terminal; otherwise role terminal wins.
+  const workerType = parsed.workerType ?? (chosenTerminal.cli as AgentType);
+  const model = chosenTerminal.model;
+  const reasoningEffort = chosenTerminal.reasoning_effort;
 
   if (parsed.autoApprove && !AUTO_APPROVE_AGENT_TYPES.has(workerType)) {
     throw new Error(
@@ -162,9 +206,12 @@ export async function spawn(args: string[]): Promise<void> {
     workbenchId: workflowId,
     assignmentId,
     runId,
-    role: "dev",
+    role: roleName,
     agentType: workerType,
-    sourceRole: "orchestrator",
+    model,
+    reasoningEffort,
+    roleBody: role.body,
+    sourceRole: null,
     objective: [
       parsed.task,
     ],
@@ -176,8 +223,9 @@ export async function spawn(args: string[]): Promise<void> {
       },
     ],
     decisionRules: [
-      "- Complete the requested task honestly.",
-      "- Use intent.type=done when the worker is actually done.",
+      "Use outcome=completed when your work is done.",
+      "Use outcome=stuck when you cannot proceed without external help.",
+      "Use outcome=error only for technical failures.",
     ],
     acceptanceCriteria: [
       "Complete the requested task",
@@ -194,6 +242,8 @@ export async function spawn(args: string[]): Promise<void> {
     repoPath: repo,
     worktreePath,
     agentType: workerType,
+    model,
+    reasoningEffort,
     taskFile: taskRun.task_file,
     resultFile: taskRun.result_file,
     autoApprove: parsed.autoApprove,
@@ -205,6 +255,7 @@ export async function spawn(args: string[]): Promise<void> {
     id: agentId,
     task: parsed.task,
     type: workerType,
+    role: roleName,
     workflowId,
     assignmentId,
     runId,
@@ -224,6 +275,7 @@ export async function spawn(args: string[]): Promise<void> {
     workflowId,
     assignmentId,
     runId,
+    role: roleName,
     terminalId: dispatch.terminalId,
     worktreePath,
     branch,

--- a/hydra/src/store.ts
+++ b/hydra/src/store.ts
@@ -9,6 +9,7 @@ export interface AgentRecord {
   id: string;
   task: string;
   type: string;
+  role?: string;
   workflowId?: string;
   assignmentId?: string;
   runId?: string;

--- a/hydra/src/task-spec-builder.ts
+++ b/hydra/src/task-spec-builder.ts
@@ -74,19 +74,7 @@ export function buildTaskSpecFromIntent(input: BuildTaskSpecInput): RunTaskSpec 
     { label: "Workflow intent", path: getWorkbenchIntentFile(repoPath, workbench.id) },
   ];
 
-  // Auto-inject approved refs
-  if (workbench.approved_refs) {
-    for (const [refNodeId, ref] of Object.entries(workbench.approved_refs)) {
-      if (fs.existsSync(ref.brief_file)) {
-        readFiles.push({ label: `Approved report (${refNodeId})`, path: ref.brief_file });
-      }
-      if (fs.existsSync(ref.result_file)) {
-        readFiles.push({ label: `Approved result (${refNodeId})`, path: ref.result_file });
-      }
-    }
-  }
-
-  // Add extra context refs provided by Lead (supplements)
+  // Add extra context refs provided by Lead via --context-ref
   if (disp.context_refs) {
     for (const ref of disp.context_refs) {
       if (fs.existsSync(ref.path)) {

--- a/hydra/src/workflow-lead.ts
+++ b/hydra/src/workflow-lead.ts
@@ -17,18 +17,17 @@ import {
   hasAssignmentTimedOut,
   retryTimedOutAssignment,
 } from "./retry.ts";
-import { loadRole } from "./roles/loader.ts";
+import { loadRole, type RoleTerminal } from "./roles/loader.ts";
+import { SUPPORTED_AGENT_TYPES } from "./agent-selection.ts";
 import { writeRunTask } from "./run-task.ts";
 import { buildTaskSpecFromIntent } from "./task-spec-builder.ts";
 import {
-  clearDispatchFeedback,
   writeDispatchFeedback,
   writeDispatchIntent,
   writeWorkbenchIntent,
   writeWorkbenchSummary,
 } from "./artifacts.ts";
 import {
-  deleteWorkbench,
   loadWorkbench,
   saveWorkbench,
   WORKBENCH_STATE_SCHEMA_VERSION,
@@ -199,6 +198,7 @@ function latestRun(assignment: AssignmentRecord): AssignmentRecord["runs"][numbe
 }
 
 async function destroyAssignmentTerminal(
+  repoPath: string,
   assignment: AssignmentRecord,
   deps?: WorkbenchDependencies,
 ): Promise<void> {
@@ -215,7 +215,7 @@ async function destroyAssignmentTerminal(
         run.session_id = telemetry.session_id;
         run.session_file = telemetry.session_file;
         run.session_provider = telemetry.provider;
-        const manager = new AssignmentManager(assignment.workspace_root ?? "", assignment.workflow_id);
+        const manager = new AssignmentManager(repoPath, assignment.workbench_id);
         manager.save(assignment);
       }
     } catch {}
@@ -466,14 +466,25 @@ export async function dispatch(
     });
   }
 
-  // Resolve role from registry and pick the highest-priority terminal.
-  // The role file's terminals[] array is the source of truth for cli /
-  // model / reasoning_effort. Today we always pick terminals[0]; future
-  // fallback logic can walk the array if the chosen CLI is unavailable.
-  // Fail fast if the role is unknown or malformed so the dispatch never
-  // reaches a worker that does not exist.
+  // Resolve role from registry and pick the first terminal whose CLI is a
+  // supported agent type. Walk terminals[] in order (preference list) and
+  // fall back if the preferred CLI is unsupported.
   const role = loadRole(options.role, repoPath);
-  const chosenTerminal = role.terminals[0];
+  const supportedSet = new Set<string>(SUPPORTED_AGENT_TYPES);
+  let chosenTerminal: RoleTerminal | undefined;
+  for (const terminal of role.terminals) {
+    if (supportedSet.has(terminal.cli)) {
+      chosenTerminal = terminal;
+      break;
+    }
+    console.error(`hydra: role "${options.role}" terminal cli="${terminal.cli}" is not a supported agent type, trying next`);
+  }
+  if (!chosenTerminal) {
+    throw new HydraError(
+      `Role "${options.role}" has no terminal with a supported CLI (tried: ${role.terminals.map(t => t.cli).join(", ")})`,
+      { errorCode: "WORKBENCH_NO_SUPPORTED_CLI", stage: "workbench.dispatch", ids: { workbench_id: workbench.id } },
+    );
+  }
   const agentType = chosenTerminal.cli as AgentType;
   const model = options.model ?? chosenTerminal.model;
   const reasoningEffort = chosenTerminal.reasoning_effort;
@@ -505,9 +516,9 @@ export async function dispatch(
   // Use dispatchId as the assignment ID directly.
   const manager = managerForWorkbench(workbench);
   manager.create({
-    id: options.dispatchId, workflow_id: workbench.id,
-    workspace_root: workbench.repo_path, worktree_path: disp.worktree_path ?? workbench.worktree_path,
-    role: options.role, from_assignment_id: null,
+    id: options.dispatchId, workbench_id: workbench.id,
+    worktree_path: disp.worktree_path ?? workbench.worktree_path,
+    role: options.role,
     requested_agent_type: agentType,
     timeout_minutes: disp.timeout_minutes ?? workbench.default_timeout_minutes,
     max_retries: disp.max_retries ?? workbench.default_max_retries,
@@ -704,7 +715,7 @@ export async function watchUntilDecision(
             failure_code: "AGENT_REPORTED_ERROR",
             failure_message: errorMessage,
           });
-          await destroyAssignmentTerminal(assignment, deps);
+          await destroyAssignmentTerminal(repoPath, assignment, deps);
           const retryRunId = generateRunId();
           const freshAssignment = loadAssignmentByIdOrThrow(manager, workbench, assignment.id);
           appendLedger(repoPath, workbench.id, "system", {
@@ -724,7 +735,7 @@ export async function watchUntilDecision(
           completed_at: now(),
         };
         await stateMachine.markCompleted(assignment.id, mappedResult);
-        await destroyAssignmentTerminal(assignment, deps);
+        await destroyAssignmentTerminal(repoPath, assignment, deps);
         workbench.dispatches[dispatchId].status = "completed";
 
         // Reload assignment to get the captured session_id (set by destroyAssignmentTerminal)
@@ -787,7 +798,7 @@ export async function watchUntilDecision(
       if (alive === false) {
         const elapsedMs = run.started_at ? Date.parse(now()) - Date.parse(run.started_at) : 0;
         if (elapsedMs > SPAWN_GRACE_PERIOD_MS) {
-          await destroyAssignmentTerminal(assignment, deps);
+          await destroyAssignmentTerminal(repoPath, assignment, deps);
           await stateMachine.markTimedOut(assignment.id, {
             code: "ASSIGNMENT_PROCESS_EXITED",
             message: `Agent process exited without writing result (${Math.round(elapsedMs / 1000)}s)`,
@@ -927,7 +938,7 @@ export interface ResetDispatchOptions {
   repoPath: string;
   workbenchId: string;
   dispatchId: string;
-  feedback?: string;
+  feedback: string;
 }
 
 export interface ResetDispatchResult {
@@ -950,13 +961,13 @@ export async function resetDispatch(
   }
 
   // Reset only the target dispatch — Lead manually resets others if needed
-  workbench.dispatches[options.dispatchId].status = "eligible";
+  workbench.dispatches[options.dispatchId].status = "reset";
 
   const disp = workbench.dispatches[options.dispatchId];
   // Use dispatchId as the assignment ID
   const assignment = manager.load(options.dispatchId);
   if (assignment) {
-    await destroyAssignmentTerminal(assignment, deps);
+    await destroyAssignmentTerminal(repoPath, assignment, deps);
     const previousStatus = assignment.status;
     assignment.status = "pending";
     assignment.updated_at = now();
@@ -970,14 +981,9 @@ export async function resetDispatch(
   }
 
   // Store feedback on target dispatch — write feedback.md, store path
-  if (options.feedback) {
-    const feedbackAbs = writeDispatchFeedback(repoPath, workbench.id, options.dispatchId, options.feedback);
-    const feedbackFileRel = path.relative(repoPath, feedbackAbs);
-    workbench.dispatches[options.dispatchId].feedback_file = feedbackFileRel;
-  } else {
-    clearDispatchFeedback(repoPath, workbench.id, options.dispatchId);
-    workbench.dispatches[options.dispatchId].feedback_file = undefined;
-  }
+  const feedbackAbs = writeDispatchFeedback(repoPath, workbench.id, options.dispatchId, options.feedback);
+  const feedbackFileRel = path.relative(repoPath, feedbackAbs);
+  workbench.dispatches[options.dispatchId].feedback_file = feedbackFileRel;
 
   appendLedger(repoPath, workbench.id, "lead", {
     type: "dispatch_reset", dispatch_id: options.dispatchId, role: workbench.dispatches[options.dispatchId].role,
@@ -1111,7 +1117,7 @@ export async function completeWorkbench(
   for (const [dispatchId, disp] of Object.entries(workbench.dispatches)) {
     const a = manager.load(dispatchId);
     if (a && (a.status === "claimed" || a.status === "in_progress")) {
-      await destroyAssignmentTerminal(a, deps);
+      await destroyAssignmentTerminal(repoPath, a, deps);
     }
   }
 
@@ -1157,7 +1163,7 @@ export async function failWorkbench(
   for (const [dispatchId, disp] of Object.entries(workbench.dispatches)) {
     const a = manager.load(dispatchId);
     if (a && (a.status === "claimed" || a.status === "in_progress")) {
-      await destroyAssignmentTerminal(a, deps);
+      await destroyAssignmentTerminal(repoPath, a, deps);
     }
   }
 
@@ -1194,12 +1200,6 @@ export function getWorkbenchStatus(repoPath: string, workbenchId: string): Workb
     .map((id) => manager.load(id))
     .filter((a): a is AssignmentRecord => a !== null);
   return { workbench, assignments };
-}
-
-// --- cleanupWorkbench ---
-
-export function cleanupWorkbenchState(repoPath: string, workbenchId: string): void {
-  deleteWorkbench(repoPath, workbenchId);
 }
 
 // --- askDispatch (Lead -> completed dispatch follow-up) ---

--- a/hydra/src/workflow-store.ts
+++ b/hydra/src/workflow-store.ts
@@ -181,6 +181,14 @@ export function listWorkbenches(repoPath: string): WorkbenchRecord[] {
     .filter((workbench): workbench is WorkbenchRecord => workbench !== null);
 }
 
+/**
+ * Permanently removes all workbench state files (workbench.json, ledger,
+ * dispatches, runs). Not called by `hydra cleanup` — cleanup only
+ * releases runtime resources (terminals, worktrees, branches) and
+ * preserves state for audit. This function exists for:
+ *   - janitor-driven archival (move to cold storage, then delete)
+ *   - manual emergency purge
+ */
 export function deleteWorkbench(repoPath: string, workbenchId: string): void {
   fs.rmSync(getWorkbenchDir(repoPath, workbenchId), { recursive: true, force: true });
 }

--- a/hydra/tests/assignment-state-machine.test.ts
+++ b/hydra/tests/assignment-state-machine.test.ts
@@ -15,9 +15,9 @@ function createFixture() {
   });
 
   const assignment = manager.create({
-    workflow_id: workflowId,
+    workbench_id: workflowId,
     role: "dev",
-    from_assignment_id: "assignment-research",
+
     requested_agent_type: "codex",
     max_retries: 1,
   });
@@ -175,9 +175,9 @@ test("scheduleRetry honors retry_policy.maximum_attempts over the legacy max_ret
   });
   // max_retries=1 (legacy budget = 1 retry) but maximum_attempts=3 → 2 retries.
   const assignment = manager.create({
-    workflow_id: "workflow-policy",
+    workbench_id: "workflow-policy",
     role: "dev",
-    from_assignment_id: null,
+
     requested_agent_type: "claude",
     max_retries: 1,
     retry_policy: { maximum_attempts: 3 },
@@ -226,9 +226,9 @@ test("scheduleRetry stamps next_retry_at when initial_interval_ms is set", async
     now: () => "2026-04-12T00:00:00.000Z",
   });
   const assignment = manager.create({
-    workflow_id: "workflow-backoff",
+    workbench_id: "workflow-backoff",
     role: "dev",
-    from_assignment_id: null,
+
     requested_agent_type: "claude",
     max_retries: 5,
     retry_policy: { initial_interval_ms: 2000, backoff_coefficient: 2 },
@@ -263,9 +263,9 @@ test("scheduleRetry fails immediately when last_error.code is in non_retryable_e
     now: () => "2026-04-12T00:00:00.000Z",
   });
   const assignment = manager.create({
-    workflow_id: "workflow-nonretry",
+    workbench_id: "workflow-nonretry",
     role: "dev",
-    from_assignment_id: null,
+
     requested_agent_type: "claude",
     max_retries: 5,
     retry_policy: {

--- a/hydra/tests/assignment.test.ts
+++ b/hydra/tests/assignment.test.ts
@@ -34,9 +34,9 @@ test("AssignmentManager creates an assignment", (t) => {
   t.after(() => cleanup(repoPath));
 
   const assignment = manager.create({
-    workflow_id: workflowId,
+    workbench_id: workflowId,
     role: "dev",
-    from_assignment_id: null,
+
     requested_agent_type: "codex",
     max_retries: 2,
   });
@@ -54,9 +54,9 @@ test("AssignmentManager loads an assignment", (t) => {
   t.after(() => cleanup(repoPath));
 
   const created = manager.create({
-    workflow_id: workflowId,
+    workbench_id: workflowId,
     role: "researcher",
-    from_assignment_id: null,
+
     requested_agent_type: "claude",
     max_retries: 1,
   });
@@ -72,9 +72,9 @@ test("AssignmentManager updates assignment status", (t) => {
   t.after(() => cleanup(repoPath));
 
   const assignment = manager.create({
-    workflow_id: workflowId,
+    workbench_id: workflowId,
     role: "reviewer",
-    from_assignment_id: "assignment-previous",
+
     requested_agent_type: "claude",
     max_retries: 1,
   });

--- a/hydra/tests/protocol.test.ts
+++ b/hydra/tests/protocol.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   RESULT_SCHEMA_VERSION,
-  validateSubAgentResult,
+  validateRunResult,
 } from "../src/protocol.ts";
 
 function buildValidResult() {
@@ -22,8 +22,8 @@ const EXPECTED_IDS = {
   run_id: "run-0001",
 } as const;
 
-test("validateSubAgentResult accepts a valid result", () => {
-  const result = validateSubAgentResult(buildValidResult(), EXPECTED_IDS);
+test("validateRunResult accepts a valid result", () => {
+  const result = validateRunResult(buildValidResult(), EXPECTED_IDS);
 
   assert.equal(result.schema_version, RESULT_SCHEMA_VERSION);
   assert.equal(result.assignment_id, EXPECTED_IDS.assignment_id);
@@ -31,14 +31,14 @@ test("validateSubAgentResult accepts a valid result", () => {
   assert.equal(result.report_file, "report.md");
 });
 
-test("validateSubAgentResult rejects invalid outcome", () => {
+test("validateRunResult rejects invalid outcome", () => {
   const invalid = {
     ...buildValidResult(),
     outcome: "invalid_value",
   };
 
   assert.throws(
-    () => validateSubAgentResult(invalid, EXPECTED_IDS),
+    () => validateRunResult(invalid, EXPECTED_IDS),
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.equal((error as Error & { errorCode?: string }).errorCode, "PROTOCOL_INVALID_RESULT");
@@ -48,28 +48,28 @@ test("validateSubAgentResult rejects invalid outcome", () => {
   );
 });
 
-test("validateSubAgentResult accepts stuck outcome", () => {
-  const result = validateSubAgentResult(
+test("validateRunResult accepts stuck outcome", () => {
+  const result = validateRunResult(
     { ...buildValidResult(), outcome: "stuck" },
     EXPECTED_IDS,
   );
   assert.equal(result.outcome, "stuck");
 });
 
-test("validateSubAgentResult accepts error outcome", () => {
-  const result = validateSubAgentResult(
+test("validateRunResult accepts error outcome", () => {
+  const result = validateRunResult(
     { ...buildValidResult(), outcome: "error" },
     EXPECTED_IDS,
   );
   assert.equal(result.outcome, "error");
 });
 
-test("validateSubAgentResult requires report_file", () => {
+test("validateRunResult requires report_file", () => {
   const invalid: Record<string, unknown> = { ...buildValidResult() };
   delete invalid.report_file;
 
   assert.throws(
-    () => validateSubAgentResult(invalid, EXPECTED_IDS),
+    () => validateRunResult(invalid, EXPECTED_IDS),
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /report_file/);
@@ -78,8 +78,8 @@ test("validateSubAgentResult requires report_file", () => {
   );
 });
 
-test("validateSubAgentResult accepts a valid stuck_reason on a stuck result", () => {
-  const result = validateSubAgentResult(
+test("validateRunResult accepts a valid stuck_reason on a stuck result", () => {
+  const result = validateRunResult(
     {
       ...buildValidResult(),
       outcome: "stuck",
@@ -91,8 +91,8 @@ test("validateSubAgentResult accepts a valid stuck_reason on a stuck result", ()
   assert.equal(result.stuck_reason, "needs_credentials");
 });
 
-test("validateSubAgentResult leaves stuck_reason undefined when not provided", () => {
-  const result = validateSubAgentResult(
+test("validateRunResult leaves stuck_reason undefined when not provided", () => {
+  const result = validateRunResult(
     { ...buildValidResult(), outcome: "stuck" },
     EXPECTED_IDS,
   );
@@ -100,10 +100,10 @@ test("validateSubAgentResult leaves stuck_reason undefined when not provided", (
   assert.equal(result.stuck_reason, undefined);
 });
 
-test("validateSubAgentResult rejects an unknown stuck_reason value", () => {
+test("validateRunResult rejects an unknown stuck_reason value", () => {
   assert.throws(
     () =>
-      validateSubAgentResult(
+      validateRunResult(
         {
           ...buildValidResult(),
           outcome: "stuck",
@@ -120,10 +120,10 @@ test("validateSubAgentResult rejects an unknown stuck_reason value", () => {
   );
 });
 
-test("validateSubAgentResult rejects stuck_reason when outcome is not stuck", () => {
+test("validateRunResult rejects stuck_reason when outcome is not stuck", () => {
   assert.throws(
     () =>
-      validateSubAgentResult(
+      validateRunResult(
         {
           ...buildValidResult(),
           outcome: "completed",
@@ -140,14 +140,14 @@ test("validateSubAgentResult rejects stuck_reason when outcome is not stuck", ()
   );
 });
 
-test("validateSubAgentResult rejects mismatched run identity", () => {
+test("validateRunResult rejects mismatched run identity", () => {
   const invalid = {
     ...buildValidResult(),
     run_id: "run-other",
   };
 
   assert.throws(
-    () => validateSubAgentResult(invalid, EXPECTED_IDS),
+    () => validateRunResult(invalid, EXPECTED_IDS),
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.equal((error as Error & { errorCode?: string }).errorCode, "PROTOCOL_INVALID_RESULT");

--- a/hydra/tests/retry.test.ts
+++ b/hydra/tests/retry.test.ts
@@ -21,9 +21,8 @@ function createFixture() {
 
   const assignment = manager.create({
     id: "assignment-123",
-    workflow_id: workbenchId,
+    workbench_id: workbenchId,
     role: "dev",
-    from_assignment_id: null,
     requested_agent_type: "codex",
     timeout_minutes: 1,
     max_retries: 1,

--- a/hydra/tests/spawn.test.ts
+++ b/hydra/tests/spawn.test.ts
@@ -5,6 +5,7 @@ import {
   generateAgentId,
   buildGitWorktreeAddArgs,
   validateWorktreePath,
+  injectScanDefaults,
 } from "../src/spawn.ts";
 
 test("parseSpawnArgs extracts all flags correctly", () => {
@@ -100,4 +101,43 @@ test("validateWorktreePath rejects worktrees outside the repo", () => {
     () => validateWorktreePath("/tmp/repo", "/tmp/other-repo"),
     /must be inside the repo/,
   );
+});
+
+// --- --role flag ---
+
+test("parseSpawnArgs parses --role flag", () => {
+  const args = parseSpawnArgs([
+    "--task", "scan",
+    "--role", "janitor",
+    "--repo", "/tmp/repo",
+  ]);
+  assert.equal(args.role, "janitor");
+});
+
+test("parseSpawnArgs leaves role undefined when not provided", () => {
+  const args = parseSpawnArgs(["--task", "do stuff", "--repo", "/tmp/repo"]);
+  assert.equal(args.role, undefined);
+});
+
+// --- injectScanDefaults ---
+
+test("injectScanDefaults adds --role janitor and default --task", () => {
+  const result = injectScanDefaults(["--repo", "/tmp/repo"]);
+  assert.ok(result.includes("--role"));
+  assert.equal(result[result.indexOf("--role") + 1], "janitor");
+  assert.ok(result.includes("--task"));
+});
+
+test("injectScanDefaults does not override existing --role", () => {
+  const result = injectScanDefaults(["--repo", "/tmp/repo", "--role", "dev"]);
+  const roleValues = result.filter((_, i) => i > 0 && result[i - 1] === "--role");
+  assert.equal(roleValues.length, 1);
+  assert.equal(roleValues[0], "dev");
+});
+
+test("injectScanDefaults does not override existing --task", () => {
+  const result = injectScanDefaults(["--repo", "/tmp/repo", "--task", "custom scan"]);
+  const taskValues = result.filter((_, i) => i > 0 && result[i - 1] === "--task");
+  assert.equal(taskValues.length, 1);
+  assert.equal(taskValues[0], "custom scan");
 });

--- a/hydra/tests/task-spec-builder.test.ts
+++ b/hydra/tests/task-spec-builder.test.ts
@@ -64,11 +64,10 @@ function makeAssignment(overrides: Partial<AssignmentRecord> = {}): AssignmentRe
   return {
     schema_version: "hydra/assignment-state/v0.1",
     id: "assignment-test",
-    workflow_id: "workflow-test",
+    workbench_id: "workflow-test",
     created_at: "2026-04-09T00:00:00.000Z",
     updated_at: "2026-04-09T00:00:00.000Z",
     role: "dev",
-    from_assignment_id: null,
     requested_agent_type: "claude",
     status: "pending",
     retry_count: 0,

--- a/hydra/tests/workflow-lead.test.ts
+++ b/hydra/tests/workflow-lead.test.ts
@@ -459,7 +459,7 @@ test("resetNode resets only the target node", async () => {
     assert.equal(result.dispatch_id, "a");
 
     const workflow = loadWorkbench(repo, init.workbench_id)!;
-    assert.equal(workflow.dispatches.a.status, "eligible");  // target: reset to eligible
+    assert.equal(workflow.dispatches.a.status, "reset");  // target: reset status
     assert.equal(workflow.dispatches.b.status, "dispatched"); // other node: unchanged
     assert.ok(workflow.dispatches.a.feedback_file);
     const feedbackContent = fs.readFileSync(path.join(repo, workflow.dispatches.a.feedback_file!), "utf-8");
@@ -669,7 +669,7 @@ test("redispatch on a non-claude assignment does not pass resumeSessionId", asyn
     manager.save(assignment);
 
     await resetDispatch({
-      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",
+      repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev", feedback: "Try again",
     }, deps);
     await redispatch({
       repoPath: repo, workbenchId: init.workbench_id, dispatchId: "dev",


### PR DESCRIPTION
## Summary

- **Naming cleanup**: `SubAgentResult` → `RunResult`, `SubAgentOutcome` → `RunOutcome`, `workflow_id` → `workbench_id`, remove dead fields (`from_assignment_id`, `workspace_root`)
- **CLI fixes**: static imports, `--intent-file` support, `--feedback` required for reset, `DispatchStatus` consistency (`reset` vs `eligible`), terminals[] fallback with warning
- **Workflow fixes**: remove `approved_refs` auto-injection (Lead uses `--context-ref` explicitly), preserve workbench state on cleanup (only release runtime resources)
- **spawn --role + scan**: `hydra spawn --role <name>` loads role definition from registry, `hydra scan` is a convenience alias for `spawn --role janitor`

## Test plan

- [ ] `npx tsc --noEmit` — only pre-existing init.ts error remains
- [ ] `npx tsx --test tests/*.test.ts` — 160 pass, 4 pre-existing failures unchanged
- [ ] `npx tsx --test tests/spawn.test.ts` — 16/16 pass (5 new tests for --role and scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)