### PR TITLE
fix: guard port file with PID to survive crashes

### DIFF
--- a/cli/termcanvas.ts
+++ b/cli/termcanvas.ts
@@ -93,15 +93,30 @@ function getConnection(): ConnectionTarget {
 
   const portFile = resolveTermCanvasPortFile(process.env);
   try {
-    const port = parseInt(fs.readFileSync(portFile, "utf-8").trim(), 10);
+    const [portStr, pidStr] = fs.readFileSync(portFile, "utf-8").trim().split("\n");
+    const port = parseInt(portStr, 10);
+    const pid = parseInt(pidStr, 10);
+    if (pid) {
+      try {
+        process.kill(pid, 0); // probe: throws if process is dead
+      } catch {
+        fs.unlinkSync(portFile);
+        console.error(`TermCanvas is not running (stale port file removed from ${portFile}).`);
+        process.exit(1);
+      }
+    }
     return {
       protocol: "http:",
       hostname: "127.0.0.1",
       port,
       basePath: "",
     };
-  } catch {
-    console.error(`TermCanvas is not running (no port file found at ${portFile}).`);
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      console.error(`TermCanvas is not running (no port file found at ${portFile}).`);
+    } else {
+      throw err;
+    }
     process.exit(1);
   }
 }

--- a/cli/termcanvas.ts
+++ b/cli/termcanvas.ts
@@ -96,11 +96,11 @@ function getConnection(): ConnectionTarget {
     const [portStr, pidStr] = fs.readFileSync(portFile, "utf-8").trim().split("\n");
     const port = parseInt(portStr, 10);
     const pid = parseInt(pidStr, 10);
-    if (pid) {
+    if (!isNaN(pid)) {
       try {
         process.kill(pid, 0); // probe: throws if process is dead
       } catch {
-        fs.unlinkSync(portFile);
+        try { fs.unlinkSync(portFile); } catch {}
         console.error(`TermCanvas is not running (stale port file removed from ${portFile}).`);
         process.exit(1);
       }
@@ -111,12 +111,9 @@ function getConnection(): ConnectionTarget {
       port,
       basePath: "",
     };
-  } catch (err: any) {
-    if (err.code === "ENOENT") {
-      console.error(`TermCanvas is not running (no port file found at ${portFile}).`);
-    } else {
-      throw err;
-    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    console.error(`TermCanvas is not running (no port file found at ${portFile}).`);
     process.exit(1);
   }
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -208,7 +208,7 @@ function perfLog(label: string, details: Record<string, unknown>) {
 }
 
 function writePortFile(port: number) {
-  fs.writeFileSync(PORT_FILE, String(port), "utf-8");
+  fs.writeFileSync(PORT_FILE, `${port}\n${process.pid}`, "utf-8");
 }
 
 function cleanupPortFile() {

--- a/mcp/computer-use-server/src/termcanvas-client.ts
+++ b/mcp/computer-use-server/src/termcanvas-client.ts
@@ -38,7 +38,7 @@ function resolveBaseUrl(): string | null {
   const portFile =
     process.env.TERMCANVAS_PORT_FILE?.trim() || defaultPortFilePath();
   try {
-    const port = Number(fs.readFileSync(portFile, "utf8").trim());
+    const port = Number(fs.readFileSync(portFile, "utf8").split("\n")[0].trim());
     if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
     return `http://127.0.0.1:${port}`;
   } catch {


### PR DESCRIPTION
## Summary

- `writePortFile` now writes `port\npid` (two lines) instead of just the port number
- CLI reader calls `kill(pid, 0)` to probe whether the process is still alive before trusting the port
- If the process is dead, the stale file is cleaned up and the user gets a clear error message instead of a confusing connection failure

## Why

Previously a crash (not a graceful `will-quit`) left `~/.termcanvas/port` behind. The next CLI invocation would read a valid-looking port, try to connect, and hit a confusing socket error. The only fix was to manually delete the port file.

The PID-guard pattern (`kill(pid, 0)` + port in same file) is the standard approach used by language servers and VS Code extensions for exactly this scenario.

## Test plan

- [ ] Normal exit (⌘Q): port file removed as before, no change in behavior
- [ ] Kill Electron with `pkill -f Electron`: CLI on next invocation prints "stale port file removed" and exits cleanly
- [ ] Old-format port file (single line, no PID): `isNaN(pid)` guard skips the probe, reads port as before — backwards compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)