### PR TITLE
fix(canvas): toolbar panel close, open-state ring, space-pan in select mode

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -369,21 +369,29 @@ export function useKeyboardShortcuts() {
           useCanvasToolStore.getState().setTool("hand");
           return;
         }
-        // Space hold → temporary hand. Repeat events are filtered above
-        // so the keydown only fires once until release. Skip when the
-        // focused control natively activates on Space (button, menu
-        // item, checkbox …) — preempting that breaks keyboard
-        // operation of the toolbar itself.
-        if (e.code === "Space") {
-          if (isActivationTarget(e.target)) {
-            return;
-          }
-          if (!useCanvasToolStore.getState().spaceHeld) {
-            useCanvasToolStore.getState().setSpaceHeld(true);
-          }
-          e.preventDefault();
+      }
+
+      // Space hold → temporary hand. Handled outside !e.repeat so that
+      // e.preventDefault() fires on every Space keydown (including
+      // repeats), preventing browser scroll while held. setSpaceHeld is
+      // only called once via the !spaceHeld guard. Skip when the focused
+      // control natively activates on Space (button, menu item, …) so
+      // keyboard operation of the toolbar itself is preserved.
+      if (
+        e.code === "Space" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        if (isActivationTarget(e.target)) {
           return;
         }
+        if (!useCanvasToolStore.getState().spaceHeld) {
+          useCanvasToolStore.getState().setSpaceHeld(true);
+        }
+        e.preventDefault();
+        return;
       }
 
       if (

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -79,23 +79,22 @@ function useCloseOnOutsideClick(
   open: boolean,
   ref: React.RefObject<HTMLElement | null>,
   close: () => void,
-  triggerRef?: React.RefObject<HTMLElement | null>,
 ): void {
   useEffect(() => {
     if (!open) return;
     const handle = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         close();
-        // Match the focus contract that Esc / item-activation already
-        // honour: outside-click should also leave focus on the trigger
-        // so a keyboard user who opened the menu and then mouse-
-        // clicked elsewhere isn't stranded on `<body>`.
-        triggerRef?.current?.focus();
+        // Don't restore focus to the trigger on mouse outside-click.
+        // Doing so would leave a toolbar button as e.target for the next
+        // keydown, causing isActivationTarget to block Space-to-pan.
+        // Keyboard close (Escape) is handled by usePopoverKeyboardNav
+        // which does return focus to the trigger there.
       }
     };
     window.addEventListener("mousedown", handle, true);
     return () => window.removeEventListener("mousedown", handle, true);
-  }, [open, ref, close, triggerRef]);
+  }, [open, ref, close]);
 }
 
 // Roving-focus keyboard nav for popover menus. Caller passes a ref to
@@ -193,18 +192,8 @@ export function BottomToolbar() {
     [],
   );
 
-  useCloseOnOutsideClick(
-    toolMenuOpen,
-    toolMenuWrapperRef,
-    closeToolMenu,
-    toolTriggerRef,
-  );
-  useCloseOnOutsideClick(
-    presetOpen,
-    presetWrapperRef,
-    closePresetMenu,
-    presetTriggerRef,
-  );
+  useCloseOnOutsideClick(toolMenuOpen, toolMenuWrapperRef, closeToolMenu);
+  useCloseOnOutsideClick(presetOpen, presetWrapperRef, closePresetMenu);
 
   const toolOptions = useMemo<
     Array<{
@@ -349,7 +338,6 @@ export function BottomToolbar() {
                     onClick={() => {
                       setTool(opt.id);
                       closeToolMenu();
-                      toolTriggerRef.current?.focus();
                     }}
                   >
                     <span className="inline-flex items-center justify-center w-4">
@@ -410,7 +398,6 @@ export function BottomToolbar() {
                     onClick={() => {
                       applyPreset(preset.scale);
                       closePresetMenu();
-                      presetTriggerRef.current?.focus();
                     }}
                   >
                     <span>{preset.label}</span>
@@ -428,7 +415,6 @@ export function BottomToolbar() {
                   onClick={() => {
                     useCanvasStore.getState().resetViewport();
                     closePresetMenu();
-                    presetTriggerRef.current?.focus();
                   }}
                 >
                   <span>{t.reset}</span>

--- a/src/toolbar/BottomToolbar.tsx
+++ b/src/toolbar/BottomToolbar.tsx
@@ -47,7 +47,7 @@ const groupBase = "flex items-center";
 const dividerCls =
   "h-4 w-px bg-[color-mix(in_srgb,var(--border)_72%,transparent)] mx-0.5";
 const buttonBase =
-  "inline-flex h-8 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_srgb,var(--text-secondary)_24%,transparent)] motion-reduce:transition-none";
+  "inline-flex h-8 items-center justify-center rounded-md text-[12px] font-medium text-[var(--text-muted)] transition-[color,background-color,transform] duration-150 hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] active:scale-[0.97] focus-visible:outline-none motion-reduce:transition-none";
 const iconButton = `${buttonBase} w-8`;
 const zoomReadout =
   "min-w-[3.25rem] h-8 inline-flex items-center justify-center text-[11px] text-[var(--text-muted)] tabular-nums rounded-md hover:bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] hover:text-[var(--text-primary)] transition-colors";
@@ -93,8 +93,8 @@ function useCloseOnOutsideClick(
         triggerRef?.current?.focus();
       }
     };
-    window.addEventListener("mousedown", handle);
-    return () => window.removeEventListener("mousedown", handle);
+    window.addEventListener("mousedown", handle, true);
+    return () => window.removeEventListener("mousedown", handle, true);
   }, [open, ref, close, triggerRef]);
 }
 
@@ -315,7 +315,7 @@ export function BottomToolbar() {
         <div className="relative" ref={toolMenuWrapperRef}>
           <button
             ref={toolTriggerRef}
-            className={`${buttonBase} px-2 gap-1`}
+            className={`${buttonBase} px-2 gap-1 ${toolMenuOpen ? "bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] text-[var(--text-primary)]" : ""}`}
             onClick={toggleToolMenu}
             title={`${activeTool.label} (${activeTool.shortcut})`}
             aria-haspopup="menu"


### PR DESCRIPTION
## Summary

- **Panel close on outside click**: `useCloseOnOutsideClick` was using a bubble-phase `mousedown` listener, but `useBoxSelect` calls `stopPropagation()` in select mode during the capture phase, so the event never bubbled to `window`. Fixed by using a capture-phase listener (`true` flag).
- **Tool trigger open-state ring**: Removed the `focus-visible:ring-1` with 24%-opacity color from `buttonBase` — it rendered inconsistently and looked out of place. Added an explicit `bg` highlight to the tool trigger button when its menu is open, so there's a clear pressed/open state.
- **Space-to-pan in select mode**: The Space handler was inside the `!e.repeat` block, so `e.preventDefault()` was only called on the first keydown. Repeat events fell through without preventing default, causing scroll/pan conflicts. Moved Space outside that block so `preventDefault` fires on every Space keydown while held; `setSpaceHeld` is still guarded by `!spaceHeld` so it only fires once.

## Test plan

- [ ] Open tool dropdown → click elsewhere on the canvas → panel closes
- [ ] Open tool dropdown → click elsewhere on the toolbar → panel closes
- [ ] Switch to Select tool (V), hold Space → cursor changes to grab, dragging pans the canvas
- [ ] While holding Space, verify toolbar shows hand icon
- [ ] Release Space → returns to select/cursor behavior
- [ ] Open tool dropdown via keyboard (Tab + Enter) → Esc closes it, focus returns to trigger without a visible ring artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)