### PR TITLE
fix(terminal): recover blank terminals after visibility loss

### DIFF
--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -1549,8 +1549,37 @@ async function spawnPty(
   }
 }
 
+let renderRecoveryInstalled = false;
+
+function installRenderRecoveryListeners() {
+  if (
+    renderRecoveryInstalled ||
+    typeof document === "undefined" ||
+    typeof document.addEventListener !== "function"
+  ) {
+    return;
+  }
+  renderRecoveryInstalled = true;
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      // WebGL canvases lose their framebuffer when the page is hidden
+      // (sleep/wake, minimize, GPU restart). xterm's IntersectionObserver
+      // only repaints if _needsFullRefresh was set during the pause, which
+      // requires terminal output while hidden. Idle terminals stay blank.
+      refreshAllTerminalRenderers("visibility_change_to_visible");
+      rebuildTerminalAtlas(undefined, "visibility_change_to_visible");
+    }
+  });
+
+  window.addEventListener("focus", () => {
+    refreshAllTerminalRenderers("window_focus");
+  });
+}
+
 function startTerminalRuntime(runtime: ManagedTerminalRuntime) {
   installRenderDiagnosticsListeners();
+  installRenderRecoveryListeners();
 
   if (runtime.started || runtime.disposed || !window.termcanvas) {
     return;
@@ -2035,6 +2064,32 @@ export function destroyAllTerminalRuntimes() {
       caller: "destroyAllTerminalRuntimes",
       reason: "destroy_all_terminal_runtimes",
     });
+  }
+}
+
+/**
+ * Force every live terminal to repaint its full visible buffer.
+ *
+ * WebGL canvases lose their framebuffer content after the window is hidden
+ * (sleep/wake, minimize, GPU process restart) because `preserveDrawingBuffer`
+ * is not set. xterm's internal IntersectionObserver only triggers a catch-up
+ * repaint when `_needsFullRefresh` was set during the pause—which requires
+ * at least one `refreshRows` call while paused. If the terminal was idle
+ * the entire time, no repaint is queued and the canvas stays blank.
+ *
+ * Call this on `document.visibilitychange → "visible"` and after window
+ * restore/focus to guarantee every terminal repaints.
+ */
+export function refreshAllTerminalRenderers(reason = "unspecified") {
+  recordRenderDiagnostic({
+    kind: "terminal_refresh_all_renderers",
+    data: { reason, runtime_count: runtimeRegistry.size },
+  });
+  for (const runtime of runtimeRegistry.values()) {
+    if (!runtime.xterm || runtime.disposed) continue;
+    try {
+      runtime.xterm.refresh(0, runtime.xterm.rows - 1);
+    } catch { /* terminal may be mid-disposal */ }
   }
 }
 

--- a/src/terminal/webglContextPool.ts
+++ b/src/terminal/webglContextPool.ts
@@ -164,6 +164,12 @@ export function acquireWebGL(terminalId: string, xterm: Terminal): boolean {
       notifyWebGLFallbackHint("context_lost");
       addon.dispose();
       entries.delete(terminalId);
+      // After addon disposal xterm creates a fallback DomRenderer, but the
+      // new renderer's canvas is empty. Force a full repaint so the buffer
+      // content is immediately visible instead of showing a blank terminal.
+      try {
+        xterm.refresh(0, xterm.rows - 1);
+      } catch { /* terminal may already be disposed */ }
     });
     xterm.loadAddon(addon);
     entries.set(terminalId, {


### PR DESCRIPTION
## Summary
- Fix all terminals going blank after sleep/wake, window minimize/restore, or GPU process crash
- WebGL canvas framebuffers are silently discarded by the browser/GPU when the page is hidden. xterm v6's IntersectionObserver pause mechanism only queues a catch-up repaint if terminal output arrived while paused — idle terminals never get repainted
- Force `xterm.refresh()` on all terminals + rebuild WebGL texture atlas on `visibilitychange → visible` and `window focus`
- Call `xterm.refresh()` immediately after WebGL context loss addon disposal so the fallback DomRenderer paints buffer content right away

## Test plan
- [ ] Open multiple terminals, minimize the window for a few seconds then restore — verify all terminal content displays correctly
- [ ] Open multiple terminals, close laptop lid (sleep) then reopen — verify terminals are not blank
- [ ] Perform the above with idle terminals (no output) — verify idle terminals also recover
- [ ] Check `localStorage.getItem("tc:webgl-loss-count")` in DevTools Console to track context loss events

🤖 Generated with [Claude Code](https://claude.com/claude-code)