### PR TITLE
feat(app): keep app alive on macOS when last window closes

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2473,6 +2473,18 @@ app.on("will-quit", (event) => {
   })();
 });
 
+// macOS convention: keep the process alive in the dock when the last window
+// closes; the `activate` handler above re-creates a window when the user
+// clicks the dock icon. Other platforms still quit. The preference is set
+// from the renderer via `app:set-quit-on-last-window-closed` and lets the
+// user opt out of the macOS behavior.
+let quitOnLastWindowClosed = false;
+ipcMain.on("app:set-quit-on-last-window-closed", (_event, value: unknown) => {
+  quitOnLastWindowClosed = value === true;
+});
+
 app.on("window-all-closed", () => {
-  app.quit();
+  if (process.platform !== "darwin" || quitOnLastWindowClosed) {
+    app.quit();
+  }
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -808,6 +808,8 @@ contextBridge.exposeInMainWorld("termcanvas", {
     homePath: process.env.HOME ?? process.env.USERPROFILE ?? "",
     platform: process.platform as "darwin" | "win32" | "linux",
     requestClose: () => ipcRenderer.send("app:request-close"),
+    setQuitOnLastWindowClosed: (value: boolean) =>
+      ipcRenderer.send("app:set-quit-on-last-window-closed", value),
   },
   updater: {
     check: () => ipcRenderer.invoke("updater:check"),

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -764,6 +764,8 @@ export function SettingsModal({ onClose }: Props) {
     setCompletionGlowEnabled,
     trackpadSwipeFocusEnabled,
     setTrackpadSwipeFocusEnabled,
+    quitOnLastWindowClosed,
+    setQuitOnLastWindowClosed,
     summaryCli,
     setSummaryCli,
     minimumContrastRatio,
@@ -1090,6 +1092,18 @@ export function SettingsModal({ onClose }: Props) {
                           on: cliLoading || effectiveCliRegistered === true,
                           off: cliLoading || effectiveCliRegistered === false,
                         }}
+                      />
+                    </SettingsRow>
+                  )}
+
+                  {isMac && (
+                    <SettingsRow
+                      label={t.quit_on_last_window_closed_toggle}
+                      description={t.quit_on_last_window_closed_toggle_desc}
+                    >
+                      <OnOffSegment
+                        value={quitOnLastWindowClosed}
+                        onChange={setQuitOnLastWindowClosed}
                       />
                     </SettingsRow>
                   )}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -374,6 +374,9 @@ export const en = {
   trackpad_swipe_focus_toggle: "Trackpad swipe to toggle focus",
   trackpad_swipe_focus_toggle_desc:
     "Experimental. Two-finger horizontal swipe on canvas to toggle between zoom-focus and fit-all view",
+  quit_on_last_window_closed_toggle: "Quit when last window closes",
+  quit_on_last_window_closed_toggle_desc:
+    "Off by default — TermCanvas stays in the dock when the last window closes, click the dock icon to open a new one. Turn on to quit instead.",
   summary_toggle: "Terminal auto-summary",
   summary_toggle_desc:
     "Experimental. AI-generated one-line summaries for CLI terminals. May increase token usage.",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -365,6 +365,9 @@ export const zh = {
   trackpad_swipe_focus_toggle: "触控板滑动切换聚焦",
   trackpad_swipe_focus_toggle_desc:
     "实验性功能。在画布上使用双指横向滑动，在聚焦终端和全景视图之间切换",
+  quit_on_last_window_closed_toggle: "关闭最后一个窗口时退出",
+  quit_on_last_window_closed_toggle_desc:
+    "默认关闭。关闭最后一个窗口时，TermCanvas 仍保留在 Dock 中，点击 Dock 图标可打开新窗口。开启则直接退出应用。",
   summary_toggle: "终端自动摘要",
   summary_toggle_desc:
     "实验性功能。为 CLI 终端自动生成一行 AI 摘要，可能增加 token 用量",

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -34,6 +34,7 @@ interface PreferencesStore {
   completionGlowEnabled: boolean;
   activityHeatmapEnabled: boolean;
   trackpadSwipeFocusEnabled: boolean;
+  quitOnLastWindowClosed: boolean;
   summaryCli: "claude" | "codex";
   minimumContrastRatio: number;
   cliCommands: Partial<Record<TerminalType, CliCommandConfig>>;
@@ -72,6 +73,7 @@ interface PreferencesStore {
   setCompletionGlowEnabled: (value: boolean) => void;
   setActivityHeatmapEnabled: (value: boolean) => void;
   setTrackpadSwipeFocusEnabled: (value: boolean) => void;
+  setQuitOnLastWindowClosed: (value: boolean) => void;
   setSummaryCli: (value: "claude" | "codex") => void;
   setCli: (type: TerminalType, config: CliCommandConfig | null) => void;
   setAgentConfig: (config: AgentProviderConfig) => void;
@@ -98,6 +100,7 @@ interface SavedPrefs {
   completionGlowEnabled: boolean;
   activityHeatmapEnabled: boolean;
   trackpadSwipeFocusEnabled: boolean;
+  quitOnLastWindowClosed: boolean;
   summaryCli: "claude" | "codex";
   minimumContrastRatio: number;
   cliCommands: Partial<Record<TerminalType, CliCommandConfig>>;
@@ -223,6 +226,9 @@ function loadPreferences(): SavedPrefs {
       let trackpadSwipeFocusEnabled = false;
       if (parsed.trackpadSwipeFocusEnabled === true) trackpadSwipeFocusEnabled = true;
 
+      let quitOnLastWindowClosed = false;
+      if (parsed.quitOnLastWindowClosed === true) quitOnLastWindowClosed = true;
+
       let summaryCli: "claude" | "codex" = "claude";
       if (parsed.summaryCli === "codex") summaryCli = "codex";
 
@@ -259,6 +265,7 @@ function loadPreferences(): SavedPrefs {
         completionGlowEnabled,
         activityHeatmapEnabled,
         trackpadSwipeFocusEnabled,
+        quitOnLastWindowClosed,
         summaryCli,
         minimumContrastRatio,
         cliCommands,
@@ -283,6 +290,7 @@ function loadPreferences(): SavedPrefs {
     completionGlowEnabled: false,
     activityHeatmapEnabled: false,
     trackpadSwipeFocusEnabled: false,
+    quitOnLastWindowClosed: false,
     summaryCli: "claude",
     minimumContrastRatio: DEFAULT_MIN_CONTRAST,
     cliCommands: {},
@@ -387,6 +395,7 @@ function getSaveState(state: PreferencesStore): SavedPrefs {
     completionGlowEnabled: state.completionGlowEnabled,
     activityHeatmapEnabled: state.activityHeatmapEnabled,
     trackpadSwipeFocusEnabled: state.trackpadSwipeFocusEnabled,
+    quitOnLastWindowClosed: state.quitOnLastWindowClosed,
     summaryCli: state.summaryCli,
     minimumContrastRatio: state.minimumContrastRatio,
     cliCommands: state.cliCommands,
@@ -412,6 +421,7 @@ export const usePreferencesStore = create<PreferencesStore>((set, get) => ({
   completionGlowEnabled: initialPrefs.completionGlowEnabled,
   activityHeatmapEnabled: initialPrefs.activityHeatmapEnabled,
   trackpadSwipeFocusEnabled: initialPrefs.trackpadSwipeFocusEnabled,
+  quitOnLastWindowClosed: initialPrefs.quitOnLastWindowClosed,
   summaryCli: initialPrefs.summaryCli,
   minimumContrastRatio: initialPrefs.minimumContrastRatio,
   cliCommands: initialPrefs.cliCommands,
@@ -479,6 +489,11 @@ export const usePreferencesStore = create<PreferencesStore>((set, get) => ({
     set({ trackpadSwipeFocusEnabled: value });
     savePreferences(getSaveState({ ...get(), trackpadSwipeFocusEnabled: value }));
   },
+  setQuitOnLastWindowClosed: (value) => {
+    set({ quitOnLastWindowClosed: value });
+    savePreferences(getSaveState({ ...get(), quitOnLastWindowClosed: value }));
+    window.termcanvas?.app.setQuitOnLastWindowClosed(value);
+  },
   setSummaryCli: (value) => {
     set({ summaryCli: value });
     savePreferences(getSaveState({ ...get(), summaryCli: value }));
@@ -518,3 +533,8 @@ export const usePreferencesStore = create<PreferencesStore>((set, get) => ({
     savePreferences(getSaveState({ ...get(), seenHints: next }));
   },
 }));
+
+// Sync the persisted value to the main process once on startup so a user
+// who flipped the toggle in a previous session keeps that behavior on the
+// very first window-close of this session.
+window.termcanvas?.app.setQuitOnLastWindowClosed(initialPrefs.quitOnLastWindowClosed);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1011,6 +1011,7 @@ export interface TermCanvasAPI {
     homePath: string;
     platform: "darwin" | "win32" | "linux";
     requestClose: () => void;
+    setQuitOnLastWindowClosed: (value: boolean) => void;
   };
   hooks: {
     getSocketPath: () => Promise<string | null>;


### PR DESCRIPTION
## Summary
- macOS 上关掉最后一个窗口不再退出进程，保留在 dock 中；点击 dock 图标会通过既有的 `activate` 处理器开一个新窗口。这是 Electron 文档和 VS Code / Cursor / iTerm2 / Warp 等同类工具的标准行为。
- 其他平台行为不变（仍然 `app.quit()`）。
- Settings → General 新增 macOS-only 开关「Quit when last window closes / 关闭最后一个窗口时退出」，默认关闭。需要老行为的用户可显式开启。

## Why
之前 `app.on("window-all-closed", () => app.quit())` 没有按平台分支，导致 macOS 上同样直接退出，从而 `app.on("activate")` 永远走不到。修复 + 给用户保留逃生开关。

## Test plan
- [ ] macOS：默认设置下关掉最后一个窗口，应用保留在 dock，点击 dock 图标会开新窗口
- [ ] macOS：在 Settings → General 把开关打开后，关掉最后一个窗口应当 `quit`
- [ ] macOS：开关状态在重启后保持
- [ ] Linux/Windows：关掉最后一个窗口仍然退出（不显示该开关）
- [ ] `pnpm typecheck` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)