### PR TITLE
chore: ignore locally-installed third-party skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ git-harness-snapshot.md
 # Local-only archives
 .local-archive/
 docs/research/harness-articles-2026/
+
+# Locally-installed third-party skills (not project-managed). The
+# project's own skill plugin lives at /skills/skills and is exposed
+# under .agents/skills/termcanvas via a tracked symlink, so we ignore
+# every other entry under .agents/skills/ instead of the whole tree.
+/.agents/skills/*/
+!/.agents/skills/termcanvas
+/skills-lock.json


### PR DESCRIPTION
## Summary

When the user installs a third-party skill through Claude Code's skills tooling, two things land in the working tree:

- `.agents/skills/<name>/` — the resolved skill content (this checkout has `pbakaus/impeccable`)
- `skills-lock.json` — a lockfile pinning that install

Nothing in this repo consumes the lockfile (no scripts, CLI, or build step references it), so it's effectively per-developer Claude Code workspace state — same nature as `.claude/`, which we already ignore. Adding the matching ignore rules.

The project's own skill plugin (`/skills/skills`) is exposed under `.agents/skills/termcanvas` through an **already-tracked symlink** (committed in `fab3519`), so a blanket ignore of `.agents/` would shadow it. The rule whitelists that symlink:

```
/.agents/skills/*/
!/.agents/skills/termcanvas
/skills-lock.json
```

Supersedes #152 (opened under the wrong account).

## Test plan

- [ ] `git check-ignore -v .agents/skills/impeccable skills-lock.json` reports both as ignored
- [ ] `git check-ignore -v .agents/skills/termcanvas` reports nothing (symlink stays tracked)
- [ ] `git status` is clean after a fresh checkout when no third-party skills are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)