### PR TITLE
feat(filetree): replace hand-rolled file tree with @pierre/trees

### DIFF
--- a/electron/file-tree-watcher.ts
+++ b/electron/file-tree-watcher.ts
@@ -17,7 +17,7 @@ export class FileTreeWatcher {
     if (this.watchers.has(dirPath)) return;
 
     try {
-      const watcher = fs.watch(dirPath, (_eventType, filename) => {
+      const watcher = fs.watch(dirPath, { recursive: true }, (_eventType, filename) => {
         if (typeof filename === "string") {
           if (this.hiddenDirs.has(filename)) return;
         }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1580,24 +1580,31 @@ function setupIpc() {
       // Non-git repo: walk the directory tree recursively
       const paths: string[] = [];
       const visited = new Set<string>();
-      const collect = (dir: string, prefix: string): void => {
+      // Returns number of file entries added from this subtree. When a
+      // directory subtree is entirely empty, emit the directory itself with a
+      // trailing "/" so @pierre/trees can still display it.
+      const collect = (dir: string, prefix: string): number => {
+        let added = 0;
         try {
           const realDir = fs.realpathSync(dir);
-          if (visited.has(realDir)) return;
+          if (visited.has(realDir)) return 0;
           visited.add(realDir);
           const entries = fs.readdirSync(dir, { withFileTypes: true });
           for (const entry of entries) {
             if (HIDDEN_DIRS.has(entry.name)) continue;
             const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
             if (entry.isDirectory()) {
-              collect(path.join(dir, entry.name), relPath);
+              added += collect(path.join(dir, entry.name), relPath);
             } else {
               paths.push(relPath);
+              added++;
             }
           }
+          if (added === 0 && prefix) paths.push(`${prefix}/`);
         } catch (err) {
           console.error(`[fs:list-all-files] failed to read ${dir}:`, err);
         }
+        return added;
       };
       collect(dirPath, "");
       return { type: "dir" as const, paths };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1563,6 +1563,47 @@ function setupIpc() {
     fileTreeWatcher.unwatchAll();
   });
 
+  ipcMain.handle("fs:list-all-files", async (_event, dirPath: string) => {
+    try {
+      const { execFile } = await import("child_process");
+      const output = await new Promise<string>((resolve, reject) => {
+        execFile(
+          "git",
+          ["ls-files", "--cached", "--others", "--exclude-standard"],
+          { cwd: dirPath, timeout: 10000 },
+          (err, stdout) => (err ? reject(err) : resolve(stdout)),
+        );
+      });
+      const paths = output.split("\n").filter(Boolean);
+      return { type: "git" as const, paths };
+    } catch {
+      // Non-git repo: walk the directory tree recursively
+      const paths: string[] = [];
+      const visited = new Set<string>();
+      const collect = (dir: string, prefix: string): void => {
+        try {
+          const realDir = fs.realpathSync(dir);
+          if (visited.has(realDir)) return;
+          visited.add(realDir);
+          const entries = fs.readdirSync(dir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (HIDDEN_DIRS.has(entry.name)) continue;
+            const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+            if (entry.isDirectory()) {
+              collect(path.join(dir, entry.name), relPath);
+            } else {
+              paths.push(relPath);
+            }
+          }
+        } catch (err) {
+          console.error(`[fs:list-all-files] failed to read ${dir}:`, err);
+        }
+      };
+      collect(dirPath, "");
+      return { type: "dir" as const, paths };
+    }
+  });
+
   ipcMain.handle("cli:is-registered", () => isCliRegistered(getCliDir()));
   ipcMain.handle("cli:register", () => {
     const cliOk = registerCli(getCliDir());

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -545,6 +545,11 @@ contextBridge.exposeInMainWorld("termcanvas", {
       ipcRenderer.invoke("fs:list-dir", dirPath) as Promise<
         { name: string; isDirectory: boolean }[]
       >,
+    listAllFiles: (dirPath: string) =>
+      ipcRenderer.invoke("fs:list-all-files", dirPath) as Promise<{
+        type: "git" | "dir";
+        paths: string[];
+      }>,
     readFile: (filePath: string) =>
       ipcRenderer.invoke("fs:read-file", filePath) as Promise<
         { type: string; content: string } | { error: string; size?: string }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@anthropic-ai/sdk": "^0.81.0",
     "@aws-sdk/client-s3": "^3.1019.0",
     "@monaco-editor/react": "^4.7.0",
+    "@pierre/trees": "1.0.0-beta.3",
     "@supabase/supabase-js": "^2.99.3",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@pierre/trees':
+        specifier: 1.0.0-beta.3
+        version: 1.0.0-beta.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@supabase/supabase-js':
         specifier: ^2.99.3
         version: 2.103.3
@@ -944,6 +947,12 @@ packages:
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@pierre/trees@1.0.0-beta.3':
+    resolution: {integrity: sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3498,6 +3507,14 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  preact-render-to-string@6.6.5:
+    resolution: {integrity: sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@11.0.0-beta.0:
+    resolution: {integrity: sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg==}
+
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -5123,6 +5140,13 @@ snapshots:
   '@npmcli/fs@4.0.0':
     dependencies:
       semver: 7.7.4
+
+  '@pierre/trees@1.0.0-beta.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      preact: 11.0.0-beta.0
+      preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7960,6 +7984,12 @@ snapshots:
     dependencies:
       commander: 9.5.0
     optional: true
+
+  preact-render-to-string@6.6.5(preact@11.0.0-beta.0):
+    dependencies:
+      preact: 11.0.0-beta.0
+
+  preact@11.0.0-beta.0: {}
 
   proc-log@5.0.0: {}
 

--- a/src/components/RightPanel/FilesContent.tsx
+++ b/src/components/RightPanel/FilesContent.tsx
@@ -1,5 +1,14 @@
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { createPortal } from "react-dom";
+import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
+import type {
+  ContextMenuItem as PierreContextMenuItem,
+  ContextMenuOpenContext as PierreContextMenuOpenContext,
+  FileTreeRenameEvent,
+  FileTreeRowDecoration,
+  FileTreeRowDecorationContext,
+  GitStatusEntry as PierreGitStatusEntry,
+} from "@pierre/trees";
 import { useWorktreeFiles } from "../../hooks/useWorktreeFiles";
 import { useGitStatus } from "../../hooks/useGitStatus";
 import { useT } from "../../i18n/useT";
@@ -13,21 +22,25 @@ interface Props {
   onFileClick: (filePath: string) => void;
 }
 
-const MONO_STYLE = { fontFamily: '"Geist Mono", monospace' } as const;
-
-const GIT_STATUS_CONFIG: Record<
-  GitFileStatus,
-  { label: string; color: string }
-> = {
-  M: { label: "M", color: "#e2b93d" },
-  A: { label: "A", color: "#73c991" },
-  D: { label: "D", color: "#e06c75" },
-  R: { label: "R", color: "#73c991" },
-  C: { label: "C", color: "#73c991" },
-  U: { label: "U", color: "#e06c75" },
-  "?": { label: "U", color: "#73c991" },
+// Map our git status codes to @pierre/trees status strings.
+// `@pierre/trees` does not have an explicit "conflict" status, so unmerged
+// (U) is mapped to "deleted" — the most attention-grabbing visual treatment
+// available — to preserve conflict visibility (instead of being lost as a
+// generic "modified" change). Copied (C) maps to "renamed" since both are
+// derived from existing files; "added" would mis-imply a fresh creation.
+const GIT_STATUS_MAP: Record<GitFileStatus, PierreGitStatusEntry["status"]> = {
+  M: "modified",
+  A: "added",
+  D: "deleted",
+  R: "renamed",
+  C: "renamed",
+  U: "deleted",
+  "?": "untracked",
 };
 
+// Lower number = higher priority (mirrors original FilesContent priority order).
+// When a file appears in both staged and unstaged lists, we surface the more
+// alarming status (U > D > M > A > R > C > ?).
 const STATUS_PRIORITY: Record<GitFileStatus, number> = {
   U: 0,
   D: 1,
@@ -38,210 +51,265 @@ const STATUS_PRIORITY: Record<GitFileStatus, number> = {
   "?": 6,
 };
 
-function GitBadge({ status }: { status: GitFileStatus }) {
-  const cfg = GIT_STATUS_CONFIG[status];
-  if (!cfg) return null;
-  return (
-    <span
-      className="ml-auto shrink-0 text-[10px] font-semibold leading-none"
-      style={{ color: cfg.color, ...MONO_STYLE }}
-    >
-      {cfg.label}
-    </span>
-  );
-}
-
-function GitDirDot({ color }: { color: string }) {
-  return (
-    <span className="ml-auto shrink-0 flex items-center justify-center w-[10px]">
-      <span
-        className="block w-[5px] h-[5px] rounded-full"
-        style={{ backgroundColor: color }}
-      />
-    </span>
-  );
-}
-
-function FileIcon({
-  isDirectory,
-  expanded,
-}: {
-  isDirectory: boolean;
-  expanded?: boolean;
-}) {
-  if (isDirectory) {
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 16 16"
-        fill="none"
-        className="shrink-0"
-      >
-        {expanded ? (
-          <path
-            d="M1.5 3.5h4l1.5 1.5h7.5v8h-13z"
-            stroke="var(--accent)"
-            strokeWidth="1.2"
-            fill="rgba(80,227,194,0.1)"
-          />
-        ) : (
-          <path
-            d="M1.5 3.5h4l1.5 1.5h7.5v8h-13z"
-            stroke="var(--text-muted)"
-            strokeWidth="1.2"
-            fill="none"
-          />
-        )}
-      </svg>
-    );
-  }
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      fill="none"
-      className="shrink-0"
-    >
-      <path
-        d="M4 1.5h5l3.5 3.5v9.5h-8.5z"
-        stroke="var(--text-muted)"
-        strokeWidth="1.2"
-        fill="none"
-      />
-      <path
-        d="M9 1.5v3.5h3.5"
-        stroke="var(--text-muted)"
-        strokeWidth="1.2"
-        fill="none"
-      />
-    </svg>
-  );
-}
-
-function InlineInput({
-  defaultValue,
-  depth,
-  isDirectory,
-  onSubmit,
-  onCancel,
-}: {
-  defaultValue: string;
-  depth: number;
-  isDirectory: boolean;
-  onSubmit: (value: string) => void;
-  onCancel: () => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const submitted = useRef(false);
-
-  const commit = () => {
-    if (submitted.current) return;
-    submitted.current = true;
-    const val = inputRef.current?.value.trim();
-    if (val && val !== defaultValue) {
-      onSubmit(val);
-    } else {
-      onCancel();
-    }
-  };
-
-  return (
-    <div
-      className="flex items-center gap-1.5 py-0.5"
-      style={{ paddingLeft: depth * 16 + 12 + 6 + 6, paddingRight: 8 }}
-    >
-      <FileIcon isDirectory={isDirectory} />
-      <input
-        ref={inputRef}
-        autoFocus
-        defaultValue={defaultValue}
-        className="flex-1 bg-[var(--surface-hover)] text-[var(--text-primary)] text-[11px] px-1 py-0.5 rounded border border-[var(--accent)] outline-none min-w-0"
-        style={MONO_STYLE}
-        onFocus={(e) => {
-          // Select name without extension for files
-          if (!isDirectory && defaultValue.includes(".")) {
-            const dotIdx = defaultValue.lastIndexOf(".");
-            e.target.setSelectionRange(0, dotIdx);
-          } else {
-            e.target.select();
-          }
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") commit();
-          if (e.key === "Escape") {
-            submitted.current = true;
-            onCancel();
-          }
-        }}
-        onBlur={commit}
-      />
-    </div>
-  );
-}
+const NEW_ENTRY_PREFIX = "__pierre_new_";
 
 export function FilesContent({ worktreePath, onFileClick }: Props) {
   const t = useT();
-  const { entries, expandedDirs, toggleDir, refreshDir, loading } =
-    useWorktreeFiles(worktreePath);
-  const previewFile = useCanvasStore((s) => s.fileEditorPath);
-
+  const { paths, loading, refresh } = useWorktreeFiles(worktreePath);
   const { changedFiles, stagedFiles } = useGitStatus(worktreePath);
+  const fileEditorPath = useCanvasStore((s) => s.fileEditorPath);
+  const { notify } = useNotificationStore.getState();
 
-  // Build a map of relative path → highest-priority git status
-  const gitStatusMap = useMemo(() => {
-    const map = new Map<string, GitFileStatus>();
+  const pierreGitStatus = useMemo<PierreGitStatusEntry[]>(() => {
+    const statusMap = new Map<string, GitFileStatus>();
     for (const entry of [...changedFiles, ...stagedFiles]) {
-      const existing = map.get(entry.path);
+      const existing = statusMap.get(entry.path);
       if (
         !existing ||
         STATUS_PRIORITY[entry.status] < STATUS_PRIORITY[existing]
       ) {
-        map.set(entry.path, entry.status);
+        statusMap.set(entry.path, entry.status);
       }
     }
-    return map;
+    const result: PierreGitStatusEntry[] = [];
+    for (const [path, status] of statusMap) {
+      const mapped = GIT_STATUS_MAP[status];
+      if (mapped) result.push({ path, status: mapped });
+    }
+    return result;
   }, [changedFiles, stagedFiles]);
 
-  // Precompute folder → highest-priority status among descendants
-  const dirStatusMap = useMemo(() => {
-    const map = new Map<string, GitFileStatus>();
-    for (const [filePath, status] of gitStatusMap) {
-      const parts = filePath.split("/");
-      // Walk each ancestor directory
-      for (let i = 1; i < parts.length; i++) {
-        const dir = parts.slice(0, i).join("/");
-        const existing = map.get(dir);
-        if (!existing || STATUS_PRIORITY[status] < STATUS_PRIORITY[existing]) {
-          map.set(dir, status);
+  const worktreePathRef = useRef(worktreePath);
+  worktreePathRef.current = worktreePath;
+
+  const onFileClickRef = useRef(onFileClick);
+  onFileClickRef.current = onFileClick;
+
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  // Tracks the currently open file (relative to worktreePath) so the row
+  // decoration renderer — which is fixed at model construction — can read the
+  // latest value without being recreated.
+  const openFileRelPathRef = useRef<string | null>(null);
+  openFileRelPathRef.current =
+    fileEditorPath && worktreePath && fileEditorPath.startsWith(worktreePath + "/")
+      ? fileEditorPath.slice(worktreePath.length + 1)
+      : null;
+
+  const pendingCreates = useRef<Map<string, "file" | "folder">>(new Map());
+
+  const handleRename = useCallback(
+    async (event: FileTreeRenameEvent) => {
+      const wtp = worktreePathRef.current;
+      if (!wtp) return;
+
+      const pendingType = pendingCreates.current.get(event.sourcePath);
+      if (pendingType !== undefined) {
+        pendingCreates.current.delete(event.sourcePath);
+        const parts = event.destinationPath.split("/");
+        const name = parts[parts.length - 1];
+        const parentRelPath = parts.slice(0, -1).join("/");
+        const parentAbsPath = parentRelPath ? `${wtp}/${parentRelPath}` : wtp;
+        try {
+          if (pendingType === "folder") {
+            await window.termcanvas.fs.mkdir(parentAbsPath, name);
+          } else {
+            await window.termcanvas.fs.createFile(parentAbsPath, name);
+          }
+        } catch (err) {
+          notify("error", `Create failed: ${err}`);
         }
+        await refreshRef.current();
+        return;
       }
-    }
-    return map;
-  }, [gitStatusMap]);
 
-  const [dropTargetDir, setDropTargetDir] = useState<string | null>(null);
-  const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const autoExpandDir = useRef<string | null>(null);
+      const dstName = event.destinationPath.split("/").pop()!;
+      const srcName = event.sourcePath.split("/").pop()!;
+      if (srcName !== dstName) {
+        try {
+          await window.termcanvas.fs.rename(`${wtp}/${event.sourcePath}`, dstName);
+        } catch (err) {
+          notify("error", `Rename failed: ${err}`);
+        }
+        await refreshRef.current();
+      }
+    },
+    [notify],
+  );
 
-  const [ctxMenu, setCtxMenu] = useState<{
-    x: number;
-    y: number;
-    path: string;
-    isDir: boolean;
-    parentDir: string;
-    name: string;
-  } | null>(null);
+  const modelRef = useRef<ReturnType<typeof useFileTree>["model"] | null>(null);
 
-  const [editing, setEditing] = useState<{
-    type: "rename" | "newFile" | "newFolder";
-    parentDir: string;
-    path: string; // for rename: the full path; for new: the parent dir
-    name: string; // current name (rename) or empty (new)
-  } | null>(null);
+  const handleSelectionChange = useCallback(
+    (selectedPaths: readonly string[]) => {
+      const wtp = worktreePathRef.current;
+      if (!wtp || selectedPaths.length !== 1) return;
+      const relPath = selectedPaths[0];
+      const item = modelRef.current?.getItem(relPath);
+      if (item && !item.isDirectory()) {
+        onFileClickRef.current(`${wtp}/${relPath}`);
+      }
+    },
+    [],
+  );
 
-  const { notify } = useNotificationStore.getState();
+  // Independent open-file marker driven by `fileEditorPath` (not by selection).
+  // Returns a small bullet decoration on the row currently open in the file
+  // editor; selection state is unaffected by clicks elsewhere in the tree.
+  const renderRowDecoration = useCallback(
+    (context: FileTreeRowDecorationContext): FileTreeRowDecoration | null => {
+      const openRel = openFileRelPathRef.current;
+      if (openRel != null && context.item.path === openRel) {
+        return { text: "●", title: "Open in editor" };
+      }
+      return null;
+    },
+    [],
+  );
+
+  const { model } = useFileTree({
+    paths: [],
+    initialExpansion: "closed",
+    search: true,
+    onSelectionChange: handleSelectionChange,
+    renderRowDecoration,
+    renaming: {
+      onRename: handleRename,
+    },
+    composition: {
+      contextMenu: {
+        enabled: true,
+        triggerMode: "right-click",
+      },
+    },
+    // Native row drag enabled (so files can be dragged out to terminals);
+    // disable drop so the library does not reorder paths internally.
+    dragAndDrop: {
+      canDrop: () => false,
+    },
+  });
+
+  modelRef.current = model;
+
+  useEffect(() => {
+    model.resetPaths(paths);
+  }, [model, paths]);
+
+  useEffect(() => {
+    model.setGitStatus(pierreGitStatus);
+  }, [model, pierreGitStatus]);
+
+  // Force the tree to re-render visible rows when the open-file path changes
+  // so renderRowDecoration is re-invoked. setIcons is the cheapest no-op
+  // mutation: we never set icons, so passing undefined preserves state while
+  // the implementation always calls renderFileTreeRoot afterwards.
+  useEffect(() => {
+    model.setIcons(undefined);
+  }, [model, fileEditorPath, worktreePath]);
+
+  const buildMenuItems = useCallback(
+    (
+      item: PierreContextMenuItem,
+      context: PierreContextMenuOpenContext,
+    ): MenuItem[] => {
+      const wtp = worktreePathRef.current;
+      if (!wtp) return [];
+
+      const isRoot = !item.path || item.path === "." || item.path === "";
+      const isDir = item.kind === "directory";
+      const targetDir = isDir
+        ? item.path
+        : item.path.split("/").slice(0, -1).join("/");
+      const name = item.name;
+
+      const startCreate = (type: "file" | "folder") => {
+        context.close();
+        const tempName = `${NEW_ENTRY_PREFIX}${Date.now()}`;
+        const tempRelPath = targetDir ? `${targetDir}/${tempName}` : tempName;
+        pendingCreates.current.set(tempRelPath, type);
+        model.add(tempRelPath);
+        if (isDir) {
+          const dirHandle = model.getItem(item.path);
+          if (dirHandle?.isDirectory()) {
+            (dirHandle as { expand(): void }).expand();
+          }
+        }
+        model.startRenaming(tempRelPath, { removeIfCanceled: true });
+      };
+
+      const items: MenuItem[] = [
+        { label: t.ctx_new_file, onClick: () => startCreate("file") },
+        { label: t.ctx_new_folder, onClick: () => startCreate("folder") },
+      ];
+
+      if (!isRoot) {
+        items.push(
+          { type: "separator" },
+          {
+            label: t.ctx_rename,
+            onClick: () => {
+              context.close();
+              model.startRenaming(item.path);
+            },
+          },
+          {
+            label: t.ctx_delete,
+            danger: true,
+            onClick: () => {
+              context.close();
+              if (!window.confirm(t.ctx_confirm_delete(name))) return;
+              window.termcanvas.fs
+                .delete(`${wtp}/${item.path}`)
+                .then(() => refreshRef.current())
+                .catch((err) => notify("error", `Delete failed: ${err}`));
+            },
+          },
+        );
+      }
+
+      items.push(
+        { type: "separator" },
+        {
+          label: t.ctx_copy_path,
+          onClick: () => {
+            context.close();
+            navigator.clipboard.writeText(item.path);
+          },
+        },
+        {
+          label: t.ctx_reveal(window.termcanvas?.app.platform ?? "darwin"),
+          onClick: () => {
+            context.close();
+            window.termcanvas.fs.reveal(
+              item.path ? `${wtp}/${item.path}` : wtp,
+            );
+          },
+        },
+      );
+
+      return items;
+    },
+    [t, model, notify],
+  );
+
+  const renderContextMenu = useCallback(
+    (item: PierreContextMenuItem, context: PierreContextMenuOpenContext) => {
+      const menuItems = buildMenuItems(item, context);
+      const rect = context.anchorRect;
+      return createPortal(
+        <ContextMenu
+          x={rect.x}
+          y={rect.y + rect.height}
+          items={menuItems}
+          onClose={() => context.close()}
+        />,
+        document.body,
+      );
+    },
+    [buildMenuItems],
+  );
+
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const isOsDrag = useCallback((e: React.DragEvent) => {
     const types = Array.from(e.dataTransfer.types);
@@ -251,388 +319,78 @@ export function FilesContent({ worktreePath, onFileClick }: Props) {
     );
   }, []);
 
-  const handleDirDragOver = useCallback(
-    (e: React.DragEvent, dirPath: string, isDir?: boolean) => {
+  const handleDrop = useCallback(
+    async (e: React.DragEvent) => {
       e.preventDefault();
-      e.stopPropagation();
-      e.dataTransfer.dropEffect = "copy";
-      if (isOsDrag(e)) {
-        setDropTargetDir(dirPath);
-        if (
-          isDir &&
-          !expandedDirs.has(dirPath) &&
-          autoExpandDir.current !== dirPath
-        ) {
-          if (autoExpandTimer.current) clearTimeout(autoExpandTimer.current);
-          autoExpandDir.current = dirPath;
-          autoExpandTimer.current = setTimeout(() => {
-            toggleDir(dirPath);
-            autoExpandTimer.current = null;
-            autoExpandDir.current = null;
-          }, 500);
-        }
-      }
-    },
-    [isOsDrag, expandedDirs, toggleDir],
-  );
-
-  const handleDirDragLeave = useCallback((e: React.DragEvent) => {
-    e.stopPropagation();
-    setDropTargetDir(null);
-    if (autoExpandTimer.current) {
-      clearTimeout(autoExpandTimer.current);
-      autoExpandTimer.current = null;
-      autoExpandDir.current = null;
-    }
-  }, []);
-
-  const handleDirDrop = useCallback(
-    async (e: React.DragEvent, dirPath: string) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setDropTargetDir(null);
-      if (autoExpandTimer.current) {
-        clearTimeout(autoExpandTimer.current);
-        autoExpandTimer.current = null;
-        autoExpandDir.current = null;
-      }
-
-      if (!isOsDrag(e)) return;
-
+      setIsDragOver(false);
+      if (!worktreePath || !isOsDrag(e)) return;
       const files = Array.from(e.dataTransfer.files);
       if (files.length === 0) return;
-
-      const sources: string[] = files
+      const sources = files
         .map((f) => window.termcanvas.fs.getFilePath(f))
         .filter(Boolean);
       if (sources.length === 0) return;
-
       try {
-        const result = await window.termcanvas.fs.copy(sources, dirPath);
-        refreshDir(dirPath);
-
+        const result = await window.termcanvas.fs.copy(sources, worktreePath);
+        await refresh();
         if (result.skipped.length > 0) {
-          const { notify } = useNotificationStore.getState();
-          notify(
-            "warn",
-            `Skipped (already exist): ${result.skipped.join(", ")}`,
-          );
+          notify("warn", `Skipped (already exist): ${result.skipped.join(", ")}`);
         }
       } catch (err) {
-        console.error("[FilesContent] copy failed", err);
-        const { notify } = useNotificationStore.getState();
         notify("error", `Copy failed: ${err}`);
       }
     },
-    [isOsDrag, refreshDir],
+    [worktreePath, isOsDrag, refresh, notify],
   );
 
-  const handleContextMenu = useCallback(
-    (
-      e: React.MouseEvent,
-      fullPath: string,
-      isDir: boolean,
-      parentDir: string,
-      name: string,
-    ) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setCtxMenu({
-        x: e.clientX,
-        y: e.clientY,
-        path: fullPath,
-        isDir,
-        parentDir,
-        name,
-      });
-    },
-    [],
-  );
+  // Container ref for capturing native dragstart events that bubble out of
+  // the @pierre/trees shadow DOM. The library sets `text/plain` to the row's
+  // relative path; in bubble phase we override with absolute paths and add
+  // our own `application/x-termcanvas-file` payload so terminal cards can
+  // accept the drop. When the dragged row is part of the model's selection,
+  // we serialize the entire selection (newline-separated) — matching the
+  // library's own multi-select drag semantics.
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e: DragEvent) => {
+      const wtp = worktreePathRef.current;
+      const m = modelRef.current;
+      if (!wtp || !e.dataTransfer || !m) return;
 
-  const handleRename = useCallback(
-    async (oldPath: string, newName: string, parentDir: string) => {
-      try {
-        await window.termcanvas.fs.rename(oldPath, newName);
-        refreshDir(parentDir);
-      } catch (err) {
-        notify("error", `Rename failed: ${err}`);
+      // Find the dragged row's path from composedPath (events bubble out of
+      // the shadow DOM but their target is retargeted to the host).
+      let originPath: string | null = null;
+      for (const node of e.composedPath()) {
+        if (!(node instanceof HTMLElement)) continue;
+        const itemPath = node.getAttribute("data-item-path");
+        if (itemPath != null) {
+          originPath = itemPath;
+          break;
+        }
       }
-      setEditing(null);
-    },
-    [refreshDir, notify],
-  );
+      if (originPath == null) return;
 
-  const handleNewFile = useCallback(
-    async (parentDir: string, name: string) => {
+      // If the drag origin is part of the current selection, drag the whole
+      // selection set; otherwise drag just the origin row. This mirrors the
+      // library's own resolveDraggedPathsForStart logic.
+      const selected = m.getSelectedPaths();
+      const draggedRelPaths = selected.includes(originPath)
+        ? Array.from(selected)
+        : [originPath];
+      const absPaths = draggedRelPaths.map((p) => `${wtp}/${p}`);
+      const serialized = absPaths.join("\n");
+
       try {
-        await window.termcanvas.fs.createFile(parentDir, name);
-        refreshDir(parentDir);
-      } catch (err) {
-        notify("error", `Create file failed: ${err}`);
-      }
-      setEditing(null);
-    },
-    [refreshDir, notify],
-  );
-
-  const handleNewFolder = useCallback(
-    async (parentDir: string, name: string) => {
-      try {
-        await window.termcanvas.fs.mkdir(parentDir, name);
-        refreshDir(parentDir);
-      } catch (err) {
-        notify("error", `Create folder failed: ${err}`);
-      }
-      setEditing(null);
-    },
-    [refreshDir, notify],
-  );
-
-  const handleDelete = useCallback(
-    async (targetPath: string, parentDir: string) => {
-      try {
-        await window.termcanvas.fs.delete(targetPath);
-        refreshDir(parentDir);
-      } catch (err) {
-        notify("error", `Delete failed: ${err}`);
-      }
-    },
-    [refreshDir, notify],
-  );
-
-  const buildMenuItems = useCallback((): MenuItem[] => {
-    if (!ctxMenu) return [];
-    const { path: filePath, isDir, parentDir, name } = ctxMenu;
-    const targetDir = isDir ? filePath : parentDir;
-    const isRoot = filePath === worktreePath;
-
-    const items: MenuItem[] = [
-      {
-        label: t.ctx_new_file,
-        onClick: () => {
-          if (isDir && !expandedDirs.has(filePath)) toggleDir(filePath);
-          setEditing({
-            type: "newFile",
-            parentDir: targetDir,
-            path: targetDir,
-            name: "",
-          });
-        },
-      },
-      {
-        label: t.ctx_new_folder,
-        onClick: () => {
-          if (isDir && !expandedDirs.has(filePath)) toggleDir(filePath);
-          setEditing({
-            type: "newFolder",
-            parentDir: targetDir,
-            path: targetDir,
-            name: "",
-          });
-        },
-      },
-    ];
-
-    if (!isRoot) {
-      items.push(
-        { type: "separator" },
-        {
-          label: t.ctx_rename,
-          onClick: () => {
-            setEditing({ type: "rename", parentDir, path: filePath, name });
-          },
-        },
-        {
-          label: t.ctx_delete,
-          danger: true,
-          onClick: () => {
-            if (window.confirm(t.ctx_confirm_delete(name))) {
-              handleDelete(filePath, parentDir);
-            }
-          },
-        },
-      );
-    }
-
-    items.push(
-      { type: "separator" },
-      {
-        label: t.ctx_copy_path,
-        onClick: () => {
-          navigator.clipboard.writeText(filePath);
-        },
-      },
-      {
-        label: t.ctx_reveal(window.termcanvas?.app.platform ?? "darwin"),
-        onClick: () => {
-          window.termcanvas.fs.reveal(filePath);
-        },
-      },
-    );
-
-    return items;
-  }, [ctxMenu, worktreePath, t, expandedDirs, toggleDir, handleDelete]);
-
-  const renderEntries = (dirPath: string, depth: number): React.ReactNode => {
-    const items = entries.get(dirPath);
-    if (!items) return null;
-
-    const nodes: React.ReactNode[] = [];
-
-    if (
-      editing &&
-      (editing.type === "newFile" || editing.type === "newFolder") &&
-      editing.parentDir === dirPath
-    ) {
-      nodes.push(
-        <InlineInput
-          key="__new__"
-          defaultValue=""
-          depth={depth + (dirPath === worktreePath ? 0 : 1)}
-          isDirectory={editing.type === "newFolder"}
-          onSubmit={(val) =>
-            editing.type === "newFile"
-              ? handleNewFile(dirPath, val)
-              : handleNewFolder(dirPath, val)
-          }
-          onCancel={() => setEditing(null)}
-        />,
-      );
-    }
-
-    if (items.length === 0 && nodes.length === 0) {
-      return [
-        <div
-          key="empty"
-          className="text-[var(--text-muted)] text-[11px] py-1"
-          style={{ ...MONO_STYLE, paddingLeft: depth * 16 + 16 }}
-        >
-          {t.file_empty_dir}
-        </div>,
-      ];
-    }
-
-    for (const entry of items) {
-      const fullPath = `${dirPath}/${entry.name}`;
-      const isExpanded = expandedDirs.has(fullPath);
-      const isSelected = !entry.isDirectory && fullPath === previewFile;
-      const isRenaming =
-        editing?.type === "rename" && editing.path === fullPath;
-
-      const relPath = worktreePath
-        ? fullPath.slice(worktreePath.length + 1)
-        : "";
-      const fileStatus = entry.isDirectory ? null : gitStatusMap.get(relPath);
-      const dirStatus = entry.isDirectory
-        ? (dirStatusMap.get(relPath) ?? null)
-        : null;
-      const nameColor = fileStatus
-        ? GIT_STATUS_CONFIG[fileStatus]?.color
-        : undefined;
-
-      nodes.push(
-        <div key={fullPath}>
-          {isRenaming ? (
-            <InlineInput
-              defaultValue={entry.name}
-              depth={depth}
-              isDirectory={entry.isDirectory}
-              onSubmit={(val) => handleRename(fullPath, val, dirPath)}
-              onCancel={() => setEditing(null)}
-            />
-          ) : (
-            <button
-              draggable
-              onDragStart={(e) => {
-                e.dataTransfer.setData("text/plain", fullPath);
-                e.dataTransfer.setData(
-                  "application/x-termcanvas-file",
-                  fullPath,
-                );
-                e.dataTransfer.effectAllowed = "copy";
-              }}
-              onDragOver={(e) =>
-                handleDirDragOver(
-                  e,
-                  entry.isDirectory ? fullPath : dirPath,
-                  entry.isDirectory,
-                )
-              }
-              onDragLeave={handleDirDragLeave}
-              onDrop={(e) =>
-                handleDirDrop(e, entry.isDirectory ? fullPath : dirPath)
-              }
-              onContextMenu={(e) =>
-                handleContextMenu(
-                  e,
-                  fullPath,
-                  entry.isDirectory,
-                  dirPath,
-                  entry.name,
-                )
-              }
-              className={`w-full flex items-center gap-1.5 py-1 transition-colors duration-150 text-left ${
-                dropTargetDir === fullPath
-                  ? "bg-[rgba(80,227,194,0.15)] border-l-2 border-[var(--accent)]"
-                  : isSelected
-                    ? "bg-[var(--surface-hover)] border-l-2 border-[var(--accent)]"
-                    : "hover:bg-[var(--surface-hover)] border-l-2 border-transparent"
-              }`}
-              style={{ paddingLeft: depth * 16 + 12, paddingRight: 8 }}
-              onClick={() => {
-                if (entry.isDirectory) {
-                  toggleDir(fullPath);
-                } else {
-                  onFileClick(fullPath);
-                }
-              }}
-            >
-              {entry.isDirectory ? (
-                <svg
-                  width="6"
-                  height="6"
-                  viewBox="0 0 6 6"
-                  fill="none"
-                  className={`shrink-0 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`}
-                >
-                  <path
-                    d="M1.5 0.5L4.5 3L1.5 5.5"
-                    stroke="var(--text-muted)"
-                    strokeWidth="1"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              ) : (
-                <span className="w-[6px] shrink-0" />
-              )}
-              <FileIcon isDirectory={entry.isDirectory} expanded={isExpanded} />
-              <span
-                className={`truncate text-[11px] ${entry.isDirectory ? "font-medium text-[var(--text-primary)]" : "text-[var(--text-primary)]"}`}
-                style={{
-                  ...MONO_STYLE,
-                  ...(nameColor ? { color: nameColor } : undefined),
-                }}
-              >
-                {entry.name}
-              </span>
-              {fileStatus && <GitBadge status={fileStatus} />}
-              {dirStatus && (
-                <GitDirDot
-                  color={GIT_STATUS_CONFIG[dirStatus]?.color ?? "#7a7773"}
-                />
-              )}
-            </button>
-          )}
-          {entry.isDirectory &&
-            isExpanded &&
-            renderEntries(fullPath, depth + 1)}
-        </div>,
-      );
-    }
-
-    return nodes;
-  };
+        e.dataTransfer.setData("text/plain", serialized);
+        e.dataTransfer.setData("application/x-termcanvas-file", serialized);
+        e.dataTransfer.effectAllowed = "copy";
+      } catch {}
+    };
+    el.addEventListener("dragstart", handler);
+    return () => el.removeEventListener("dragstart", handler);
+  }, []);
 
   if (!worktreePath) {
     return (
@@ -647,51 +405,31 @@ export function FilesContent({ worktreePath, onFileClick }: Props) {
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center">
-        <span className="text-[var(--text-muted)] text-[11px]">
-          {t.loading}
-        </span>
+        <span className="text-[var(--text-muted)] text-[11px]">{t.loading}</span>
       </div>
     );
   }
 
   return (
     <div
-      className={`flex-1 overflow-auto min-h-0 pt-1 ${dropTargetDir === worktreePath ? "ring-1 ring-[var(--accent)]" : ""}`}
-      style={{ ...MONO_STYLE, fontSize: 11 }}
+      ref={containerRef}
+      className={`flex-1 min-h-0 flex flex-col ${isDragOver ? "ring-1 ring-[var(--accent)]" : ""}`}
       onDragOver={(e) => {
+        if (!isOsDrag(e)) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = "copy";
-        if (isOsDrag(e) && !dropTargetDir) setDropTargetDir(worktreePath);
+        setIsDragOver(true);
       }}
       onDragLeave={(e) => {
-        if (e.currentTarget === e.target) setDropTargetDir(null);
+        if (e.currentTarget === e.target) setIsDragOver(false);
       }}
-      onDrop={(e) => handleDirDrop(e, worktreePath!)}
-      onContextMenu={(e) => {
-        if (e.target === e.currentTarget) {
-          e.preventDefault();
-          setCtxMenu({
-            x: e.clientX,
-            y: e.clientY,
-            path: worktreePath,
-            isDir: true,
-            parentDir: worktreePath,
-            name: worktreePath.split("/").pop() || "",
-          });
-        }
-      }}
+      onDrop={handleDrop}
     >
-      {renderEntries(worktreePath, 0)}
-      {ctxMenu &&
-        createPortal(
-          <ContextMenu
-            x={ctxMenu.x}
-            y={ctxMenu.y}
-            items={buildMenuItems()}
-            onClose={() => setCtxMenu(null)}
-          />,
-          document.body,
-        )}
+      <PierreFileTree
+        model={model}
+        renderContextMenu={renderContextMenu}
+        style={{ flex: 1, minHeight: 0 }}
+      />
     </div>
   );
 }

--- a/src/components/RightPanel/FilesContent.tsx
+++ b/src/components/RightPanel/FilesContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
 import type {
@@ -428,7 +428,30 @@ export function FilesContent({ worktreePath, onFileClick }: Props) {
       <PierreFileTree
         model={model}
         renderContextMenu={renderContextMenu}
-        style={{ flex: 1, minHeight: 0 }}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          // Map TermCanvas CSS variables into @pierre/trees shadow DOM via
+          // inherited custom properties.
+          ["--trees-theme-sidebar-bg" as string]: "var(--surface)",
+          ["--trees-theme-sidebar-fg" as string]: "var(--text-primary)",
+          ["--trees-theme-sidebar-header-fg" as string]: "var(--text-secondary)",
+          ["--trees-theme-sidebar-border" as string]: "var(--border)",
+          ["--trees-theme-list-hover-bg" as string]: "var(--surface-hover)",
+          ["--trees-theme-list-active-selection-bg" as string]: "var(--accent-soft)",
+          ["--trees-theme-list-active-selection-fg" as string]: "var(--text-primary)",
+          ["--trees-theme-focus-ring" as string]: "var(--accent)",
+          ["--trees-theme-input-bg" as string]: "var(--sidebar)",
+          ["--trees-theme-input-border" as string]: "var(--border)",
+          ["--trees-theme-input-fg" as string]: "var(--text-primary)",
+          ["--trees-theme-scrollbar-thumb" as string]: "var(--border-hover)",
+          ["--trees-theme-git-added-fg" as string]: "var(--cyan)",
+          ["--trees-theme-git-modified-fg" as string]: "var(--amber)",
+          ["--trees-theme-git-deleted-fg" as string]: "var(--red)",
+          ["--trees-theme-git-renamed-fg" as string]: "var(--amber)",
+          ["--trees-theme-git-untracked-fg" as string]: "var(--text-secondary)",
+          ["--trees-theme-git-ignored-fg" as string]: "var(--text-faint)",
+        } as React.CSSProperties}
       />
     </div>
   );

--- a/src/components/RightPanel/FilesContent.tsx
+++ b/src/components/RightPanel/FilesContent.tsx
@@ -273,7 +273,7 @@ export function FilesContent({ worktreePath, onFileClick }: Props) {
           label: t.ctx_copy_path,
           onClick: () => {
             context.close();
-            navigator.clipboard.writeText(item.path);
+            navigator.clipboard.writeText(item.path ? `${wtp}/${item.path}` : wtp);
           },
         },
         {

--- a/src/hooks/useWorktreeFiles.ts
+++ b/src/hooks/useWorktreeFiles.ts
@@ -1,70 +1,61 @@
-import { useState, useEffect, useCallback } from "react";
-
-export interface DirEntry {
-  name: string;
-  isDirectory: boolean;
-}
+import { useState, useEffect, useCallback, useRef } from "react";
 
 export function useWorktreeFiles(worktreePath: string | null) {
-  const [entries, setEntries] = useState<Map<string, DirEntry[]>>(new Map());
-  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
+  const [paths, setPaths] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
+  // Monotonic load id; bumping it invalidates any in-flight load
+  const loadIdRef = useRef(0);
+
+  const loadFiles = useCallback(async () => {
+    if (!worktreePath || !window.termcanvas) return;
+    const myId = ++loadIdRef.current;
+    try {
+      const result = await window.termcanvas.fs.listAllFiles(worktreePath);
+      if (loadIdRef.current !== myId) return;
+      setPaths(result.paths);
+    } catch {
+      if (loadIdRef.current !== myId) return;
+      setPaths([]);
+    } finally {
+      if (loadIdRef.current === myId) setLoading(false);
+    }
+  }, [worktreePath]);
 
   useEffect(() => {
     if (!worktreePath || !window.termcanvas) {
-      setEntries(new Map());
+      // Invalidate any in-flight load before resetting state
+      loadIdRef.current++;
+      setPaths([]);
       setLoading(false);
       return;
     }
 
-    window.termcanvas.fs.unwatchAllDirs();
-
     setLoading(true);
-    window.termcanvas.fs.listDir(worktreePath).then((items) => {
-      setEntries(new Map([[worktreePath, items]]));
-      setLoading(false);
+    loadFiles();
+
+    window.termcanvas.fs.watchDir(worktreePath);
+    const unsubFs = window.termcanvas.fs.onDirChanged(() => {
+      loadFiles();
+    });
+
+    // git emit may carry the worktree root or a subdirectory path; accept both
+    const unsubGit = window.termcanvas.git.onChanged((changedPath: string) => {
+      if (
+        changedPath === worktreePath ||
+        changedPath.startsWith(worktreePath + "/")
+      ) {
+        loadFiles();
+      }
     });
 
     return () => {
-      window.termcanvas.fs.unwatchAllDirs();
+      // Invalidate any in-flight load so it doesn't setState after unmount
+      loadIdRef.current++;
+      window.termcanvas.fs.unwatchDir(worktreePath);
+      unsubFs();
+      unsubGit();
     };
-  }, [worktreePath]);
+  }, [worktreePath, loadFiles]);
 
-  const refreshDir = useCallback(
-    (dirPath: string) => {
-      window.termcanvas.fs.listDir(dirPath).then((items) => {
-        setEntries((prev) => new Map(prev).set(dirPath, items));
-      });
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (!window.termcanvas) return;
-    return window.termcanvas.fs.onDirChanged(refreshDir);
-  }, [refreshDir]);
-
-  const toggleDir = useCallback(
-    (dirPath: string) => {
-      setExpandedDirs((prev) => {
-        const next = new Set(prev);
-        if (next.has(dirPath)) {
-          next.delete(dirPath);
-          window.termcanvas.fs.unwatchDir(dirPath);
-        } else {
-          next.add(dirPath);
-          window.termcanvas.fs.watchDir(dirPath);
-          if (!entries.has(dirPath)) {
-            window.termcanvas.fs.listDir(dirPath).then((items) => {
-              setEntries((prev) => new Map(prev).set(dirPath, items));
-            });
-          }
-        }
-        return next;
-      });
-    },
-    [entries]
-  );
-
-  return { entries, expandedDirs, toggleDir, refreshDir, loading };
+  return { paths, loading, refresh: loadFiles };
 }

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -829,13 +829,13 @@ export function TerminalTile({
       e.stopPropagation();
       setDragOver(false);
 
-      const filePath = e.dataTransfer?.getData("text/plain");
-      if (!filePath) return;
+      const rawPath = e.dataTransfer?.getData("text/plain");
+      if (!rawPath) return;
 
       const ptyId = getTerminalPtyId(terminal.id);
       if (ptyId === null) return;
 
-      const escaped = shellEscapePath(filePath);
+      const escaped = rawPath.split("\n").filter(Boolean).map(shellEscapePath).join(" ");
       window.termcanvas.terminal.input(ptyId, " " + escaped);
       activateTerminalInScene(projectId, worktreeId, terminal.id);
     };
@@ -898,13 +898,13 @@ export function TerminalTile({
       e.stopPropagation();
       setDragOver(false);
 
-      const filePath = e.dataTransfer.getData("text/plain");
-      if (!filePath) return;
+      const rawPath = e.dataTransfer.getData("text/plain");
+      if (!rawPath) return;
 
       const ptyId = getTerminalPtyId(terminal.id);
       if (ptyId === null) return;
 
-      const escaped = shellEscapePath(filePath);
+      const escaped = rawPath.split("\n").filter(Boolean).map(shellEscapePath).join(" ");
       window.termcanvas.terminal.input(ptyId, " " + escaped);
       activateTerminalInScene(projectId, worktreeId, terminal.id);
     },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -782,6 +782,9 @@ export interface TermCanvasAPI {
     listDir: (
       dirPath: string,
     ) => Promise<{ name: string; isDirectory: boolean }[]>;
+    listAllFiles: (
+      dirPath: string,
+    ) => Promise<{ type: "git" | "dir"; paths: string[] }>;
     readFile: (
       filePath: string,
     ) => Promise<


### PR DESCRIPTION
## Summary

- Replace hand-rolled recursive file tree renderer with `@pierre/trees`, gaining virtualized rendering, built-in search, and git status display
- Rewrite data layer: `git ls-files --cached --others --exclude-standard` replaces per-directory `listDir` calls; single recursive root watcher replaces expand/collapse watcher management
- Non-git directory fallback uses recursive `fs.readdirSync` with symlink cycle detection and empty directory emission
- Open-file marker decoupled from selection state via `renderRowDecoration`
- Fix multi-select drag to pass all selected paths to terminal drop handler
- Apply TermCanvas dark theme via CSS variable mapping through shadow DOM boundary
- Fix Copy Path context menu to write absolute filesystem path

## Test plan

- [ ] File tree renders in right panel for a git repo
- [ ] File tree renders for a non-git directory
- [ ] Built-in search filters file list
- [ ] Git status badges appear on modified/added/deleted/untracked files
- [ ] Right-click context menu: New File, New Folder, Rename, Delete, Copy Path, Reveal all work
- [ ] Copy Path writes absolute path to clipboard
- [ ] Inline rename creates/renames file on disk
- [ ] Drag a single file from tree onto a terminal — correct path pasted
- [ ] Multi-select files, drag onto terminal — all paths pasted space-separated
- [ ] Open a file via terminal command; verify tree highlights it via decoration marker
- [ ] Click a folder — open-file marker stays on the open file
- [ ] File changes in terminal (touch, rm) cause tree to refresh automatically
- [ ] Newly created folder appears immediately in tree (empty directory support)
- [ ] Theme matches app dark theme (no white background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)