### PR TITLE
fix(canvas): stop worktree label from snapping back on drop

### DIFF
--- a/src/canvas/WorktreeLabelLayer.tsx
+++ b/src/canvas/WorktreeLabelLayer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 import { useReactFlow } from "@xyflow/react";
 import type { ProjectData } from "../types";
 import { useProjectStore } from "../stores/projectStore";
@@ -53,7 +53,6 @@ import { focusWorktreeInScene } from "../actions/sceneSelectionActions";
  */
 
 const HUD_THRESHOLD = 0.7;
-const FADE_END = 0.3;
 const LOD_THRESHOLD = 0.15;
 
 // Pixel-space gap to leave between two stacked labels.
@@ -212,19 +211,9 @@ function clusterOpacity(
   hasFocus: boolean,
 ): number {
   if (scale >= HUD_THRESHOLD) return 0;
-  const fadeProgress = Math.min(
-    1,
-    Math.max(0, (HUD_THRESHOLD - scale) / (HUD_THRESHOLD - FADE_END)),
-  );
-  let dim: number;
-  if (isFocused || isHovered) {
-    dim = 1;
-  } else if (hasFocus) {
-    dim = 0.35;
-  } else {
-    dim = 0.85;
-  }
-  return fadeProgress * dim;
+  if (isFocused || isHovered) return 1;
+  if (hasFocus) return 0.35;
+  return 0.85;
 }
 
 function estimateLabelWidth(text: string): number {
@@ -303,8 +292,7 @@ const LABEL_BASE_STYLE = {
   backdropFilter: "blur(4px)",
   WebkitBackdropFilter: "blur(4px)",
   boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
-  transition:
-    "opacity 120ms ease-out, transform 120ms ease-out, background-color 120ms ease-out",
+  transition: "background-color 120ms ease-out",
 } as const;
 
 interface ClusterEntry {
@@ -586,19 +574,14 @@ export function WorktreeLabelLayer() {
       window.removeEventListener("pointerup", finishDrag);
       window.removeEventListener("pointercancel", finishDrag);
       dragStateRef.current = null;
-      setIsDragging(false);
 
-      // Reset label transform.
+      // Capture label element before the re-render detaches its ref.
       const el = dragLabelRef.current;
-      if (el) el.style.transform = "translate(0, -100%)";
 
       if (active.moved) {
         suppressClickUntilRef.current = performance.now() + 250;
       }
 
-      // Commit final positions to the store.  Even without dragging,
-      // pointerdown already snapped terminals to compact positions via
-      // setNodes — sync the store so panToWorktree reads correct coords.
       const vp = viewportRef.current;
       const delta = active.moved
         ? screenDeltaToCanvasDelta(
@@ -623,7 +606,16 @@ export function WorktreeLabelLayer() {
           y: snap(finalAnchorY + offset.y),
         };
       });
-      useProjectStore.getState().updateTerminalPositions(updates);
+
+      // Flush store + drag-flag together so React commits the new left/top
+      // BEFORE we clear the imperative transform — otherwise the label paints
+      // one frame at the old anchor position and visibly snaps back to start.
+      flushSync(() => {
+        useProjectStore.getState().updateTerminalPositions(updates);
+        setIsDragging(false);
+      });
+
+      if (el) el.style.transform = "translate(0, -100%)";
 
       // Resolve collisions with all other terminals.
       const allProjects = useProjectStore.getState().projects;


### PR DESCRIPTION
## Summary
- Remove the opacity fade between `HUD_THRESHOLD` and `FADE_END` from `WorktreeLabelLayer` — the element unmounts at opacity 0, so the transition never actually played and the threshold just produced a ghostly half-rendered band.
- Fix the drag-drop snap-back: `finishDrag` now captures the label DOM ref up front, wraps the store commit + `isDragging` flip in `flushSync`, and only resets the imperative transform after React has committed the new `left/top`.

## Why
- The zoom-hide "animation" was always broken — the element was removed before the 120ms transition could run, so users saw a flash rather than a fade.
- The label dropped at the correct position but painted one frame at the old anchor first, because the transform reset ran before the store update propagated.

## Test plan
- [ ] Drag a worktree label across the canvas — on drop, the label should land at the new position without any momentary snap back to the drag start.
- [ ] Zoom past `HUD_THRESHOLD` (0.7) in both directions — labels should appear/disappear cleanly, no fading band.
- [ ] Hover focus still dims non-focused labels (0.35) and lights focused/hovered (1.0).
- [ ] LOD mode (`scale < 0.15`) still collapses into "Project (N)" labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
