### PR TITLE
feat(terminal): Cmd/Ctrl+Click to open URLs in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@supabase/supabase-js": "^2.99.3",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xyflow/react": "^12.10.1",
     "adm-zip": "^0.5.16",
     "electron-updater": "^6.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1499,6 +1502,9 @@ packages:
 
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -4964,6 +4970,8 @@ snapshots:
   '@xterm/addon-image@0.9.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -4,6 +4,7 @@ import type { Terminal as XtermTerminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ImageAddon } from "@xterm/addon-image";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import {
   acquireWebGL,
   releaseWebGL,
@@ -1042,6 +1043,12 @@ function createTerminalRenderer(
   try {
     xterm.loadAddon(new ImageAddon());
   } catch {}
+
+  xterm.loadAddon(
+    new WebLinksAddon((_event, uri) => {
+      window.open(uri);
+    }),
+  );
 
   xterm.attachCustomKeyEventHandler((event) => {
     if (event.type === "keydown" && isRegisteredAppShortcutEvent(event)) {


### PR DESCRIPTION
## Summary
- Add `@xterm/addon-web-links` to enable URL detection in canvas terminals
- Cmd/Ctrl+Click on a URL now opens it in the system default browser, matching native terminal behavior (e.g. Ghostty)
- Uses existing `window.open()` → `shell.openExternal()` Electron bridge, no new IPC needed

## Test plan
- [ ] Open a terminal on the canvas
- [ ] Run a command that outputs a URL (e.g. `echo https://github.com`)
- [ ] Hover over the URL — should show underline
- [ ] Cmd+Click (macOS) / Ctrl+Click (Linux/Windows) — should open in default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)