### PR TITLE
fix(updater): restore install-and-restart path after #155

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -104,8 +104,7 @@ function UpdateCheckButton() {
   }, []);
 
   const handleInstall = useCallback(() => {
-    useUpdaterStore.getState().requestRestartOnClose();
-    window.termcanvas.app.requestClose();
+    window.termcanvas.updater.install();
   }, []);
 
   if (upToDate) {

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -22,10 +22,8 @@ export function UpdateModal({ onClose }: Props) {
   const backdropRef = useRef<HTMLDivElement>(null);
 
   const handleInstall = useCallback(() => {
-    useUpdaterStore.getState().requestRestartOnClose();
-    onClose();
-    window.termcanvas.app.requestClose();
-  }, [onClose]);
+    window.termcanvas.updater.install();
+  }, []);
 
   const handleRetry = useCallback(() => {
     useUpdaterStore.setState({ status: "checking", errorMessage: null });

--- a/src/stores/updaterStore.ts
+++ b/src/stores/updaterStore.ts
@@ -12,27 +12,13 @@ interface UpdaterStore {
   info: UpdateEventInfo | null;
   downloadPercent: number;
   errorMessage: string | null;
-  installOnCloseRequested: boolean;
-  requestRestartOnClose: () => void;
-  cancelRestartOnClose: () => void;
-  consumeRestartOnClose: () => boolean;
 }
 
-export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
+export const useUpdaterStore = create<UpdaterStore>((set) => ({
   status: "idle",
   info: null,
   downloadPercent: 0,
   errorMessage: null,
-  installOnCloseRequested: false,
-  requestRestartOnClose: () => set({ installOnCloseRequested: true }),
-  cancelRestartOnClose: () => set({ installOnCloseRequested: false }),
-  consumeRestartOnClose: () => {
-    const requested = get().installOnCloseRequested;
-    if (requested) {
-      set({ installOnCloseRequested: false });
-    }
-    return requested;
-  },
 }));
 
 export function initUpdaterListeners(): () => void {


### PR DESCRIPTION
## 问题

#155 删掉了 `app:close-confirmed` IPC 路径后，「Restart & Update」按钮的流程断了：

老流程：点按钮 → `requestRestartOnClose()` → `requestClose()` → `app:close-confirmed { installUpdate: true }` → `installDownloadedUpdate()`

现在 `app:close-confirmed` 不存在了，按钮只是把窗口关掉，更新安装并没有触发。

## 修法

主进程本来就有 `updater:install` IPC handler（`ipcMain.on("updater:install", () => installDownloadedUpdate())`），之前没人直接用它。现在让 `SettingsModal` 和 `UpdateModal` 的 install 按钮直接调 `window.termcanvas.updater.install()`，走这条现成的路，干净利落。

顺带删掉 `updaterStore` 里因此变成死代码的四个字段：`installOnCloseRequested`、`requestRestartOnClose`、`cancelRestartOnClose`、`consumeRestartOnClose`。

## Closes

Review comment on #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)