### PR TITLE
feat(canvas): Figma-style canvas controls (bottom toolbar + hand tool + keybindings)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { CanvasRoot } from "./canvas/CanvasRoot";
 import { addProjectFromDirectoryPath } from "./canvas/sceneCommands";
 import { Toolbar } from "./toolbar/Toolbar";
+import { BottomToolbar } from "./toolbar/BottomToolbar";
 import { NotificationToast } from "./components/NotificationToast";
 import { LeftPanel } from "./components/LeftPanel";
 import { RightPanel } from "./components/RightPanel";
@@ -591,6 +592,7 @@ export function App() {
       <LeftPanel />
       <RightPanel />
       <CanvasRoot />
+      <BottomToolbar />
       {drawingEnabled && <DrawingPanel />}
       {completionGlowEnabled && <CompletionGlow />}
       <ShortcutHints />

--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -23,6 +23,7 @@ import { useTaskStore } from "../stores/taskStore";
 import { useDrawingStore } from "../stores/drawingStore";
 import { useCanvasToolStore } from "../stores/canvasToolStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
+import { useSelectionStore } from "../stores/selectionStore";
 import { useSidebarDragStore } from "../stores/sidebarDragStore";
 import {
   PANEL_TRANSITION_DURATION_MS,
@@ -443,18 +444,114 @@ function XyFlowCanvasInner() {
     [isPanMode],
   );
 
-  const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(() => {
-    // No-op in flat canvas — no bringToFront needed
-  }, []);
+  // Multi-drag plumbing. When the user starts dragging a terminal that
+  // is part of a multi-select, we capture every selected terminal's
+  // starting position here and consult it on every drag tick to keep
+  // the rest of the group in lock-step with the dragged node. An empty
+  // map (or a map with <2 entries) means "single-drag, do nothing
+  // special" and we fall through to the existing per-node logic.
+  const multiDragStartsRef = useRef<Map<string, { x: number; y: number }>>(
+    new Map(),
+  );
+
+  const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(
+    (_event, node) => {
+      const selectedTerminalIds = new Set(
+        useSelectionStore
+          .getState()
+          .selectedItems.flatMap((item) =>
+            item.type === "terminal" ? [item.terminalId] : [],
+          ),
+      );
+      if (
+        selectedTerminalIds.size < 2 ||
+        !selectedTerminalIds.has(node.data.terminalId)
+      ) {
+        multiDragStartsRef.current.clear();
+        return;
+      }
+      const starts = new Map<string, { x: number; y: number }>();
+      for (const candidate of nodes) {
+        if (candidate.type !== "terminal") continue;
+        if (selectedTerminalIds.has(candidate.data.terminalId)) {
+          starts.set(candidate.data.terminalId, {
+            x: candidate.position.x,
+            y: candidate.position.y,
+          });
+        }
+      }
+      multiDragStartsRef.current = starts;
+    },
+    [nodes],
+  );
+
+  const handleNodeDrag = useCallback<OnNodeDrag<CanvasFlowNode>>(
+    (_event, node) => {
+      const starts = multiDragStartsRef.current;
+      if (starts.size < 2) return;
+      const myStart = starts.get(node.data.terminalId);
+      if (!myStart) return;
+      const dx = node.position.x - myStart.x;
+      const dy = node.position.y - myStart.y;
+      setNodes((current) =>
+        current.map((candidate) => {
+          if (candidate.type !== "terminal") return candidate;
+          if (candidate.data.terminalId === node.data.terminalId) {
+            return candidate;
+          }
+          const start = starts.get(candidate.data.terminalId);
+          if (!start) return candidate;
+          return {
+            ...candidate,
+            position: { x: start.x + dx, y: start.y + dy },
+          };
+        }),
+      );
+    },
+    [setNodes],
+  );
 
   const handleNodeDragStop = useCallback<OnNodeDrag<CanvasFlowNode>>(
     (_event, node) => {
-      // Write terminal position back to store
       const { projectId, worktreeId, terminalId } = node.data;
       const snappedX =
         Math.round(node.position.x / SNAP_GRID[0]) * SNAP_GRID[0];
       const snappedY =
         Math.round(node.position.y / SNAP_GRID[1]) * SNAP_GRID[1];
+
+      const starts = multiDragStartsRef.current;
+      if (starts.size >= 2) {
+        // Multi-drag commit. Use the dragged node's delta as the
+        // group's translation vector — every selected terminal moves
+        // by the same (snapped) offset. We deliberately skip
+        // collision resolution here: shoving the group's neighbours
+        // around mid-translation defeats the user's intent of
+        // arranging the picked set as a unit.
+        const myStart = starts.get(terminalId);
+        if (myStart) {
+          const dx = snappedX - myStart.x;
+          const dy = snappedY - myStart.y;
+          const allProjects = useProjectStore.getState().projects;
+          const updatePos = useProjectStore.getState().updateTerminalPosition;
+          for (const [movedId, start] of starts.entries()) {
+            const finalX =
+              Math.round((start.x + dx) / SNAP_GRID[0]) * SNAP_GRID[0];
+            const finalY =
+              Math.round((start.y + dy) / SNAP_GRID[1]) * SNAP_GRID[1];
+            for (const p of allProjects) {
+              for (const w of p.worktrees) {
+                if (w.terminals.some((term) => term.id === movedId)) {
+                  updatePos(p.id, w.id, movedId, finalX, finalY);
+                }
+              }
+            }
+          }
+        }
+        multiDragStartsRef.current.clear();
+        return;
+      }
+
+      // Single-drag path (unchanged behaviour).
       useProjectStore
         .getState()
         .updateTerminalPosition(
@@ -465,7 +562,6 @@ function XyFlowCanvasInner() {
           snappedY,
         );
 
-      // Resolve collisions after drag
       const allProjects = useProjectStore.getState().projects;
       const allRects = allProjects.flatMap((p) =>
         p.worktrees.flatMap((w) =>
@@ -644,6 +740,7 @@ function XyFlowCanvasInner() {
         onPaneContextMenu={handlePaneContextMenu}
         onNodeClick={handleNodeClick}
         onNodeDragStart={handleNodeDragStart}
+        onNodeDrag={handleNodeDrag}
         onNodeDragStop={handleNodeDragStop}
         nodesConnectable={false}
         nodesDraggable={!isPanMode}

--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -651,7 +651,11 @@ function XyFlowCanvasInner() {
         edgesFocusable={false}
         elementsSelectable={false}
         selectNodesOnDrag={false}
-        panOnDrag={[0, 1]}
+        // In Hand mode (or Space-held), left+middle both pan. In Move
+        // mode, only middle-button pans — the left button is reserved
+        // for marquee on empty canvas (handled by useBoxSelect) and
+        // node drag (handled by React Flow's nodesDraggable).
+        panOnDrag={isPanMode ? [0, 1] : [1]}
         panOnScroll
         panOnScrollMode={PanOnScrollMode.Free}
         snapToGrid

--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -433,14 +433,18 @@ function XyFlowCanvasInner() {
 
   const handleNodeClick = useCallback<NodeMouseHandler<CanvasFlowNode>>(
     (_event, node) => {
-      // In hand-tool / space-pan mode, a click is the tail of a pan
-      // gesture (or a no-op tap). Don't activate the worktree —
-      // matches Figma where the hand tool never selects.
-      if (isPanMode) return;
+      // Space-held panning is a transient override on top of whatever
+      // tool is active — a click that lands while Space is down is the
+      // tail of a pan gesture, so suppress the activate. Persistent
+      // Hand mode is different: clicking a terminal there is the user's
+      // way of getting *into* a terminal without leaving Hand. Without
+      // this distinction the now-default Hand tool can't focus a
+      // worktree by clicking, which made the canvas feel inert.
+      if (spaceHeld) return;
       const { projectId, worktreeId } = node.data;
       useProjectStore.getState().setFocusedWorktree(projectId, worktreeId);
     },
-    [isPanMode],
+    [spaceHeld],
   );
 
   const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(() => {
@@ -590,13 +594,33 @@ function XyFlowCanvasInner() {
     };
   }, [isPanning]);
 
+  // isPanning takes precedence over isPanMode for the cursor: if the
+  // user holds Space, presses the mouse, then releases Space before
+  // mouseup, the gesture is still in flight and the cursor must keep
+  // saying "grabbing". Without this, the cursor snaps back to default
+  // mid-drag.
   const cursorClass = isDrawing
     ? "cursor-crosshair"
-    : isPanMode
-      ? isPanning
-        ? "cursor-grabbing"
-        : "cursor-grab"
-      : "";
+    : isPanning
+      ? "cursor-grabbing"
+      : isPanMode
+        ? "cursor-grab"
+        : "";
+
+  // Cursors set on the outer div lose to the `cursor: text !important`
+  // rule that .tc-xterm-host / .xterm enforces inside terminal tiles.
+  // Toggle body classes that the matching CSS overrides target so the
+  // pan cursor wins everywhere on the canvas, not just over empty
+  // pane.
+  useEffect(() => {
+    const body = document.body;
+    body.classList.toggle("tc-canvas-pan-mode", isPanMode || isPanning);
+    body.classList.toggle("tc-canvas-pan-grabbing", isPanning);
+    return () => {
+      body.classList.remove("tc-canvas-pan-mode");
+      body.classList.remove("tc-canvas-pan-grabbing");
+    };
+  }, [isPanMode, isPanning]);
 
   return (
     <div

--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -23,7 +23,6 @@ import { useTaskStore } from "../stores/taskStore";
 import { useDrawingStore } from "../stores/drawingStore";
 import { useCanvasToolStore } from "../stores/canvasToolStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
-import { useSelectionStore } from "../stores/selectionStore";
 import { useSidebarDragStore } from "../stores/sidebarDragStore";
 import {
   PANEL_TRANSITION_DURATION_MS,
@@ -444,114 +443,18 @@ function XyFlowCanvasInner() {
     [isPanMode],
   );
 
-  // Multi-drag plumbing. When the user starts dragging a terminal that
-  // is part of a multi-select, we capture every selected terminal's
-  // starting position here and consult it on every drag tick to keep
-  // the rest of the group in lock-step with the dragged node. An empty
-  // map (or a map with <2 entries) means "single-drag, do nothing
-  // special" and we fall through to the existing per-node logic.
-  const multiDragStartsRef = useRef<Map<string, { x: number; y: number }>>(
-    new Map(),
-  );
-
-  const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(
-    (_event, node) => {
-      const selectedTerminalIds = new Set(
-        useSelectionStore
-          .getState()
-          .selectedItems.flatMap((item) =>
-            item.type === "terminal" ? [item.terminalId] : [],
-          ),
-      );
-      if (
-        selectedTerminalIds.size < 2 ||
-        !selectedTerminalIds.has(node.data.terminalId)
-      ) {
-        multiDragStartsRef.current.clear();
-        return;
-      }
-      const starts = new Map<string, { x: number; y: number }>();
-      for (const candidate of nodes) {
-        if (candidate.type !== "terminal") continue;
-        if (selectedTerminalIds.has(candidate.data.terminalId)) {
-          starts.set(candidate.data.terminalId, {
-            x: candidate.position.x,
-            y: candidate.position.y,
-          });
-        }
-      }
-      multiDragStartsRef.current = starts;
-    },
-    [nodes],
-  );
-
-  const handleNodeDrag = useCallback<OnNodeDrag<CanvasFlowNode>>(
-    (_event, node) => {
-      const starts = multiDragStartsRef.current;
-      if (starts.size < 2) return;
-      const myStart = starts.get(node.data.terminalId);
-      if (!myStart) return;
-      const dx = node.position.x - myStart.x;
-      const dy = node.position.y - myStart.y;
-      setNodes((current) =>
-        current.map((candidate) => {
-          if (candidate.type !== "terminal") return candidate;
-          if (candidate.data.terminalId === node.data.terminalId) {
-            return candidate;
-          }
-          const start = starts.get(candidate.data.terminalId);
-          if (!start) return candidate;
-          return {
-            ...candidate,
-            position: { x: start.x + dx, y: start.y + dy },
-          };
-        }),
-      );
-    },
-    [setNodes],
-  );
+  const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(() => {
+    // No-op in flat canvas — no bringToFront needed
+  }, []);
 
   const handleNodeDragStop = useCallback<OnNodeDrag<CanvasFlowNode>>(
     (_event, node) => {
+      // Write terminal position back to store
       const { projectId, worktreeId, terminalId } = node.data;
       const snappedX =
         Math.round(node.position.x / SNAP_GRID[0]) * SNAP_GRID[0];
       const snappedY =
         Math.round(node.position.y / SNAP_GRID[1]) * SNAP_GRID[1];
-
-      const starts = multiDragStartsRef.current;
-      if (starts.size >= 2) {
-        // Multi-drag commit. Use the dragged node's delta as the
-        // group's translation vector — every selected terminal moves
-        // by the same (snapped) offset. We deliberately skip
-        // collision resolution here: shoving the group's neighbours
-        // around mid-translation defeats the user's intent of
-        // arranging the picked set as a unit.
-        const myStart = starts.get(terminalId);
-        if (myStart) {
-          const dx = snappedX - myStart.x;
-          const dy = snappedY - myStart.y;
-          const allProjects = useProjectStore.getState().projects;
-          const updatePos = useProjectStore.getState().updateTerminalPosition;
-          for (const [movedId, start] of starts.entries()) {
-            const finalX =
-              Math.round((start.x + dx) / SNAP_GRID[0]) * SNAP_GRID[0];
-            const finalY =
-              Math.round((start.y + dy) / SNAP_GRID[1]) * SNAP_GRID[1];
-            for (const p of allProjects) {
-              for (const w of p.worktrees) {
-                if (w.terminals.some((term) => term.id === movedId)) {
-                  updatePos(p.id, w.id, movedId, finalX, finalY);
-                }
-              }
-            }
-          }
-        }
-        multiDragStartsRef.current.clear();
-        return;
-      }
-
-      // Single-drag path (unchanged behaviour).
       useProjectStore
         .getState()
         .updateTerminalPosition(
@@ -562,6 +465,7 @@ function XyFlowCanvasInner() {
           snappedY,
         );
 
+      // Resolve collisions after drag
       const allProjects = useProjectStore.getState().projects;
       const allRects = allProjects.flatMap((p) =>
         p.worktrees.flatMap((w) =>
@@ -740,7 +644,6 @@ function XyFlowCanvasInner() {
         onPaneContextMenu={handlePaneContextMenu}
         onNodeClick={handleNodeClick}
         onNodeDragStart={handleNodeDragStart}
-        onNodeDrag={handleNodeDrag}
         onNodeDragStop={handleNodeDragStop}
         nodesConnectable={false}
         nodesDraggable={!isPanMode}

--- a/src/canvas/XyFlowCanvas.tsx
+++ b/src/canvas/XyFlowCanvas.tsx
@@ -21,6 +21,7 @@ import { useProjectStore } from "../stores/projectStore";
 import { useCanvasStore } from "../stores/canvasStore";
 import { useTaskStore } from "../stores/taskStore";
 import { useDrawingStore } from "../stores/drawingStore";
+import { useCanvasToolStore } from "../stores/canvasToolStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import { useSidebarDragStore } from "../stores/sidebarDragStore";
 import {
@@ -300,6 +301,8 @@ function XyFlowCanvasInner() {
   const petEnabled = usePreferencesStore((state) => state.petEnabled);
   const animationBlur = usePreferencesStore((state) => state.animationBlur);
   const drawingTool = useDrawingStore((state) => state.tool);
+  const canvasTool = useCanvasToolStore((state) => state.tool);
+  const spaceHeld = useCanvasToolStore((state) => state.spaceHeld);
   const { handleMouseDown: handleBoxSelectMouseDown } = useBoxSelect();
   const layoutKey = useMemo(() => buildLayoutKey(projects), [projects]);
   const leftOffset = getCanvasLeftInset(
@@ -309,6 +312,8 @@ function XyFlowCanvasInner() {
   );
   const sidebarDragging = useSidebarDragStore((s) => s.active);
   const isDrawing = drawingEnabled && drawingTool !== "select";
+  const isPanMode = canvasTool === "hand" || spaceHeld;
+  const [isPanning, setIsPanning] = useState(false);
   const previousAnimatingRef = useRef(isAnimating);
   const canvasContainerRef = useRef<HTMLDivElement>(null);
   useTrackpadSwipeFocus(canvasContainerRef);
@@ -428,11 +433,14 @@ function XyFlowCanvasInner() {
 
   const handleNodeClick = useCallback<NodeMouseHandler<CanvasFlowNode>>(
     (_event, node) => {
-      // In flat canvas, clicking a terminal node activates its project/worktree
+      // In hand-tool / space-pan mode, a click is the tail of a pan
+      // gesture (or a no-op tap). Don't activate the worktree —
+      // matches Figma where the hand tool never selects.
+      if (isPanMode) return;
       const { projectId, worktreeId } = node.data;
       useProjectStore.getState().setFocusedWorktree(projectId, worktreeId);
     },
-    [],
+    [isPanMode],
   );
 
   const handleNodeDragStart = useCallback<OnNodeDrag<CanvasFlowNode>>(() => {
@@ -523,6 +531,11 @@ function XyFlowCanvasInner() {
 
   const handleWheelCapture = useCallback(
     (event: React.WheelEvent<HTMLDivElement>) => {
+      // Two distinct gestures land here:
+      //   1. Cmd/Ctrl + wheel — explicit zoom intent.
+      //   2. Trackpad pinch — Chromium synthesises wheel events with
+      //      ctrlKey=true even though no key is pressed. Same code path
+      //      handles both, anchored at the cursor position.
       if (!(event.ctrlKey || event.metaKey)) {
         return;
       }
@@ -556,17 +569,46 @@ function XyFlowCanvasInner() {
     [leftPanelCollapsed, leftPanelWidth, taskDrawerOpen, viewport],
   );
 
+  const handleContainerMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (isPanMode && event.button === 0) {
+        setIsPanning(true);
+      }
+      handleBoxSelectMouseDown(event);
+    },
+    [handleBoxSelectMouseDown, isPanMode],
+  );
+
+  useEffect(() => {
+    if (!isPanning) return;
+    const stop = () => setIsPanning(false);
+    window.addEventListener("mouseup", stop);
+    window.addEventListener("blur", stop);
+    return () => {
+      window.removeEventListener("mouseup", stop);
+      window.removeEventListener("blur", stop);
+    };
+  }, [isPanning]);
+
+  const cursorClass = isDrawing
+    ? "cursor-crosshair"
+    : isPanMode
+      ? isPanning
+        ? "cursor-grabbing"
+        : "cursor-grab"
+      : "";
+
   return (
     <div
       ref={canvasContainerRef}
-      className={`fixed top-0 right-0 bottom-0 overflow-hidden canvas-bg ${isDrawing ? "cursor-crosshair" : ""}`}
+      className={`fixed top-0 right-0 bottom-0 overflow-hidden canvas-bg ${cursorClass}`}
       style={{
         left: leftOffset,
         transition: sidebarDragging
           ? undefined
           : `left ${PANEL_TRANSITION_DURATION_MS}ms ${PANEL_TRANSITION_EASING_CSS}`,
       }}
-      onMouseDownCapture={handleBoxSelectMouseDown}
+      onMouseDownCapture={handleContainerMouseDown}
       onWheelCapture={handleWheelCapture}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
@@ -604,6 +646,7 @@ function XyFlowCanvasInner() {
         onNodeDragStart={handleNodeDragStart}
         onNodeDragStop={handleNodeDragStop}
         nodesConnectable={false}
+        nodesDraggable={!isPanMode}
         nodesFocusable={false}
         edgesFocusable={false}
         elementsSelectable={false}

--- a/src/canvas/zoomActions.ts
+++ b/src/canvas/zoomActions.ts
@@ -1,0 +1,102 @@
+import { useCanvasStore } from "../stores/canvasStore";
+import { useProjectStore } from "../stores/projectStore";
+import { TOOLBAR_HEIGHT } from "../toolbar/toolbarHeight";
+import {
+  getCanvasLeftInset,
+  getCanvasRightInset,
+} from "./viewportBounds";
+import {
+  clampScale,
+  getNextZoomStep,
+  getViewportCenterClientPoint,
+  zoomAtClientPoint,
+} from "./viewportZoom";
+
+const FIT_PADDING = 80;
+
+function getCanvasInsets() {
+  const {
+    leftPanelCollapsed,
+    leftPanelWidth,
+    rightPanelCollapsed,
+    rightPanelWidth,
+  } = useCanvasStore.getState();
+  return {
+    leftPanelCollapsed,
+    leftPanelWidth,
+    rightPanelCollapsed,
+    rightPanelWidth,
+  };
+}
+
+export function fitAllProjects(): void {
+  const { projects } = useProjectStore.getState();
+  if (projects.length === 0) return;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const project of projects) {
+    for (const wt of project.worktrees) {
+      for (const term of wt.terminals) {
+        if (term.stashed) continue;
+        minX = Math.min(minX, term.x);
+        minY = Math.min(minY, term.y);
+        maxX = Math.max(maxX, term.x + term.width);
+        maxY = Math.max(maxY, term.y + term.height);
+      }
+    }
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) return;
+
+  const contentW = maxX - minX;
+  const contentH = maxY - minY;
+  const insets = getCanvasInsets();
+  const leftOffset = getCanvasLeftInset(
+    insets.leftPanelCollapsed,
+    insets.leftPanelWidth,
+  );
+  const rightOffset = getCanvasRightInset(
+    insets.rightPanelCollapsed,
+    insets.rightPanelWidth,
+  );
+  const viewW = window.innerWidth - leftOffset - rightOffset - FIT_PADDING * 2;
+  const viewH = window.innerHeight - TOOLBAR_HEIGHT - FIT_PADDING * 2;
+  const scale = clampScale(Math.min(1, viewW / contentW, viewH / contentH));
+  const x = -minX * scale + FIT_PADDING;
+  const y = -minY * scale + FIT_PADDING + TOOLBAR_HEIGHT;
+  useCanvasStore.getState().setViewport({ x, y, scale });
+}
+
+export function setZoomToHundred(): void {
+  zoomAroundCenter(1);
+}
+
+export function stepZoomAtCenter(direction: "in" | "out"): void {
+  const viewport = useCanvasStore.getState().viewport;
+  const nextScale = getNextZoomStep(viewport.scale, direction);
+  zoomAroundCenter(nextScale);
+}
+
+function zoomAroundCenter(nextScale: number): void {
+  const insets = getCanvasInsets();
+  const center = getViewportCenterClientPoint({
+    leftPanelCollapsed: insets.leftPanelCollapsed,
+    leftPanelWidth: insets.leftPanelWidth,
+    rightPanelCollapsed: insets.rightPanelCollapsed,
+    rightPanelWidth: insets.rightPanelWidth,
+    topInset: TOOLBAR_HEIGHT,
+  });
+  const viewport = useCanvasStore.getState().viewport;
+  useCanvasStore.getState().setViewport(
+    zoomAtClientPoint({
+      clientX: center.x,
+      clientY: center.y,
+      leftPanelCollapsed: insets.leftPanelCollapsed,
+      leftPanelWidth: insets.leftPanelWidth,
+      nextScale: clampScale(nextScale),
+      viewport,
+    }),
+  );
+}

--- a/src/canvas/zoomActions.ts
+++ b/src/canvas/zoomActions.ts
@@ -1,5 +1,6 @@
 import { useCanvasStore } from "../stores/canvasStore";
 import { useProjectStore } from "../stores/projectStore";
+import { useTaskStore } from "../stores/taskStore";
 import { TOOLBAR_HEIGHT } from "../toolbar/toolbarHeight";
 import {
   getCanvasLeftInset,
@@ -21,11 +22,14 @@ function getCanvasInsets() {
     rightPanelCollapsed,
     rightPanelWidth,
   } = useCanvasStore.getState();
+  const taskDrawerOpen =
+    useTaskStore.getState().openProjectPath !== null;
   return {
     leftPanelCollapsed,
     leftPanelWidth,
     rightPanelCollapsed,
     rightPanelWidth,
+    taskDrawerOpen,
   };
 }
 
@@ -56,6 +60,7 @@ export function fitAllProjects(): void {
   const leftOffset = getCanvasLeftInset(
     insets.leftPanelCollapsed,
     insets.leftPanelWidth,
+    insets.taskDrawerOpen,
   );
   const rightOffset = getCanvasRightInset(
     insets.rightPanelCollapsed,
@@ -63,6 +68,14 @@ export function fitAllProjects(): void {
   );
   const viewW = window.innerWidth - leftOffset - rightOffset - FIT_PADDING * 2;
   const viewH = window.innerHeight - TOOLBAR_HEIGHT - FIT_PADDING * 2;
+  // Bail if the geometry is degenerate. With a tiny window
+  // (narrower than the padding) viewW / viewH go non-positive; with
+  // zero-sized content (a single terminal that hasn't been laid out
+  // yet) contentW / contentH do. Either case feeds NaN / -Infinity
+  // into the scale calc and lands the viewport off-screen.
+  if (contentW <= 0 || contentH <= 0 || viewW <= 0 || viewH <= 0) {
+    return;
+  }
   const scale = clampScale(Math.min(1, viewW / contentW, viewH / contentH));
   const x = -minX * scale + FIT_PADDING;
   const y = -minY * scale + FIT_PADDING + TOOLBAR_HEIGHT;
@@ -86,6 +99,7 @@ function zoomAroundCenter(nextScale: number): void {
     leftPanelWidth: insets.leftPanelWidth,
     rightPanelCollapsed: insets.rightPanelCollapsed,
     rightPanelWidth: insets.rightPanelWidth,
+    taskDrawerOpen: insets.taskDrawerOpen,
     topInset: TOOLBAR_HEIGHT,
   });
   const viewport = useCanvasStore.getState().viewport;
@@ -95,6 +109,7 @@ function zoomAroundCenter(nextScale: number): void {
       clientY: center.y,
       leftPanelCollapsed: insets.leftPanelCollapsed,
       leftPanelWidth: insets.leftPanelWidth,
+      taskDrawerOpen: insets.taskDrawerOpen,
       nextScale: clampScale(nextScale),
       viewport,
     }),

--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -108,6 +108,7 @@ function getPassthroughSequence(
 export function ComposerBar() {
   const t = useT();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const { notify } = useNotificationStore();
   const {
     draft,
@@ -238,6 +239,27 @@ export function ComposerBar() {
     const handleFocusComposer = () => requestAnimationFrame(() => textareaRef.current?.focus());
     window.addEventListener("termcanvas:focus-composer", handleFocusComposer);
     return () => window.removeEventListener("termcanvas:focus-composer", handleFocusComposer);
+  }, []);
+
+  // Publish the composer's measured height so the floating BottomToolbar
+  // can sit just above it. Without this it ends up obscured the moment
+  // the user adds a second line, image, or rename row.
+  useEffect(() => {
+    const node = wrapperRef.current;
+    if (!node) return;
+    const root = document.documentElement;
+    const publish = (height: number) => {
+      root.style.setProperty("--composer-height", `${Math.round(height)}px`);
+    };
+    publish(node.getBoundingClientRect().height);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) publish(entry.contentRect.height);
+    });
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty("--composer-height");
+    };
   }, []);
 
   const handleImagePaste = useCallback(
@@ -516,11 +538,12 @@ export function ComposerBar() {
 
   return (
     <div
+      ref={wrapperRef}
       className="fixed bottom-4 z-[90] pointer-events-none flex justify-center px-4"
       style={{ left: composerLeft, right: composerRight }}
     >
       <div
-        className={`pointer-events-auto w-full max-w-4xl rounded-xl border bg-[var(--surface)] shadow-[0_18px_48px_rgba(0,0,0,0.24)] transition-colors duration-150 ${
+        className={`pointer-events-auto w-full max-w-4xl rounded-xl border bg-[var(--surface)] shadow-[0_18px_48px_-12px_color-mix(in_srgb,var(--shadow-color)_36%,transparent)] transition-colors duration-150 ${
           isDragOver
             ? "border-[var(--accent)] bg-[var(--accent)]/5"
             : "border-[var(--border)]"

--- a/src/hooks/shortcutTarget.ts
+++ b/src/hooks/shortcutTarget.ts
@@ -1,4 +1,4 @@
-function isEditableTarget(target: EventTarget | null): boolean {
+export function isEditableTarget(target: EventTarget | null): boolean {
   const element = target as HTMLElement | null;
   if (!element) return false;
   const tag = element.tagName?.toLowerCase();
@@ -7,6 +7,16 @@ function isEditableTarget(target: EventTarget | null): boolean {
     tag === "input" ||
     tag === "select" ||
     element.isContentEditable
+  );
+}
+
+// Elements that natively activate on Space / Enter. Stealing these
+// keys for app shortcuts would silently break keyboard operation of
+// the focused control.
+export function isActivationTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return target.matches(
+    'button, a[href], [role="button"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="checkbox"], [role="radio"], [role="tab"], [role="switch"]',
   );
 }
 

--- a/src/hooks/useBoxSelect.ts
+++ b/src/hooks/useBoxSelect.ts
@@ -19,6 +19,7 @@ import {
   resolveAllCardPositions,
 } from "../stores/cardLayoutStore";
 import { useDrawingStore } from "../stores/drawingStore";
+import { useCanvasToolStore } from "../stores/canvasToolStore";
 import { type SelectedItem } from "../stores/selectionStore";
 import { screenPointToCanvasPoint } from "../canvas/viewportBounds";
 
@@ -149,6 +150,13 @@ export function useBoxSelect() {
 
     // Don't activate in drawing mode
     if (useDrawingStore.getState().tool !== "select") return;
+    // Hand tool / Space-held panning takes precedence over marquee.
+    if (
+      useCanvasToolStore.getState().tool === "hand" ||
+      useCanvasToolStore.getState().spaceHeld
+    ) {
+      return;
+    }
 
     e.preventDefault();
     e.stopPropagation();

--- a/src/hooks/useBoxSelect.ts
+++ b/src/hooks/useBoxSelect.ts
@@ -145,7 +145,7 @@ export function activateSingleBoxSelectionItem(item: SelectedItem): void {
 
 export function useBoxSelect() {
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if (e.button !== 0 || !e.shiftKey) return;
+    if (e.button !== 0) return;
     if (shouldIgnoreBoxSelectTarget(e.target)) return;
 
     // Don't activate in drawing mode
@@ -154,6 +154,19 @@ export function useBoxSelect() {
     if (
       useCanvasToolStore.getState().tool === "hand" ||
       useCanvasToolStore.getState().spaceHeld
+    ) {
+      return;
+    }
+
+    // If the press starts on a node, hand the gesture to React Flow so
+    // a plain drag moves the terminal (Move-tool semantics in Figma).
+    // Shift+drag still falls through to marquee for the "add to
+    // selection" gesture.
+    const target = e.target;
+    if (
+      target instanceof Element &&
+      target.closest(".react-flow__node") &&
+      !e.shiftKey
     ) {
       return;
     }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,12 @@ import {
   ensureTerminalCreationTarget,
 } from "../projects/projectCreation";
 import { useCanvasStore } from "../stores/canvasStore";
+import { useCanvasToolStore } from "../stores/canvasToolStore";
+import {
+  fitAllProjects,
+  setZoomToHundred,
+  stepZoomAtCenter,
+} from "../canvas/zoomActions";
 import { useNotificationStore } from "../stores/notificationStore";
 import { promptAndAddProjectToScene } from "../canvas/sceneCommands";
 import { useShortcutStore, matchesShortcut } from "../stores/shortcutStore";
@@ -297,8 +303,75 @@ export function useKeyboardShortcuts() {
         return;
       }
 
+      // Figma-style canvas zoom: Cmd+0 fit, Cmd+1 100%, Cmd+= / Cmd+-
+      // step. Allowed before shouldIgnoreShortcutTarget because the
+      // primary modifier means terminal text input never produces these.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        if (e.key === "0") {
+          consumeShortcut();
+          fitAllProjects();
+          return;
+        }
+        if (e.key === "1" && !e.shiftKey) {
+          consumeShortcut();
+          setZoomToHundred();
+          return;
+        }
+        // Browsers map Cmd++ → Cmd+= and Cmd+- to zoom; we override.
+        if (e.key === "=" || e.key === "+") {
+          consumeShortcut();
+          stepZoomAtCenter("in");
+          return;
+        }
+        if (e.key === "-" || e.key === "_") {
+          consumeShortcut();
+          stepZoomAtCenter("out");
+          return;
+        }
+      }
+
       if (shouldIgnoreShortcutTarget(e)) {
         return;
+      }
+
+      // Shift+1 → fit all (Figma "fit content"). After
+      // shouldIgnoreShortcutTarget so it can't hijack "!" in editable
+      // fields.
+      if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.key === "!") {
+        consumeShortcut();
+        fitAllProjects();
+        return;
+      }
+
+      // V / H — switch canvas tool. No modifiers; fall through if any
+      // modifier is held so things like Cmd+H (hide on macOS) survive.
+      if (
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey &&
+        !e.repeat
+      ) {
+        const key = e.key.toLowerCase();
+        if (key === "v") {
+          consumeShortcut();
+          useCanvasToolStore.getState().setTool("select");
+          return;
+        }
+        if (key === "h") {
+          consumeShortcut();
+          useCanvasToolStore.getState().setTool("hand");
+          return;
+        }
+        // Space hold → temporary hand. Repeat events are filtered above
+        // so the keydown only fires once until release.
+        if (e.code === "Space") {
+          if (!useCanvasToolStore.getState().spaceHeld) {
+            useCanvasToolStore.getState().setSpaceHeld(true);
+          }
+          e.preventDefault();
+          return;
+        }
       }
 
       if (
@@ -614,7 +687,29 @@ export function useKeyboardShortcuts() {
       }
     };
 
+    // Release temp-pan when Space lifts. Listening on keyup directly
+    // (rather than threading through `handler`) keeps the release path
+    // independent of focus checks — if focus shifted into an editable
+    // field mid-hold, we still want the panning state to clear.
+    const releaseSpacePan = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      if (useCanvasToolStore.getState().spaceHeld) {
+        useCanvasToolStore.getState().setSpaceHeld(false);
+      }
+    };
+    const releaseOnBlur = () => {
+      if (useCanvasToolStore.getState().spaceHeld) {
+        useCanvasToolStore.getState().setSpaceHeld(false);
+      }
+    };
+
     window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
+    window.addEventListener("keyup", releaseSpacePan, true);
+    window.addEventListener("blur", releaseOnBlur);
+    return () => {
+      window.removeEventListener("keydown", handler, true);
+      window.removeEventListener("keyup", releaseSpacePan, true);
+      window.removeEventListener("blur", releaseOnBlur);
+    };
   }, [shortcuts, t]);
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -343,7 +343,7 @@ export function useKeyboardShortcuts() {
       // Shift+1 → fit all (Figma "fit content"). After
       // shouldIgnoreShortcutTarget so it can't hijack "!" in editable
       // fields.
-      if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.key === "!") {
+      if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.code === "Digit1") {
         consumeShortcut();
         fitAllProjects();
         return;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -38,7 +38,11 @@ import {
   getWorktreeFocusOrder,
 } from "../stores/projectFocus";
 import { pickCloseFocusTarget } from "../canvas/closeFocusTarget";
-import { shouldIgnoreShortcutTarget } from "./shortcutTarget";
+import {
+  isActivationTarget,
+  isEditableTarget,
+  shouldIgnoreShortcutTarget,
+} from "./shortcutTarget";
 import { snapshotStateWithRefresh } from "../snapshotState";
 import { updateWindowTitle } from "../titleHelper";
 import { panToTerminal } from "../utils/panToTerminal";
@@ -304,9 +308,11 @@ export function useKeyboardShortcuts() {
       }
 
       // Figma-style canvas zoom: Cmd+0 fit, Cmd+1 100%, Cmd+= / Cmd+-
-      // step. Allowed before shouldIgnoreShortcutTarget because the
-      // primary modifier means terminal text input never produces these.
-      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+      // step. Skip when focus is in an editable target so Monaco /
+      // textareas / inputs keep their own Cmd+0/=/- semantics —
+      // shouldIgnoreShortcutTarget alone doesn't gate these because
+      // the modifier flips its check off.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !isEditableTarget(e.target)) {
         if (e.key === "0") {
           consumeShortcut();
           fitAllProjects();
@@ -364,8 +370,14 @@ export function useKeyboardShortcuts() {
           return;
         }
         // Space hold → temporary hand. Repeat events are filtered above
-        // so the keydown only fires once until release.
+        // so the keydown only fires once until release. Skip when the
+        // focused control natively activates on Space (button, menu
+        // item, checkbox …) — preempting that breaks keyboard
+        // operation of the toolbar itself.
         if (e.code === "Space") {
+          if (isActivationTarget(e.target)) {
+            return;
+          }
           if (!useCanvasToolStore.getState().spaceHeld) {
             useCanvasToolStore.getState().setSpaceHeld(true);
           }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -263,6 +263,9 @@ export const en = {
   toolbar_untitled_workspace: "Untitled Workspace",
   zoom_out: "Zoom out",
   zoom_in: "Zoom in",
+  canvas_tool_select: "Move",
+  canvas_tool_hand: "Hand",
+  canvas_zoom_to: "Zoom to",
 
   shortcut_add_project: "Add project folder…",
   shortcut_cycle_focus_level: "Cycle focus level",

--- a/src/i18n/useT.ts
+++ b/src/i18n/useT.ts
@@ -1,10 +1,28 @@
+import { useMemo } from "react";
 import { useLocaleStore } from "../stores/localeStore";
 import { en } from "./en";
 import { zh } from "./zh";
 
 const dictionaries = { en, zh } as const;
+type Locale = keyof typeof dictionaries;
+type Dict = typeof en;
 
-export function useT() {
+// Cache the merged dictionary per locale so `useT()` returns a stable
+// reference across renders. Without this, every consumer that puts `t`
+// in a useEffect / useCallback / useMemo dep array re-runs on every
+// parent render — most visibly in useKeyboardShortcuts, which
+// otherwise tears down and re-attaches three capture-phase window
+// listeners on every viewport tick.
+const mergedCache = new Map<Locale, Dict>();
+function getMerged(locale: Locale): Dict {
+  const cached = mergedCache.get(locale);
+  if (cached) return cached;
+  const merged = { ...en, ...dictionaries[locale] } as Dict;
+  mergedCache.set(locale, merged);
+  return merged;
+}
+
+export function useT(): Dict {
   const locale = useLocaleStore((s) => s.locale);
-  return { ...en, ...dictionaries[locale] };
+  return useMemo(() => getMerged(locale), [locale]);
 }

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -257,6 +257,9 @@ export const zh = {
   toolbar_untitled_workspace: "未命名工作区",
   zoom_out: "缩小",
   zoom_in: "放大",
+  canvas_tool_select: "移动",
+  canvas_tool_hand: "抓手",
+  canvas_zoom_to: "缩放至",
 
   shortcut_add_project: "添加项目目录…",
   shortcut_cycle_focus_level: "切换聚焦层级",

--- a/src/index.css
+++ b/src/index.css
@@ -409,6 +409,29 @@ body {
   cursor: pointer !important;
 }
 
+/* Pan mode overrides the terminal's text cursor. The above
+   `cursor: text !important` rule still wins over the canvas
+   container's Tailwind cursor whenever the pointer is inside a
+   terminal tile, so without this block the user sees a text I-beam
+   while in Hand mode (or holding Space). XyFlowCanvas toggles these
+   body classes based on (isPanMode, isPanning). The `pan-grabbing`
+   rule comes after `pan-mode` so it wins while a drag is in-flight. */
+body.tc-canvas-pan-mode .tc-xterm-host,
+body.tc-canvas-pan-mode .terminal-tile .xterm,
+body.tc-canvas-pan-mode .terminal-tile .xterm .xterm-viewport,
+body.tc-canvas-pan-mode .terminal-tile .xterm .xterm-screen,
+body.tc-canvas-pan-mode .terminal-tile .xterm .xterm-scrollable-element {
+  cursor: grab !important;
+}
+
+body.tc-canvas-pan-grabbing .tc-xterm-host,
+body.tc-canvas-pan-grabbing .terminal-tile .xterm,
+body.tc-canvas-pan-grabbing .terminal-tile .xterm .xterm-viewport,
+body.tc-canvas-pan-grabbing .terminal-tile .xterm .xterm-screen,
+body.tc-canvas-pan-grabbing .terminal-tile .xterm .xterm-scrollable-element {
+  cursor: grabbing !important;
+}
+
 /* xterm v6 scroll shadows sit at z-index 11 along the top and left edges
    of the scrollable element.  They intercept mouse events in the top-left
    area of the terminal, preventing text selection from starting there.

--- a/src/index.css
+++ b/src/index.css
@@ -75,6 +75,11 @@
      under one --bubble-bg name lets the component reference the
      semantic role, not whichever neutral happens to land near it. */
   --bubble-bg: #2a2928;
+  /* Cast colour for floating-UI shadows. Warm near-black so it lands
+     in the same hue family as the dark neutrals (#1a1918 / #222120)
+     instead of looking ashy. Components compose translucency on top
+     via color-mix(); never used at full opacity. */
+  --shadow-color: #0a0908;
   --radius: 8px;
   color-scheme: dark;
 }
@@ -109,6 +114,10 @@
      cooler than --surface (#f3f2ef) and reads as "soft container" on
      the cream-paper light background. */
   --bubble-bg: #F3F3F4;
+  /* See dark-theme block. Warm dark grey (close to text-primary)
+     keeps shadows in the same hue family as the light neutrals so
+     they read as "soft depth" rather than "hard cutout". */
+  --shadow-color: #1c1917;
   --radius: 8px;
   color-scheme: light;
 }

--- a/src/stores/canvasToolStore.ts
+++ b/src/stores/canvasToolStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+export type CanvasTool = "select" | "hand";
+
+interface CanvasToolStore {
+  tool: CanvasTool;
+  /**
+   * True while the user is holding Space to temporarily pan. The active
+   * tool stays "select" — only the cursor and pan behavior shift, so
+   * releasing Space restores the previous mode without further state.
+   */
+  spaceHeld: boolean;
+  setTool: (tool: CanvasTool) => void;
+  setSpaceHeld: (held: boolean) => void;
+}
+
+export const useCanvasToolStore = create<CanvasToolStore>((set) => ({
+  tool: "select",
+  spaceHeld: false,
+  setTool: (tool) => set({ tool }),
+  setSpaceHeld: (held) => set({ spaceHeld: held }),
+}));
+
+export function isPanModeActive(state = useCanvasToolStore.getState()): boolean {
+  return state.tool === "hand" || state.spaceHeld;
+}

--- a/src/stores/canvasToolStore.ts
+++ b/src/stores/canvasToolStore.ts
@@ -14,8 +14,13 @@ interface CanvasToolStore {
   setSpaceHeld: (held: boolean) => void;
 }
 
+// Default to Hand. Move is still reachable via the toolbar dropdown
+// (or the V shortcut) for users who want marquee box-select, but the
+// tool's payoff didn't justify making it the entry experience —
+// most canvas sessions are pan + zoom + click-into-a-terminal, which
+// Hand serves directly.
 export const useCanvasToolStore = create<CanvasToolStore>((set) => ({
-  tool: "select",
+  tool: "hand",
   spaceHeld: false,
   setTool: (tool) => set({ tool }),
   setSpaceHeld: (held) => set({ spaceHeld: held }),

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -14,7 +14,6 @@ import {
   findTerminalById,
   getChildTerminals,
 } from "../stores/projectStore";
-import { useSelectionStore } from "../stores/selectionStore";
 import { ContextMenu } from "../components/ContextMenu";
 import { TagManager } from "./TagManager";
 import { usePreferencesStore } from "../stores/preferencesStore";
@@ -308,12 +307,6 @@ export function TerminalTile({
       customTitleInputRef.current?.select();
     });
   }, [isEditingCustomTitle]);
-
-  const isSelected = useSelectionStore((s) =>
-    s.selectedItems.some(
-      (item) => item.type === "terminal" && item.terminalId === terminal.id,
-    ),
-  );
 
   useEffect(() => {
     // Skip the initial mount — only show the toast when the nonce actually

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -934,19 +934,8 @@ export function TerminalTile({
           !dragOver && !taskFlash && terminal.focused
             ? "var(--border-hover)"
             : undefined,
-        // Multi-select ring. Routed through `outline` so it stacks
-        // cleanly with the existing focus / drag boxShadow chain. Sits
-        // 2 px off the tile edge so it reads as "I picked this one"
-        // rather than "this is hovered". Suppressed during the
-        // dragOver / taskFlash treatments above — those already
-        // own the perimeter with their own accent ring and a stacked
-        // selection outline next to them looks like noise.
-        outline:
-          isSelected && !dragOver && !taskFlash
-            ? "1.5px solid color-mix(in srgb, var(--accent) 65%, transparent)"
-            : "none",
-        outlineOffset: isSelected && !dragOver && !taskFlash ? 2 : 0,
-        transition: "box-shadow 150ms ease, outline-color 150ms ease",
+        outline: "none",
+        transition: "box-shadow 150ms ease",
       }}
       onClick={(e) => {
         e.stopPropagation();

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -934,8 +934,19 @@ export function TerminalTile({
           !dragOver && !taskFlash && terminal.focused
             ? "var(--border-hover)"
             : undefined,
-        outline: "none",
-        transition: "box-shadow 150ms ease",
+        // Multi-select ring. Routed through `outline` so it stacks
+        // cleanly with the existing focus / drag boxShadow chain. Sits
+        // 2 px off the tile edge so it reads as "I picked this one"
+        // rather than "this is hovered". Suppressed during the
+        // dragOver / taskFlash treatments above — those already
+        // own the perimeter with their own accent ring and a stacked
+        // selection outline next to them looks like noise.
+        outline:
+          isSelected && !dragOver && !taskFlash
+            ? "1.5px solid color-mix(in srgb, var(--accent) 65%, transparent)"
+            : "none",
+        outlineOffset: isSelected && !dragOver && !taskFlash ? 2 : 0,
+        transition: "box-shadow 150ms ease, outline-color 150ms ease",
       }}
       onClick={(e) => {
         e.stopPropagation();

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -49,7 +49,7 @@ const buttonBase =
   "inline-flex h-8 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_srgb,var(--text-secondary)_24%,transparent)] motion-reduce:transition-none";
 const iconButton = `${buttonBase} w-8`;
 const zoomReadout =
-  "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-faint)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
+  "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-muted)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
 
 const platform = window.termcanvas?.app.platform ?? "darwin";
 const isMac = platform === "darwin";
@@ -78,15 +78,23 @@ function useCloseOnOutsideClick(
   open: boolean,
   ref: React.RefObject<HTMLElement | null>,
   close: () => void,
+  triggerRef?: React.RefObject<HTMLElement | null>,
 ): void {
   useEffect(() => {
     if (!open) return;
     const handle = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) close();
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        close();
+        // Match the focus contract that Esc / item-activation already
+        // honour: outside-click should also leave focus on the trigger
+        // so a keyboard user who opened the menu and then mouse-
+        // clicked elsewhere isn't stranded on `<body>`.
+        triggerRef?.current?.focus();
+      }
     };
     window.addEventListener("mousedown", handle);
     return () => window.removeEventListener("mousedown", handle);
-  }, [open, ref, close]);
+  }, [open, ref, close, triggerRef]);
 }
 
 // Roving-focus keyboard nav for popover menus. Caller passes a ref to
@@ -159,8 +167,13 @@ export function BottomToolbar() {
   const viewport = useCanvasStore((s) => s.viewport);
   const composerEnabled = usePreferencesStore((s) => s.composerEnabled);
 
-  const [toolMenuOpen, setToolMenuOpen] = useState(false);
-  const [presetOpen, setPresetOpen] = useState(false);
+  // Single open-menu slot so the two popovers are mutually exclusive —
+  // opening the zoom menu while the tool menu is open used to leave
+  // both visible, with both rendering their own keydown listener and
+  // ArrowDown / Esc bouncing focus between them.
+  const [openMenu, setOpenMenu] = useState<"tool" | "preset" | null>(null);
+  const toolMenuOpen = openMenu === "tool";
+  const presetOpen = openMenu === "preset";
   const toolMenuWrapperRef = useRef<HTMLDivElement>(null);
   const toolMenuPopoverRef = useRef<HTMLDivElement>(null);
   const toolTriggerRef = useRef<HTMLButtonElement>(null);
@@ -168,11 +181,29 @@ export function BottomToolbar() {
   const presetPopoverRef = useRef<HTMLDivElement>(null);
   const presetTriggerRef = useRef<HTMLButtonElement>(null);
 
-  const closeToolMenu = useCallback(() => setToolMenuOpen(false), []);
-  const closePresetMenu = useCallback(() => setPresetOpen(false), []);
+  const closeToolMenu = useCallback(() => setOpenMenu(null), []);
+  const closePresetMenu = useCallback(() => setOpenMenu(null), []);
+  const toggleToolMenu = useCallback(
+    () => setOpenMenu((prev) => (prev === "tool" ? null : "tool")),
+    [],
+  );
+  const togglePresetMenu = useCallback(
+    () => setOpenMenu((prev) => (prev === "preset" ? null : "preset")),
+    [],
+  );
 
-  useCloseOnOutsideClick(toolMenuOpen, toolMenuWrapperRef, closeToolMenu);
-  useCloseOnOutsideClick(presetOpen, presetWrapperRef, closePresetMenu);
+  useCloseOnOutsideClick(
+    toolMenuOpen,
+    toolMenuWrapperRef,
+    closeToolMenu,
+    toolTriggerRef,
+  );
+  useCloseOnOutsideClick(
+    presetOpen,
+    presetWrapperRef,
+    closePresetMenu,
+    presetTriggerRef,
+  );
 
   const toolOptions = useMemo<
     Array<{
@@ -280,7 +311,7 @@ export function BottomToolbar() {
           <button
             ref={toolTriggerRef}
             className={`${buttonBase} px-2 gap-1`}
-            onClick={() => setToolMenuOpen((open) => !open)}
+            onClick={toggleToolMenu}
             title={`${activeTool.label} (${activeTool.shortcut})`}
             aria-haspopup="menu"
             aria-expanded={toolMenuOpen}
@@ -320,7 +351,7 @@ export function BottomToolbar() {
                       {opt.icon}
                     </span>
                     <span className="flex-1 text-left">{opt.label}</span>
-                    <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                    <span className="text-[10px] font-mono text-[var(--text-muted)]">
                       {opt.shortcut}
                     </span>
                     <span className="w-4 inline-flex items-center justify-center text-[var(--text-primary)]">
@@ -349,7 +380,7 @@ export function BottomToolbar() {
             <button
               ref={presetTriggerRef}
               className={zoomReadout}
-              onClick={() => setPresetOpen((open) => !open)}
+              onClick={togglePresetMenu}
               title={t.canvas_zoom_to}
               aria-haspopup="menu"
               aria-expanded={presetOpen}
@@ -378,7 +409,7 @@ export function BottomToolbar() {
                     }}
                   >
                     <span>{preset.label}</span>
-                    <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                    <span className="text-[10px] font-mono text-[var(--text-muted)]">
                       {preset.hint ?? ""}
                     </span>
                   </button>

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -213,7 +213,7 @@ export function BottomToolbar() {
     open: presetOpen,
     popoverRef: presetPopoverRef,
     triggerRef: presetTriggerRef,
-    // +1 for the Fit row appended after the presets.
+    // +1 for the Reset row appended after the presets.
     itemCount: ZOOM_PRESETS.length + 1,
     close: closePresetMenu,
   });
@@ -286,7 +286,7 @@ export function BottomToolbar() {
               ref={toolMenuPopoverRef}
               role="menu"
               aria-label={t.canvas_tool_select}
-              className={`absolute bottom-full left-0 mb-2 min-w-[160px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
+              className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 min-w-[160px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
             >
               {toolOptions.map((opt) => {
                 const active = opt.id === tool;
@@ -382,14 +382,14 @@ export function BottomToolbar() {
                   tabIndex={-1}
                   className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] focus:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] focus:text-[var(--text-primary)] focus:outline-none"
                   onClick={() => {
-                    fitAllProjects();
+                    useCanvasStore.getState().resetViewport();
                     closePresetMenu();
                     presetTriggerRef.current?.focus();
                   }}
                 >
-                  <span>{t.fit}</span>
+                  <span>{t.reset}</span>
                   <span className="text-[10px] font-mono text-[var(--text-faint)]">
-                    {KEY_HINT.fit}
+                    0,0
                   </span>
                 </button>
               </div>
@@ -449,17 +449,17 @@ function HandIcon() {
 function CaretIcon({ open }: { open: boolean }) {
   return (
     <svg
-      width="8"
-      height="8"
-      viewBox="0 0 8 8"
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
       fill="none"
-      className={`transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+      className={`transition-transform duration-150 opacity-70 ${open ? "rotate-180" : ""}`}
       aria-hidden="true"
     >
       <path
-        d="M1.5 3l2.5 2.5L6.5 3"
+        d="M2 3.75L5 6.75L8 3.75"
         stroke="currentColor"
-        strokeWidth="1.2"
+        strokeWidth="1.4"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -24,17 +24,23 @@ import {
 import { TOOLBAR_HEIGHT } from "./toolbarHeight";
 import { useT } from "../i18n/useT";
 
-// ComposerBar sits at `bottom-4` (16 px) and is roughly 120 px tall;
-// when it's mounted we float above it with an 8 px gap so the pill is
-// never obscured. Drops back to `bottom: 20` when the composer is off.
-const BOTTOM_OFFSET_WITH_COMPOSER = 16 + 120 + 8;
+// ComposerBar sits at `bottom-4` (16 px). Its height varies — single
+// line vs multi-line vs with image attachments vs rename mode — so a
+// hard-coded estimate gets the toolbar covered the moment composer
+// content grows. ComposerBar publishes its measured height to
+// `--composer-height` and we read it here, falling back to a safe
+// default for the brief moment before measurement, and to a smaller
+// constant when composer is disabled entirely.
+const COMPOSER_GAP = 8;
+const COMPOSER_BOTTOM_INSET = 16;
+const COMPOSER_FALLBACK_HEIGHT = 120;
 const BOTTOM_OFFSET_PLAIN = 20;
 
 const PILL_BG =
   "bg-[color-mix(in_srgb,var(--surface)_92%,transparent)] backdrop-blur-md";
 const PILL_BORDER = "border border-[var(--border)]";
 const PILL_SHADOW =
-  "shadow-[0_8px_24px_-12px_color-mix(in_srgb,#000_36%,transparent),0_2px_6px_-2px_color-mix(in_srgb,#000_24%,transparent)]";
+  "shadow-[0_8px_24px_-12px_color-mix(in_srgb,var(--shadow-color)_36%,transparent),0_2px_6px_-2px_color-mix(in_srgb,var(--shadow-color)_24%,transparent)]";
 
 const groupBase = "flex items-center";
 const dividerCls =
@@ -247,14 +253,17 @@ export function BottomToolbar() {
   const activeTool =
     toolOptions.find((opt) => opt.id === tool) ?? toolOptions[0];
 
+  // When composer is enabled, sit just above its measured height
+  // (published as `--composer-height`). The fallback covers the brief
+  // moment between mount and first ResizeObserver tick.
+  const bottomOffset = composerEnabled
+    ? `calc(${COMPOSER_BOTTOM_INSET}px + var(--composer-height, ${COMPOSER_FALLBACK_HEIGHT}px) + ${COMPOSER_GAP}px)`
+    : `${BOTTOM_OFFSET_PLAIN}px`;
+
   return (
     <div
       className="fixed left-1/2 -translate-x-1/2 z-[95] pointer-events-none"
-      style={{
-        bottom: composerEnabled
-          ? BOTTOM_OFFSET_WITH_COMPOSER
-          : BOTTOM_OFFSET_PLAIN,
-      }}
+      style={{ bottom: bottomOffset }}
     >
       <div
         className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useCanvasStore } from "../stores/canvasStore";
+import { useCanvasToolStore } from "../stores/canvasToolStore";
+import {
+  fitAllProjects,
+  setZoomToHundred,
+  stepZoomAtCenter,
+} from "../canvas/zoomActions";
+import {
+  clampScale,
+  getViewportCenterClientPoint,
+  zoomAtClientPoint,
+} from "../canvas/viewportZoom";
+import { TOOLBAR_HEIGHT } from "./toolbarHeight";
+import { useT } from "../i18n/useT";
+
+const PILL_BG =
+  "bg-[color-mix(in_srgb,var(--surface)_92%,transparent)] backdrop-blur-md";
+const PILL_BORDER = "border border-[var(--border)]";
+const PILL_SHADOW =
+  "shadow-[0_8px_24px_-12px_color-mix(in_srgb,#000_36%,transparent),0_2px_6px_-2px_color-mix(in_srgb,#000_24%,transparent)]";
+
+const groupBase = "flex items-center";
+const dividerCls =
+  "h-4 w-px bg-[color-mix(in_srgb,var(--border)_72%,transparent)] mx-0.5";
+const buttonBase =
+  "inline-flex h-8 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_srgb,var(--text-secondary)_24%,transparent)] motion-reduce:transition-none";
+const iconButton = `${buttonBase} w-8`;
+const segmentButton = `${buttonBase} px-2.5 gap-1.5`;
+const segmentActive =
+  "bg-[color-mix(in_srgb,var(--surface)_82%,transparent)] text-[var(--text-primary)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--border)_70%,transparent)]";
+const zoomReadout =
+  "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-faint)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
+
+const ZOOM_PRESETS: Array<{ scale: number; label: string }> = [
+  { scale: 0.5, label: "50%" },
+  { scale: 1, label: "100%" },
+  { scale: 2, label: "200%" },
+];
+
+export function BottomToolbar() {
+  const t = useT();
+  const tool = useCanvasToolStore((s) => s.tool);
+  const setTool = useCanvasToolStore((s) => s.setTool);
+  const viewport = useCanvasStore((s) => s.viewport);
+  const [presetOpen, setPresetOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!presetOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
+        setPresetOpen(false);
+      }
+    };
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [presetOpen]);
+
+  const applyPreset = useCallback((nextScale: number) => {
+    const {
+      leftPanelCollapsed,
+      leftPanelWidth,
+      rightPanelCollapsed,
+      rightPanelWidth,
+      viewport: current,
+    } = useCanvasStore.getState();
+    const center = getViewportCenterClientPoint({
+      leftPanelCollapsed,
+      leftPanelWidth,
+      rightPanelCollapsed,
+      rightPanelWidth,
+      topInset: TOOLBAR_HEIGHT,
+    });
+    useCanvasStore.getState().setViewport(
+      zoomAtClientPoint({
+        clientX: center.x,
+        clientY: center.y,
+        leftPanelCollapsed,
+        leftPanelWidth,
+        nextScale: clampScale(nextScale),
+        viewport: current,
+      }),
+    );
+  }, []);
+
+  const zoomPercent = Math.round(viewport.scale * 100);
+
+  return (
+    <div
+      className="fixed left-1/2 -translate-x-1/2 z-40 pointer-events-none"
+      style={{ bottom: 20 }}
+    >
+      <div
+        className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
+      >
+        <div className={groupBase} role="group" aria-label={t.canvas_tool_select}>
+          <button
+            className={`${segmentButton} ${tool === "select" ? segmentActive : ""}`}
+            onClick={() => setTool("select")}
+            title={`${t.canvas_tool_select} (V)`}
+            aria-label={t.canvas_tool_select}
+            aria-pressed={tool === "select"}
+          >
+            <SelectIcon />
+            <span className="text-[11px] font-mono opacity-60">V</span>
+          </button>
+          <button
+            className={`${segmentButton} ${tool === "hand" ? segmentActive : ""}`}
+            onClick={() => setTool("hand")}
+            title={`${t.canvas_tool_hand} (H)`}
+            aria-label={t.canvas_tool_hand}
+            aria-pressed={tool === "hand"}
+          >
+            <HandIcon />
+            <span className="text-[11px] font-mono opacity-60">H</span>
+          </button>
+        </div>
+
+        <div aria-hidden="true" className={dividerCls} />
+
+        <div className={groupBase}>
+          <button
+            className={iconButton}
+            onClick={() => stepZoomAtCenter("out")}
+            title={t.zoom_out}
+            aria-label={t.zoom_out}
+          >
+            <span className="text-[14px] leading-none">−</span>
+          </button>
+
+          <div className="relative" ref={popoverRef}>
+            <button
+              className={zoomReadout}
+              onClick={() => setPresetOpen((open) => !open)}
+              title={t.canvas_zoom_to}
+              aria-haspopup="menu"
+              aria-expanded={presetOpen}
+              style={{ fontFamily: '"Geist Mono", monospace' }}
+            >
+              {zoomPercent}%
+            </button>
+            {presetOpen && (
+              <div
+                role="menu"
+                className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 min-w-[140px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
+              >
+                {ZOOM_PRESETS.map((preset) => (
+                  <button
+                    key={preset.scale}
+                    role="menuitem"
+                    className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                    onClick={() => {
+                      applyPreset(preset.scale);
+                      setPresetOpen(false);
+                    }}
+                  >
+                    <span>{preset.label}</span>
+                    <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                      {preset.scale === 1 ? "⌘0" : ""}
+                    </span>
+                  </button>
+                ))}
+                <div className="my-1 h-px bg-[var(--border)] opacity-60" />
+                <button
+                  role="menuitem"
+                  className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                  onClick={() => {
+                    fitAllProjects();
+                    setPresetOpen(false);
+                  }}
+                >
+                  <span>{t.fit}</span>
+                  <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                    ⇧1
+                  </span>
+                </button>
+              </div>
+            )}
+          </div>
+
+          <button
+            className={iconButton}
+            onClick={() => stepZoomAtCenter("in")}
+            title={t.zoom_in}
+            aria-label={t.zoom_in}
+          >
+            <span className="text-[14px] leading-none">+</span>
+          </button>
+        </div>
+
+        <div aria-hidden="true" className={dividerCls} />
+
+        <button
+          className={`${buttonBase} px-2.5`}
+          onClick={fitAllProjects}
+          title={t.fit}
+          aria-label={t.fit}
+        >
+          {t.fit}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SelectIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+      <path
+        d="M3 2.2v8.6l2.3-2.1 1.6 3.3 1.7-.8-1.6-3.3 3 .1L3 2.2Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function HandIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+      <path
+        d="M4 6V2.7a.9.9 0 1 1 1.8 0V6m0 0V1.9a.9.9 0 1 1 1.8 0V6m0 0V2.4a.9.9 0 1 1 1.8 0V6m0 0V3.6a.9.9 0 1 1 1.8 0v4.6c0 2.3-1.7 3.6-3.5 3.6S2.5 10.5 2.5 8.5V6.5a.9.9 0 1 1 1.5-.5"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 import { useCanvasStore } from "../stores/canvasStore";
+import { useTaskStore } from "../stores/taskStore";
 import {
   useCanvasToolStore,
   type CanvasTool,
@@ -262,11 +263,14 @@ export function BottomToolbar() {
       rightPanelWidth,
       viewport: current,
     } = useCanvasStore.getState();
+    const taskDrawerOpen =
+      useTaskStore.getState().openProjectPath !== null;
     const center = getViewportCenterClientPoint({
       leftPanelCollapsed,
       leftPanelWidth,
       rightPanelCollapsed,
       rightPanelWidth,
+      taskDrawerOpen,
       topInset: TOOLBAR_HEIGHT,
     });
     useCanvasStore.getState().setViewport(
@@ -275,6 +279,7 @@ export function BottomToolbar() {
         clientY: center.y,
         leftPanelCollapsed,
         leftPanelWidth,
+        taskDrawerOpen,
         nextScale: clampScale(nextScale),
         viewport: current,
       }),

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useCanvasStore } from "../stores/canvasStore";
-import { useCanvasToolStore } from "../stores/canvasToolStore";
+import {
+  useCanvasToolStore,
+  type CanvasTool,
+} from "../stores/canvasToolStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import {
   fitAllProjects,
@@ -33,9 +36,6 @@ const dividerCls =
 const buttonBase =
   "inline-flex h-8 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_srgb,var(--text-secondary)_24%,transparent)] motion-reduce:transition-none";
 const iconButton = `${buttonBase} w-8`;
-const segmentButton = `${buttonBase} px-2.5 gap-1.5`;
-const segmentActive =
-  "bg-[color-mix(in_srgb,var(--surface)_82%,transparent)] text-[var(--text-primary)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--border)_70%,transparent)]";
 const zoomReadout =
   "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-faint)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
 
@@ -45,28 +45,37 @@ const ZOOM_PRESETS: Array<{ scale: number; label: string }> = [
   { scale: 2, label: "200%" },
 ];
 
+function useCloseOnOutsideClick(
+  open: boolean,
+  ref: React.RefObject<HTMLElement | null>,
+  close: () => void,
+): void {
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) close();
+    };
+    window.addEventListener("mousedown", handle);
+    return () => window.removeEventListener("mousedown", handle);
+  }, [open, ref, close]);
+}
+
 export function BottomToolbar() {
   const t = useT();
   const tool = useCanvasToolStore((s) => s.tool);
   const setTool = useCanvasToolStore((s) => s.setTool);
   const viewport = useCanvasStore((s) => s.viewport);
   const composerEnabled = usePreferencesStore((s) => s.composerEnabled);
-  const [presetOpen, setPresetOpen] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!presetOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(e.target as Node)
-      ) {
-        setPresetOpen(false);
-      }
-    };
-    window.addEventListener("mousedown", handleClick);
-    return () => window.removeEventListener("mousedown", handleClick);
-  }, [presetOpen]);
+  const [toolMenuOpen, setToolMenuOpen] = useState(false);
+  const [presetOpen, setPresetOpen] = useState(false);
+  const toolMenuRef = useRef<HTMLDivElement>(null);
+  const presetRef = useRef<HTMLDivElement>(null);
+
+  useCloseOnOutsideClick(toolMenuOpen, toolMenuRef, () =>
+    setToolMenuOpen(false),
+  );
+  useCloseOnOutsideClick(presetOpen, presetRef, () => setPresetOpen(false));
 
   const applyPreset = useCallback((nextScale: number) => {
     const {
@@ -97,6 +106,18 @@ export function BottomToolbar() {
 
   const zoomPercent = Math.round(viewport.scale * 100);
 
+  const toolOptions: Array<{
+    id: CanvasTool;
+    label: string;
+    shortcut: string;
+    icon: React.ReactNode;
+  }> = [
+    { id: "select", label: t.canvas_tool_select, shortcut: "V", icon: <SelectIcon /> },
+    { id: "hand", label: t.canvas_tool_hand, shortcut: "H", icon: <HandIcon /> },
+  ];
+  const activeTool =
+    toolOptions.find((opt) => opt.id === tool) ?? toolOptions[0];
+
   return (
     <div
       className="fixed left-1/2 -translate-x-1/2 z-[95] pointer-events-none"
@@ -109,27 +130,55 @@ export function BottomToolbar() {
       <div
         className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
       >
-        <div className={groupBase} role="group" aria-label={t.canvas_tool_select}>
+        <div className="relative" ref={toolMenuRef}>
           <button
-            className={`${segmentButton} ${tool === "select" ? segmentActive : ""}`}
-            onClick={() => setTool("select")}
-            title={`${t.canvas_tool_select} (V)`}
-            aria-label={t.canvas_tool_select}
-            aria-pressed={tool === "select"}
+            className={`${buttonBase} px-2 gap-1`}
+            onClick={() => setToolMenuOpen((open) => !open)}
+            title={`${activeTool.label} (${activeTool.shortcut})`}
+            aria-haspopup="menu"
+            aria-expanded={toolMenuOpen}
+            aria-label={activeTool.label}
           >
-            <SelectIcon />
-            <span className="text-[11px] font-mono opacity-60">V</span>
+            {activeTool.icon}
+            <CaretIcon open={toolMenuOpen} />
           </button>
-          <button
-            className={`${segmentButton} ${tool === "hand" ? segmentActive : ""}`}
-            onClick={() => setTool("hand")}
-            title={`${t.canvas_tool_hand} (H)`}
-            aria-label={t.canvas_tool_hand}
-            aria-pressed={tool === "hand"}
-          >
-            <HandIcon />
-            <span className="text-[11px] font-mono opacity-60">H</span>
-          </button>
+          {toolMenuOpen && (
+            <div
+              role="menu"
+              className={`absolute bottom-full left-0 mb-2 min-w-[160px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
+            >
+              {toolOptions.map((opt) => {
+                const active = opt.id === tool;
+                return (
+                  <button
+                    key={opt.id}
+                    role="menuitemradio"
+                    aria-checked={active}
+                    className={`flex w-full items-center gap-3 px-2.5 py-1.5 text-[12px] transition-colors ${
+                      active
+                        ? "text-[var(--text-primary)] bg-[color-mix(in_srgb,var(--surface)_72%,transparent)]"
+                        : "text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                    }`}
+                    onClick={() => {
+                      setTool(opt.id);
+                      setToolMenuOpen(false);
+                    }}
+                  >
+                    <span className="w-4 inline-flex items-center justify-center">
+                      {active ? <CheckIcon /> : null}
+                    </span>
+                    <span className="inline-flex items-center justify-center w-4">
+                      {opt.icon}
+                    </span>
+                    <span className="flex-1 text-left">{opt.label}</span>
+                    <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                      {opt.shortcut}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         <div aria-hidden="true" className={dividerCls} />
@@ -144,7 +193,7 @@ export function BottomToolbar() {
             <span className="text-[14px] leading-none">−</span>
           </button>
 
-          <div className="relative" ref={popoverRef}>
+          <div className="relative" ref={presetRef}>
             <button
               className={zoomReadout}
               onClick={() => setPresetOpen((open) => !open)}
@@ -166,7 +215,11 @@ export function BottomToolbar() {
                     role="menuitem"
                     className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
                     onClick={() => {
-                      applyPreset(preset.scale);
+                      if (preset.scale === 1) {
+                        setZoomToHundred();
+                      } else {
+                        applyPreset(preset.scale);
+                      }
                       setPresetOpen(false);
                     }}
                   >
@@ -237,6 +290,41 @@ function HandIcon() {
         d="M4 6V2.7a.9.9 0 1 1 1.8 0V6m0 0V1.9a.9.9 0 1 1 1.8 0V6m0 0V2.4a.9.9 0 1 1 1.8 0V6m0 0V3.6a.9.9 0 1 1 1.8 0v4.6c0 2.3-1.7 3.6-3.5 3.6S2.5 10.5 2.5 8.5V6.5a.9.9 0 1 1 1.5-.5"
         stroke="currentColor"
         strokeWidth="1.1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CaretIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
+      fill="none"
+      className={`transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+      aria-hidden="true"
+    >
+      <path
+        d="M1.5 3l2.5 2.5L6.5 3"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden="true">
+      <path
+        d="M2 5.8L4.4 8.2L9 3.2"
+        stroke="currentColor"
+        strokeWidth="1.4"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -155,6 +155,7 @@ export function BottomToolbar() {
   const t = useT();
   const tool = useCanvasToolStore((s) => s.tool);
   const setTool = useCanvasToolStore((s) => s.setTool);
+  const spaceHeld = useCanvasToolStore((s) => s.spaceHeld);
   const viewport = useCanvasStore((s) => s.viewport);
   const composerEnabled = usePreferencesStore((s) => s.composerEnabled);
 
@@ -250,8 +251,15 @@ export function BottomToolbar() {
   }, []);
 
   const zoomPercent = Math.round(viewport.scale * 100);
+  // Trigger reflects the *effective* tool — when Space is held, the
+  // canvas behaves like Hand even though the persisted tool is still
+  // Move. Showing the hand glyph here gives the user the same visual
+  // confirmation Figma's cursor change provides. The dropdown's
+  // checkmark below stays on the persisted tool so the user always
+  // knows what'll be active when Space lifts.
+  const effectiveToolId: CanvasTool = spaceHeld ? "hand" : tool;
   const activeTool =
-    toolOptions.find((opt) => opt.id === tool) ?? toolOptions[0];
+    toolOptions.find((opt) => opt.id === effectiveToolId) ?? toolOptions[0];
 
   // When composer is enabled, sit just above its measured height
   // (published as `--composer-height`). The fallback covers the brief
@@ -266,7 +274,7 @@ export function BottomToolbar() {
       style={{ bottom: bottomOffset }}
     >
       <div
-        className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
+        className={`pointer-events-auto inline-flex items-center gap-1 rounded-lg px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
       >
         <div className="relative" ref={toolMenuWrapperRef}>
           <button
@@ -308,15 +316,15 @@ export function BottomToolbar() {
                       toolTriggerRef.current?.focus();
                     }}
                   >
-                    <span className="w-4 inline-flex items-center justify-center">
-                      {active ? <CheckIcon /> : null}
-                    </span>
                     <span className="inline-flex items-center justify-center w-4">
                       {opt.icon}
                     </span>
                     <span className="flex-1 text-left">{opt.label}</span>
                     <span className="text-[10px] font-mono text-[var(--text-faint)]">
                       {opt.shortcut}
+                    </span>
+                    <span className="w-4 inline-flex items-center justify-center text-[var(--text-primary)]">
+                      {active ? <CheckIcon /> : null}
                     </span>
                   </button>
                 );
@@ -388,9 +396,6 @@ export function BottomToolbar() {
                   }}
                 >
                   <span>{t.reset}</span>
-                  <span className="text-[10px] font-mono text-[var(--text-faint)]">
-                    0,0
-                  </span>
                 </button>
               </div>
             )}

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useCanvasStore } from "../stores/canvasStore";
 import { useCanvasToolStore } from "../stores/canvasToolStore";
+import { usePreferencesStore } from "../stores/preferencesStore";
 import {
   fitAllProjects,
   setZoomToHundred,
@@ -13,6 +14,12 @@ import {
 } from "../canvas/viewportZoom";
 import { TOOLBAR_HEIGHT } from "./toolbarHeight";
 import { useT } from "../i18n/useT";
+
+// ComposerBar sits at `bottom-4` (16 px) and is roughly 120 px tall;
+// when it's mounted we float above it with an 8 px gap so the pill is
+// never obscured. Drops back to `bottom: 20` when the composer is off.
+const BOTTOM_OFFSET_WITH_COMPOSER = 16 + 120 + 8;
+const BOTTOM_OFFSET_PLAIN = 20;
 
 const PILL_BG =
   "bg-[color-mix(in_srgb,var(--surface)_92%,transparent)] backdrop-blur-md";
@@ -43,6 +50,7 @@ export function BottomToolbar() {
   const tool = useCanvasToolStore((s) => s.tool);
   const setTool = useCanvasToolStore((s) => s.setTool);
   const viewport = useCanvasStore((s) => s.viewport);
+  const composerEnabled = usePreferencesStore((s) => s.composerEnabled);
   const [presetOpen, setPresetOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -91,8 +99,12 @@ export function BottomToolbar() {
 
   return (
     <div
-      className="fixed left-1/2 -translate-x-1/2 z-40 pointer-events-none"
-      style={{ bottom: 20 }}
+      className="fixed left-1/2 -translate-x-1/2 z-[95] pointer-events-none"
+      style={{
+        bottom: composerEnabled
+          ? BOTTOM_OFFSET_WITH_COMPOSER
+          : BOTTOM_OFFSET_PLAIN,
+      }}
     >
       <div
         className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useCanvasStore } from "../stores/canvasStore";
 import {
   useCanvasToolStore,
@@ -39,9 +45,26 @@ const iconButton = `${buttonBase} w-8`;
 const zoomReadout =
   "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-faint)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
 
-const ZOOM_PRESETS: Array<{ scale: number; label: string }> = [
+const platform = window.termcanvas?.app.platform ?? "darwin";
+const isMac = platform === "darwin";
+
+// One source of truth for the shortcut text shown in this toolbar's
+// menus. Keep aligned with the bindings registered in
+// useKeyboardShortcuts.ts (Cmd+0 fits, Cmd+1 = 100%, etc.).
+const KEY_HINT = {
+  fit: isMac ? "⌘0" : "Ctrl 0",
+  zoom100: isMac ? "⌘1" : "Ctrl 1",
+};
+
+type ZoomPreset = {
+  scale: number;
+  label: string;
+  hint?: string;
+};
+
+const ZOOM_PRESETS: ZoomPreset[] = [
   { scale: 0.5, label: "50%" },
-  { scale: 1, label: "100%" },
+  { scale: 1, label: "100%", hint: KEY_HINT.zoom100 },
   { scale: 2, label: "200%" },
 ];
 
@@ -60,6 +83,68 @@ function useCloseOnOutsideClick(
   }, [open, ref, close]);
 }
 
+// Roving-focus keyboard nav for popover menus. Caller passes a ref to
+// the popover container, the trigger button (so we can return focus
+// when Esc closes the menu), and an item count for arrow-key wrap.
+function usePopoverKeyboardNav({
+  open,
+  popoverRef,
+  triggerRef,
+  itemCount,
+  initialIndex = 0,
+  close,
+}: {
+  open: boolean;
+  popoverRef: React.RefObject<HTMLDivElement | null>;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  itemCount: number;
+  initialIndex?: number;
+  close: () => void;
+}): void {
+  useEffect(() => {
+    if (!open) return;
+    const popover = popoverRef.current;
+    if (!popover) return;
+
+    const items = () =>
+      Array.from(
+        popover.querySelectorAll<HTMLElement>("[data-popover-item]"),
+      );
+
+    // Focus the requested item once mounted (rAF lets the popover
+    // paint first, otherwise focus flashes briefly to the trigger).
+    const raf = requestAnimationFrame(() => {
+      const list = items();
+      list[Math.min(initialIndex, Math.max(0, list.length - 1))]?.focus();
+    });
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        triggerRef.current?.focus();
+        return;
+      }
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      e.preventDefault();
+      const list = items();
+      if (list.length === 0) return;
+      const current = list.findIndex((el) => el === document.activeElement);
+      const delta = e.key === "ArrowDown" ? 1 : -1;
+      const fallback = e.key === "ArrowDown" ? 0 : list.length - 1;
+      const next =
+        current < 0 ? fallback : (current + delta + list.length) % list.length;
+      list[next].focus();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("keydown", handler);
+    };
+  }, [open, popoverRef, triggerRef, itemCount, initialIndex, close]);
+}
+
 export function BottomToolbar() {
   const t = useT();
   const tool = useCanvasToolStore((s) => s.tool);
@@ -69,15 +154,69 @@ export function BottomToolbar() {
 
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
   const [presetOpen, setPresetOpen] = useState(false);
-  const toolMenuRef = useRef<HTMLDivElement>(null);
-  const presetRef = useRef<HTMLDivElement>(null);
+  const toolMenuWrapperRef = useRef<HTMLDivElement>(null);
+  const toolMenuPopoverRef = useRef<HTMLDivElement>(null);
+  const toolTriggerRef = useRef<HTMLButtonElement>(null);
+  const presetWrapperRef = useRef<HTMLDivElement>(null);
+  const presetPopoverRef = useRef<HTMLDivElement>(null);
+  const presetTriggerRef = useRef<HTMLButtonElement>(null);
 
-  useCloseOnOutsideClick(toolMenuOpen, toolMenuRef, () =>
-    setToolMenuOpen(false),
+  const closeToolMenu = useCallback(() => setToolMenuOpen(false), []);
+  const closePresetMenu = useCallback(() => setPresetOpen(false), []);
+
+  useCloseOnOutsideClick(toolMenuOpen, toolMenuWrapperRef, closeToolMenu);
+  useCloseOnOutsideClick(presetOpen, presetWrapperRef, closePresetMenu);
+
+  const toolOptions = useMemo<
+    Array<{
+      id: CanvasTool;
+      label: string;
+      shortcut: string;
+      icon: React.ReactNode;
+    }>
+  >(
+    () => [
+      {
+        id: "select",
+        label: t.canvas_tool_select,
+        shortcut: "V",
+        icon: <SelectIcon />,
+      },
+      {
+        id: "hand",
+        label: t.canvas_tool_hand,
+        shortcut: "H",
+        icon: <HandIcon />,
+      },
+    ],
+    [t.canvas_tool_select, t.canvas_tool_hand],
   );
-  useCloseOnOutsideClick(presetOpen, presetRef, () => setPresetOpen(false));
+
+  usePopoverKeyboardNav({
+    open: toolMenuOpen,
+    popoverRef: toolMenuPopoverRef,
+    triggerRef: toolTriggerRef,
+    itemCount: toolOptions.length,
+    initialIndex: Math.max(
+      0,
+      toolOptions.findIndex((opt) => opt.id === tool),
+    ),
+    close: closeToolMenu,
+  });
+  usePopoverKeyboardNav({
+    open: presetOpen,
+    popoverRef: presetPopoverRef,
+    triggerRef: presetTriggerRef,
+    // +1 for the Fit row appended after the presets.
+    itemCount: ZOOM_PRESETS.length + 1,
+    close: closePresetMenu,
+  });
 
   const applyPreset = useCallback((nextScale: number) => {
+    if (nextScale === 1) {
+      setZoomToHundred();
+      return;
+    }
     const {
       leftPanelCollapsed,
       leftPanelWidth,
@@ -105,16 +244,6 @@ export function BottomToolbar() {
   }, []);
 
   const zoomPercent = Math.round(viewport.scale * 100);
-
-  const toolOptions: Array<{
-    id: CanvasTool;
-    label: string;
-    shortcut: string;
-    icon: React.ReactNode;
-  }> = [
-    { id: "select", label: t.canvas_tool_select, shortcut: "V", icon: <SelectIcon /> },
-    { id: "hand", label: t.canvas_tool_hand, shortcut: "H", icon: <HandIcon /> },
-  ];
   const activeTool =
     toolOptions.find((opt) => opt.id === tool) ?? toolOptions[0];
 
@@ -130,8 +259,9 @@ export function BottomToolbar() {
       <div
         className={`pointer-events-auto inline-flex items-center gap-1 rounded-full px-2 py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
       >
-        <div className="relative" ref={toolMenuRef}>
+        <div className="relative" ref={toolMenuWrapperRef}>
           <button
+            ref={toolTriggerRef}
             className={`${buttonBase} px-2 gap-1`}
             onClick={() => setToolMenuOpen((open) => !open)}
             title={`${activeTool.label} (${activeTool.shortcut})`}
@@ -144,7 +274,9 @@ export function BottomToolbar() {
           </button>
           {toolMenuOpen && (
             <div
+              ref={toolMenuPopoverRef}
               role="menu"
+              aria-label={t.canvas_tool_select}
               className={`absolute bottom-full left-0 mb-2 min-w-[160px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
             >
               {toolOptions.map((opt) => {
@@ -152,16 +284,19 @@ export function BottomToolbar() {
                 return (
                   <button
                     key={opt.id}
+                    data-popover-item
                     role="menuitemradio"
                     aria-checked={active}
-                    className={`flex w-full items-center gap-3 px-2.5 py-1.5 text-[12px] transition-colors ${
+                    tabIndex={-1}
+                    className={`flex w-full items-center gap-3 px-2.5 py-1.5 text-[12px] transition-colors focus:outline-none ${
                       active
                         ? "text-[var(--text-primary)] bg-[color-mix(in_srgb,var(--surface)_72%,transparent)]"
-                        : "text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                        : "text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] focus:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] focus:text-[var(--text-primary)]"
                     }`}
                     onClick={() => {
                       setTool(opt.id);
-                      setToolMenuOpen(false);
+                      closeToolMenu();
+                      toolTriggerRef.current?.focus();
                     }}
                   >
                     <span className="w-4 inline-flex items-center justify-center">
@@ -193,8 +328,9 @@ export function BottomToolbar() {
             <span className="text-[14px] leading-none">−</span>
           </button>
 
-          <div className="relative" ref={presetRef}>
+          <div className="relative" ref={presetWrapperRef}>
             <button
+              ref={presetTriggerRef}
               className={zoomReadout}
               onClick={() => setPresetOpen((open) => !open)}
               title={t.canvas_zoom_to}
@@ -206,41 +342,45 @@ export function BottomToolbar() {
             </button>
             {presetOpen && (
               <div
+                ref={presetPopoverRef}
                 role="menu"
+                aria-label={t.canvas_zoom_to}
                 className={`absolute bottom-full left-1/2 -translate-x-1/2 mb-2 min-w-[140px] rounded-md py-1 ${PILL_BG} ${PILL_BORDER} ${PILL_SHADOW}`}
               >
                 {ZOOM_PRESETS.map((preset) => (
                   <button
                     key={preset.scale}
+                    data-popover-item
                     role="menuitem"
-                    className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                    tabIndex={-1}
+                    className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] focus:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] focus:text-[var(--text-primary)] focus:outline-none"
                     onClick={() => {
-                      if (preset.scale === 1) {
-                        setZoomToHundred();
-                      } else {
-                        applyPreset(preset.scale);
-                      }
-                      setPresetOpen(false);
+                      applyPreset(preset.scale);
+                      closePresetMenu();
+                      presetTriggerRef.current?.focus();
                     }}
                   >
                     <span>{preset.label}</span>
                     <span className="text-[10px] font-mono text-[var(--text-faint)]">
-                      {preset.scale === 1 ? "⌘0" : ""}
+                      {preset.hint ?? ""}
                     </span>
                   </button>
                 ))}
                 <div className="my-1 h-px bg-[var(--border)] opacity-60" />
                 <button
+                  data-popover-item
                   role="menuitem"
-                  className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)]"
+                  tabIndex={-1}
+                  className="flex w-full items-center justify-between px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] focus:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] focus:text-[var(--text-primary)] focus:outline-none"
                   onClick={() => {
                     fitAllProjects();
-                    setPresetOpen(false);
+                    closePresetMenu();
+                    presetTriggerRef.current?.focus();
                   }}
                 >
                   <span>{t.fit}</span>
                   <span className="text-[10px] font-mono text-[var(--text-faint)]">
-                    ⇧1
+                    {KEY_HINT.fit}
                   </span>
                 </button>
               </div>
@@ -262,7 +402,7 @@ export function BottomToolbar() {
         <button
           className={`${buttonBase} px-2.5`}
           onClick={fitAllProjects}
-          title={t.fit}
+          title={`${t.fit} (${KEY_HINT.fit})`}
           aria-label={t.fit}
         >
           {t.fit}

--- a/src/toolbar/Toolbar.tsx
+++ b/src/toolbar/Toolbar.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { createBrowserCardInScene } from "../actions/sceneCardActions";
 import { useCanvasStore } from "../stores/canvasStore";
 import { useTaskStore } from "../stores/taskStore";
-import { useProjectStore } from "../stores/projectStore";
 import { useThemeStore } from "../stores/themeStore";
 import { useUpdaterStore } from "../stores/updaterStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
@@ -18,42 +17,28 @@ import {
   getCanvasLeftInset,
   getCanvasRightInset,
 } from "../canvas/viewportBounds";
-import {
-  getNextZoomStep,
-  getViewportCenterClientPoint,
-  zoomAtClientPoint,
-} from "../canvas/viewportZoom";
+
+export { TOOLBAR_HEIGHT } from "./toolbarHeight";
 
 const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
 const platform = window.termcanvas?.app.platform ?? "darwin";
 const isMac = platform === "darwin";
 const isWin = platform === "win32";
-export const TOOLBAR_HEIGHT = 44;
 
 const controlRow =
   "relative z-10 flex items-center gap-2 text-[var(--text-secondary)]";
 const controlSection = "flex items-center gap-0.5";
-const controlDivider =
-  "h-4 w-px bg-[color-mix(in_srgb,var(--border)_72%,transparent)]";
 const buttonBase =
   "inline-flex h-7 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_srgb,var(--text-secondary)_24%,transparent)] motion-reduce:transition-none";
 const iconButton = `${buttonBase} w-7`;
-const textButton = `${buttonBase} px-2.5`;
-const zoomReadout =
-  "min-w-[3.25rem] text-center text-[11px] text-[var(--text-faint)] tabular-nums";
 
 export function Toolbar({ onShowTutorial }: { onShowTutorial: () => void }) {
-  const {
-    viewport,
-    setViewport,
-    resetViewport,
-    rightPanelCollapsed,
-    rightPanelWidth,
-    leftPanelCollapsed,
-    leftPanelWidth,
-  } = useCanvasStore();
+  const viewport = useCanvasStore((s) => s.viewport);
+  const leftPanelCollapsed = useCanvasStore((s) => s.leftPanelCollapsed);
+  const leftPanelWidth = useCanvasStore((s) => s.leftPanelWidth);
+  const rightPanelCollapsed = useCanvasStore((s) => s.rightPanelCollapsed);
+  const rightPanelWidth = useCanvasStore((s) => s.rightPanelWidth);
   const taskDrawerOpen = useTaskStore((s) => s.openProjectPath !== null);
-  const { projects } = useProjectStore();
   const { theme, toggleTheme } = useThemeStore();
   const browserEnabled = usePreferencesStore((s) => s.browserEnabled);
   const terminalRenderer = usePreferencesStore((s) => s.terminalRenderer);
@@ -66,84 +51,6 @@ export function Toolbar({ onShowTutorial }: { onShowTutorial: () => void }) {
   const closeSettings = useSettingsModalStore((s) => s.closeSettings);
   const [showUpdate, setShowUpdate] = useState(false);
 
-  const handleFitAll = useCallback(() => {
-    if (projects.length === 0) return;
-    const padding = 80;
-    let minX = Infinity,
-      minY = Infinity,
-      maxX = -Infinity,
-      maxY = -Infinity;
-    for (const p of projects) {
-      for (const wt of p.worktrees) {
-        for (const t of wt.terminals) {
-          if (t.stashed) continue;
-          minX = Math.min(minX, t.x);
-          minY = Math.min(minY, t.y);
-          maxX = Math.max(maxX, t.x + t.width);
-          maxY = Math.max(maxY, t.y + t.height);
-        }
-      }
-    }
-    const contentW = maxX - minX;
-    const contentH = maxY - minY;
-    const leftOffset = getCanvasLeftInset(
-      leftPanelCollapsed,
-      leftPanelWidth,
-      taskDrawerOpen,
-    );
-    const rightOffset = getCanvasRightInset(rightPanelCollapsed, rightPanelWidth);
-    const viewW = window.innerWidth - leftOffset - rightOffset - padding * 2;
-    const viewH = window.innerHeight - TOOLBAR_HEIGHT - padding * 2;
-    const scale = Math.min(1, viewW / contentW, viewH / contentH);
-    const x = -minX * scale + padding;
-    const y = -minY * scale + padding + TOOLBAR_HEIGHT;
-    setViewport({ x, y, scale });
-  }, [
-    projects,
-    leftPanelCollapsed,
-    leftPanelWidth,
-    rightPanelCollapsed,
-    rightPanelWidth,
-    taskDrawerOpen,
-    setViewport,
-  ]);
-
-  const applyStepZoom = useCallback(
-    (direction: "in" | "out") => {
-      const nextScale = getNextZoomStep(viewport.scale, direction);
-      const centerPoint = getViewportCenterClientPoint({
-        leftPanelCollapsed,
-        leftPanelWidth,
-        rightPanelCollapsed,
-        rightPanelWidth,
-        taskDrawerOpen,
-        topInset: TOOLBAR_HEIGHT,
-      });
-
-      setViewport(
-        zoomAtClientPoint({
-          clientX: centerPoint.x,
-          clientY: centerPoint.y,
-          leftPanelCollapsed,
-          leftPanelWidth,
-          taskDrawerOpen,
-          nextScale,
-          viewport,
-        }),
-      );
-    },
-    [
-      leftPanelCollapsed,
-      leftPanelWidth,
-      rightPanelCollapsed,
-      rightPanelWidth,
-      taskDrawerOpen,
-      setViewport,
-      viewport,
-    ],
-  );
-
-  const zoomPercent = Math.round(viewport.scale * 100);
   const workspaceName =
     getWorkspaceBaseName(workspacePath) ?? t.toolbar_untitled_workspace;
 
@@ -407,7 +314,7 @@ export function Toolbar({ onShowTutorial }: { onShowTutorial: () => void }) {
                         strokeLinecap="round"
                       />
                     </svg>
-                    <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-green-500" />
+                    <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-[var(--green)]" />
                   </>
                 ) : updateStatus === "error" ? (
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -510,40 +417,6 @@ export function Toolbar({ onShowTutorial }: { onShowTutorial: () => void }) {
                 </svg>
               </button>
             )}
-          </div>
-
-          <div aria-hidden="true" className={controlDivider} />
-
-          <div className={controlSection}>
-            <button
-              className={iconButton}
-              onClick={() => applyStepZoom("out")}
-              title={t.zoom_out}
-              aria-label={t.zoom_out}
-            >
-              −
-            </button>
-            <span
-              className={zoomReadout}
-              style={{ fontFamily: '"Geist Mono", monospace' }}
-            >
-              {zoomPercent}%
-            </span>
-            <button
-              className={iconButton}
-              onClick={() => applyStepZoom("in")}
-              title={t.zoom_in}
-              aria-label={t.zoom_in}
-            >
-              +
-            </button>
-            <div aria-hidden="true" className={controlDivider} />
-            <button className={textButton} onClick={resetViewport}>
-              {t.reset}
-            </button>
-            <button className={textButton} onClick={handleFitAll}>
-              {t.fit}
-            </button>
           </div>
         </div>
       </div>

--- a/src/toolbar/toolbarHeight.ts
+++ b/src/toolbar/toolbarHeight.ts
@@ -1,0 +1,5 @@
+// Top toolbar dock height. Lives in a leaf module so that helpers
+// outside the toolbar (zoom actions, fit-all math) can read it
+// without pulling Toolbar.tsx — that file imports React/components,
+// so making it a sibling of those helpers would risk cycles.
+export const TOOLBAR_HEIGHT = 44;


### PR DESCRIPTION
## Summary

Aligns the canvas operation logic with Figma's conventions, the first slice of the broader UI direction discussed offline. Four module-scoped commits, each independently buildable:

- **refactor(canvas)** — extract `TOOLBAR_HEIGHT` to a leaf module and add shared canvas-tool / zoom-action helpers.
- **feat(toolbar)** — new bottom-middle floating pill (V/H, − % +, Fit + preset menu); top toolbar slimmed to app-level controls.
- **feat(canvas)** — hand tool and Space-held temporary pan: cursor swaps to grab/grabbing, terminals become non-draggable, node-click no longer activates, marquee yields to pan.
- **feat(canvas)** — Figma keybindings: V/H, Space-hold, ⌘0 / ⌘1 / ⌘= / ⌘-, Shift+1.

Out of scope (deferred): Stage Manager–style soft-snap, Cmd+K command palette, mini-map, drawing-tool consolidation. Drawing remains gated behind its preference flag and untouched.

## Test plan

- [ ] Top toolbar no longer shows zoom buttons; bottom pill appears with V/H tool toggle, − % +, and Fit
- [ ] Click V → cursor returns to default; click H → cursor turns to grab; click % → preset menu opens
- [ ] `V` / `H` keys switch the tool (no modifier, not while typing in terminal/composer)
- [ ] Hold `Space` over canvas → temporary hand; release → restore
- [ ] Press `Space` while focused inside a terminal → terminal receives space input (no pan)
- [ ] In hand mode, left-drag a terminal pans the canvas instead of moving the tile; click on a terminal does not activate it
- [ ] In hand mode, `Shift+drag` does not start a marquee
- [ ] `⌘0` fits all projects, `⌘1` zooms to 100%, `⌘=` / `⌘-` step zoom around the viewport center, `Shift+1` fits all
- [ ] Trackpad two-finger pan still works; trackpad pinch still zooms (anchored at gesture center)

🤖 Generated with [Claude Code](https://claude.com/claude-code)