### PR TITLE
fix(terminal): require Ctrl/Cmd for link underline and click

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -342,6 +342,11 @@ body {
   cursor: text !important;
 }
 
+.tc-xterm-host.modifier-held .xterm.xterm-cursor-pointer,
+.tc-xterm-host.modifier-held .xterm .xterm-cursor-pointer {
+  cursor: pointer !important;
+}
+
 /* xterm v6 scroll shadows sit at z-index 11 along the top and left edges
    of the scrollable element.  They intercept mouse events in the top-left
    area of the terminal, preventing text selection from starting there.

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -1,10 +1,9 @@
 import { create } from "zustand";
 import * as xtermModule from "@xterm/xterm";
-import type { Terminal as XtermTerminal } from "@xterm/xterm";
+import type { Terminal as XtermTerminal, ILink, ILinkProvider } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { ImageAddon } from "@xterm/addon-image";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import {
   acquireWebGL,
   releaseWebGL,
@@ -1010,6 +1009,86 @@ function syncAttachedTerminalGeometry(runtime: ManagedTerminalRuntime) {
   recordRuntimeDiagnostic(runtime, "terminal_runtime_fit");
 }
 
+const URL_REGEX =
+  /(https?|HTTPS?):\/\/[^\s"'!*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]/;
+
+function registerModifierAwareLinkProvider(
+  xterm: XtermTerminal,
+  host: HTMLElement,
+) {
+  let modifierHeld = false;
+  const activeLinks = new Set<ILink>();
+
+  const updateDecorations = () => {
+    host.classList.toggle("modifier-held", modifierHeld);
+    for (const link of activeLinks) {
+      if (link.decorations) {
+        link.decorations.underline = modifierHeld;
+        link.decorations.pointerCursor = modifierHeld;
+      }
+    }
+  };
+
+  const onKeyChange = (e: KeyboardEvent) => {
+    const held = e.type === "keydown" && (e.metaKey || e.ctrlKey);
+    if (held !== modifierHeld) {
+      modifierHeld = held;
+      updateDecorations();
+    }
+  };
+
+  host.addEventListener("keydown", onKeyChange, true);
+  host.addEventListener("keyup", onKeyChange, true);
+  window.addEventListener("blur", () => {
+    if (modifierHeld) {
+      modifierHeld = false;
+      updateDecorations();
+    }
+  });
+
+  const provider: ILinkProvider = {
+    provideLinks(bufferLineNumber, callback) {
+      const line = xterm.buffer.active.getLine(bufferLineNumber - 1);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+      const text = line.translateToString(true);
+      const links: ILink[] = [];
+      const regex = new RegExp(URL_REGEX.source, "g");
+      let match: RegExpExecArray | null;
+
+      while ((match = regex.exec(text)) !== null) {
+        const uri = match[0];
+        const startX = match.index + 1;
+        const endX = match.index + uri.length;
+        const link: ILink = {
+          range: {
+            start: { x: startX, y: bufferLineNumber },
+            end: { x: endX, y: bufferLineNumber },
+          },
+          text: uri,
+          decorations: { underline: modifierHeld, pointerCursor: modifierHeld },
+          activate(_event, linkText) {
+            if (_event.metaKey || _event.ctrlKey) {
+              window.open(linkText);
+            }
+          },
+          dispose() {
+            activeLinks.delete(link);
+          },
+        };
+        activeLinks.add(link);
+        links.push(link);
+      }
+
+      callback(links.length > 0 ? links : undefined);
+    },
+  };
+
+  xterm.registerLinkProvider(provider);
+}
+
 function createTerminalRenderer(
   runtime: ManagedTerminalRuntime,
   container: HTMLDivElement,
@@ -1044,11 +1123,7 @@ function createTerminalRenderer(
     xterm.loadAddon(new ImageAddon());
   } catch {}
 
-  xterm.loadAddon(
-    new WebLinksAddon((_event, uri) => {
-      window.open(uri);
-    }),
-  );
+  registerModifierAwareLinkProvider(xterm, host);
 
   xterm.attachCustomKeyEventHandler((event) => {
     if (event.type === "keydown" && isRegisteredAppShortcutEvent(event)) {

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -1015,7 +1015,7 @@ const URL_REGEX =
 function registerModifierAwareLinkProvider(
   xterm: XtermTerminal,
   host: HTMLElement,
-) {
+): () => void {
   let modifierHeld = false;
   const activeLinks = new Set<ILink>();
 
@@ -1030,21 +1030,23 @@ function registerModifierAwareLinkProvider(
   };
 
   const onKeyChange = (e: KeyboardEvent) => {
-    const held = e.type === "keydown" && (e.metaKey || e.ctrlKey);
+    const held = e.metaKey || e.ctrlKey;
     if (held !== modifierHeld) {
       modifierHeld = held;
       updateDecorations();
     }
   };
 
-  host.addEventListener("keydown", onKeyChange, true);
-  host.addEventListener("keyup", onKeyChange, true);
-  window.addEventListener("blur", () => {
+  const onWindowBlur = () => {
     if (modifierHeld) {
       modifierHeld = false;
       updateDecorations();
     }
-  });
+  };
+
+  host.addEventListener("keydown", onKeyChange, true);
+  host.addEventListener("keyup", onKeyChange, true);
+  window.addEventListener("blur", onWindowBlur);
 
   const provider: ILinkProvider = {
     provideLinks(bufferLineNumber, callback) {
@@ -1086,7 +1088,16 @@ function registerModifierAwareLinkProvider(
     },
   };
 
-  xterm.registerLinkProvider(provider);
+  const linkDisposable = xterm.registerLinkProvider(provider);
+
+  return () => {
+    linkDisposable.dispose();
+    host.removeEventListener("keydown", onKeyChange, true);
+    host.removeEventListener("keyup", onKeyChange, true);
+    window.removeEventListener("blur", onWindowBlur);
+    host.classList.remove("modifier-held");
+    activeLinks.clear();
+  };
 }
 
 function createTerminalRenderer(
@@ -1123,7 +1134,7 @@ function createTerminalRenderer(
     xterm.loadAddon(new ImageAddon());
   } catch {}
 
-  registerModifierAwareLinkProvider(xterm, host);
+  runtime.globalDisposers.push(registerModifierAwareLinkProvider(xterm, host));
 
   xterm.attachCustomKeyEventHandler((event) => {
     if (event.type === "keydown" && isRegisteredAppShortcutEvent(event)) {


### PR DESCRIPTION
## Summary
- Replace `WebLinksAddon` with a custom `registerLinkProvider` implementation that only shows link decorations (underline + pointer cursor) when Ctrl or Cmd is held
- Links are visually inert by default — no underline, no cursor change on hover
- Clicking a link only opens it when the modifier key is active, matching VS Code's terminal behavior
- Carve out the existing `cursor: text !important` override so `.xterm-cursor-pointer` can take effect during modifier-held state

## Test plan
- [ ] Open a terminal, confirm URLs appear as plain text (no underline on hover)
- [ ] Hold Ctrl (Linux/Windows) or Cmd (macOS), hover a URL — underline and pointer cursor should appear
- [ ] Ctrl/Cmd+Click a URL — should open in default browser
- [ ] Click a URL without modifier — should not open
- [ ] Release modifier — underline and pointer cursor should disappear immediately
- [ ] Switch away from the app while holding modifier, switch back — no stuck state

🤖 Generated with [Claude Code](https://claude.com/claude-code)