### PR TITLE
fix(updater): surface toast when app location blocks auto-update

### DIFF
--- a/electron/mac-updater.ts
+++ b/electron/mac-updater.ts
@@ -486,6 +486,7 @@ export class MacCustomUpdater {
   private pendingUpdate: PendingUpdate | null = null;
   private downloading = false;
   private installing = false;
+  private locationWarningSent = false;
 
   constructor(window: BrowserWindow) {
     this.window = window;
@@ -510,7 +511,17 @@ export class MacCustomUpdater {
     if (this.downloading) return;
 
     // Skip updates when the .app is on a read-only volume (e.g. mounted DMG)
-    if (!isAppLocationWritable()) return;
+    // or in a TCC-restricted location like ~/Downloads. Notify the UI once so
+    // the user knows why auto-update is silently unavailable.
+    if (!isAppLocationWritable()) {
+      if (!this.locationWarningSent) {
+        this.locationWarningSent = true;
+        sendToWindow(this.window, "updater:location-warning", {
+          bundlePath: getAppBundlePath(),
+        });
+      }
+      return;
+    }
 
     try {
       const ymlUrl = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest/download/latest-mac.yml`;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -739,6 +739,17 @@ contextBridge.exposeInMainWorld("termcanvas", {
       ipcRenderer.on("updater:error", listener);
       return () => ipcRenderer.removeListener("updater:error", listener);
     },
+    onLocationWarning: (
+      callback: (info: { bundlePath: string }) => void,
+    ) => {
+      const listener = (
+        _e: Electron.IpcRendererEvent,
+        info: { bundlePath: string },
+      ) => callback(info);
+      ipcRenderer.on("updater:location-warning", listener);
+      return () =>
+        ipcRenderer.removeListener("updater:location-warning", listener);
+    },
   },
   hooks: {
     getSocketPath: () =>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -341,6 +341,8 @@ export const en = {
     `Downloading ${Math.round(percent)}%`,
   update_up_to_date: "Up to date",
   update_restart_short: "Restart & Update",
+  update_location_warning:
+    "Auto-update disabled: move TermCanvas to /Applications to receive updates.",
 
   agent_provider: "Agent Provider",
   agent_model: "Agent Model",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -331,6 +331,8 @@ export const zh = {
     `下载中 ${Math.round(percent)}%`,
   update_up_to_date: "已是最新",
   update_restart_short: "重启并更新",
+  update_location_warning:
+    "自动更新已禁用：请将 TermCanvas 移动到 /Applications 目录以接收更新。",
 
   agent_provider: "Agent 提供商",
   agent_model: "Agent 模型",

--- a/src/stores/updaterStore.ts
+++ b/src/stores/updaterStore.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
 import type { UpdateEventInfo } from "../types";
+import { useNotificationStore } from "./notificationStore";
+import { useLocaleStore } from "./localeStore";
+import { en } from "../i18n/en";
+import { zh } from "../i18n/zh";
 
 export type UpdateStatus = "idle" | "checking" | "downloading" | "ready" | "error";
 
@@ -61,6 +65,18 @@ export function initUpdaterListeners(): () => void {
       useUpdaterStore.setState({ status: "error", errorMessage: error.message });
     }),
   );
+
+  if (window.termcanvas.updater.onLocationWarning) {
+    cleanups.push(
+      window.termcanvas.updater.onLocationWarning(() => {
+        const locale = useLocaleStore.getState().locale;
+        const dict = locale === "zh" ? { ...en, ...zh } : en;
+        useNotificationStore
+          .getState()
+          .notify("warn", dict.update_location_warning);
+      }),
+    );
+  }
 
   return () => cleanups.forEach((fn) => fn());
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -938,6 +938,9 @@ export interface TermCanvasAPI {
       callback: (info: UpdateEventInfo) => void,
     ) => () => void;
     onError: (callback: (error: { message: string }) => void) => () => void;
+    onLocationWarning?: (
+      callback: (info: { bundlePath: string }) => void,
+    ) => () => void;
   };
 }
 


### PR DESCRIPTION
## Summary
- macOS auto-updater previously bailed out of `checkForUpdates()` with a silent `return` when `isAppLocationWritable()` failed (app launched from `~/Downloads`, a mounted DMG, or any TCC-restricted folder). No log, no event, no UI feedback — users assumed auto-update was broken.
- Now emits a one-shot `updater:location-warning` IPC event the first time the guard trips in a process lifetime. The renderer wires this to `useNotificationStore.notify("warn", ...)`, which renders a yellow toast via the existing `NotificationToast` component telling the user to move TermCanvas into `/Applications`.
- Fires at most once per app launch (class field `locationWarningSent`), so the 30-minute periodic check does not re-nag.
- i18n: English + 简体中文.
- Backwards-compatible: `onLocationWarning` is optional on the preload bridge so a newer renderer paired with an older preload just skips the listener.

## Changes
- `electron/mac-updater.ts` — turn the silent `isAppLocationWritable()` return into a one-shot `updater:location-warning` event
- `electron/preload.ts` — expose `onLocationWarning` listener
- `src/stores/updaterStore.ts` — subscribe and trigger the warn toast
- `src/types/index.ts` — add optional `onLocationWarning` to the updater surface
- `src/i18n/{en,zh}.ts` — add `update_location_warning` string

## Test plan
- [ ] `npm run build && npx electron-builder --mac --dir` then launch the unpacked `.app` from `~/Downloads` — yellow toast appears ~5s after launch
- [ ] Move the same `.app` into `/Applications`, relaunch — no toast, download proceeds normally
- [ ] Launch from a mounted DMG (read-only) — toast appears
- [ ] Confirm toast auto-dismisses after 5s and does not re-appear on the next 30-minute tick
- [ ] Locale switch: verify zh string renders when `useLocaleStore.locale === "zh"`
- [ ] Windows + Linux builds unchanged (guard is mac-only, electron-updater path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)