### PR TITLE
fix(canvas): remove React Flow attribution badge

### DIFF
--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -605,6 +605,7 @@ function XyFlowCanvasInner() {
         // TerminalTile remount churn during viewport animation and focus
         // cycling, which in turn destabilizes xterm/WebGL lifecycle.
         preventScrolling
+        proOptions={{ hideAttribution: true }}
       >
         <Background gap={20} size={1} color="var(--border)" />
       </ReactFlow>


### PR DESCRIPTION
## Summary
- Remove the default xyflow branding watermark from the canvas bottom-right corner
- The badge only links to the xyflow website and serves no purpose in the desktop app

## Test plan
- [ ] Verify the xyflow logo/badge no longer appears in the bottom-right corner of the canvas
- [ ] Verify canvas panning, zooming, and node interactions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)