### PR TITLE
Fix Windows session history path matching

### DIFF
--- a/electron/session-search-index.ts
+++ b/electron/session-search-index.ts
@@ -82,6 +82,26 @@ const MAX_FILE_SIZE_FOR_INDEX = 20 * 1024 * 1024;
 const AVG_LINE_BYTES_ESTIMATE = 500;
 const FIRST_PROMPT_MAX_LENGTH = 200;
 
+/**
+ * Normalize a project path for set membership checks in the session index.
+ *
+ * The history panel passes canvas worktree paths exactly as stored in app
+ * state, while Codex/Kimi session files report their cwd exactly as emitted by
+ * the CLI. On Windows these two sources often differ only by slash style
+ * (`E:/repo/app` vs `E:\repo\app`) and sometimes by drive-letter casing. We
+ * normalize both sides before comparison so the same project does not get
+ * filtered out due to formatting-only path differences.
+ */
+function normalizeProjectPathForMatch(projectDir: string): string {
+  const trimmed = projectDir.trim();
+  if (!trimmed) return "";
+
+  const normalized = path.normalize(trimmed);
+  return process.platform === "win32"
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
 function decodeClaudeEncodedPath(encoded: string): string {
   // Claude stores projects under `-Users-foo-bar`; decode back to
   // `/Users/foo/bar`. This is a lossy encoding — a project with an
@@ -499,7 +519,9 @@ export async function listSessionsForProjects(
   projectDirs: string[],
 ): Promise<SessionSearchEntry[]> {
   if (projectDirs.length === 0) return [];
-  const projectSet = new Set(projectDirs);
+  const projectSet = new Set(
+    projectDirs.map(normalizeProjectPathForMatch).filter(Boolean),
+  );
   const candidates = await listSessionFileCandidates(projectDirs);
 
   const results: SessionSearchEntry[] = [];
@@ -512,7 +534,7 @@ export async function listSessionsForProjects(
     if (!built) continue;
     if (
       (candidate.provider === "codex" || candidate.provider === "kimi") &&
-      !projectSet.has(built.projectDir)
+      !projectSet.has(normalizeProjectPathForMatch(built.projectDir))
     ) {
       // Codex/Kimi file not in one of our projects — skip.
       continue;
@@ -546,7 +568,9 @@ export async function listSessionsForProjectsPaged(
   if (projectDirs.length === 0) return { entries: [], total: 0 };
   const offset = options.offset ?? 0;
   const limit = options.limit;
-  const projectSet = new Set(projectDirs);
+  const projectSet = new Set(
+    projectDirs.map(normalizeProjectPathForMatch).filter(Boolean),
+  );
 
   const candidates = await listSessionFileCandidates(projectDirs);
 
@@ -562,7 +586,10 @@ export async function listSessionsForProjectsPaged(
       candidate.claudeProjectDir,
     );
     if (!built) continue;
-    if (candidate.provider === "codex" && !projectSet.has(built.projectDir)) {
+    if (
+      (candidate.provider === "codex" || candidate.provider === "kimi") &&
+      !projectSet.has(normalizeProjectPathForMatch(built.projectDir))
+    ) {
       continue;
     }
     if (skipped < offset) {

--- a/tests/session-search-index.test.ts
+++ b/tests/session-search-index.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  clearSessionIndexCache,
+  listSessionsForProjects,
+  listSessionsForProjectsPaged,
+} from "../electron/session-search-index.ts";
+
+async function withTempHome(
+  fn: (homeDir: string) => Promise<void> | void,
+): Promise<void> {
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "termcanvas-session-search-index-"),
+  );
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+  try {
+    clearSessionIndexCache();
+    await fn(homeDir);
+  } finally {
+    clearSessionIndexCache();
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+function writeJsonl(filePath: string, lines: object[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    lines.map((line) => JSON.stringify(line)).join("\n"),
+    "utf-8",
+  );
+}
+
+test("listSessionsForProjects matches codex cwd against canvas paths despite slash style differences on Windows", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionFile = path.join(
+      homeDir,
+      ".codex",
+      "sessions",
+      "2026",
+      "05",
+      "01",
+      "rollout-2026-05-01T21-02-49-session-1.jsonl",
+    );
+    writeJsonl(sessionFile, [
+      {
+        timestamp: "2026-05-01T13:02:49.179Z",
+        type: "session_meta",
+        payload: {
+          id: "session-1",
+          cwd: "E:\\GitHub\\open-source\\termcanvas",
+          timestamp: "2026-05-01T13:02:49.179Z",
+        },
+      },
+      {
+        timestamp: "2026-05-01T13:02:50.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "调查历史面板为什么缺会话",
+        },
+      },
+    ]);
+
+    const entries = await listSessionsForProjects([
+      "E:/GitHub/open-source/termcanvas",
+    ]);
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.sessionId, "session-1");
+    assert.equal(
+      entries[0]?.projectDir,
+      "E:\\GitHub\\open-source\\termcanvas",
+    );
+  });
+});
+
+test("listSessionsForProjectsPaged applies the same normalized matching for codex and kimi sessions", async () => {
+  await withTempHome(async (homeDir) => {
+    const codexFile = path.join(
+      homeDir,
+      ".codex",
+      "sessions",
+      "2026",
+      "05",
+      "01",
+      "rollout-2026-05-01T21-02-49-session-codex.jsonl",
+    );
+    writeJsonl(codexFile, [
+      {
+        timestamp: "2026-05-01T13:02:49.179Z",
+        type: "session_meta",
+        payload: {
+          id: "session-codex",
+          cwd: "E:\\GitHub\\others\\test-repo",
+          timestamp: "2026-05-01T13:02:49.179Z",
+        },
+      },
+      {
+        timestamp: "2026-05-01T13:02:50.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "修一下历史面板",
+        },
+      },
+    ]);
+
+    const { entries } = await listSessionsForProjectsPaged(
+      ["E:/GitHub/others/test-repo"],
+      { limit: 10, offset: 0 },
+    );
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.sessionId, "session-codex");
+  });
+});


### PR DESCRIPTION
## Summary

- normalize project paths before matching session history entries
- fix Windows slash and drive-letter formatting mismatches between canvas worktrees and session cwd values
- add regression coverage for paged and non-paged Codex history lookups

## Testing

- pnpm dlx tsx --test tests/session-search-index.test.ts
