### PR TITLE
Reset WebGL renderer when recovering terminal rendering

### DIFF
--- a/src/components/CommandPalette/commandRegistry.ts
+++ b/src/components/CommandPalette/commandRegistry.ts
@@ -42,7 +42,7 @@ import { useThemeStore } from "../../stores/themeStore";
 import { useHubStore } from "../../stores/hubStore";
 import { useCanvasRegistryStore } from "../../stores/canvasRegistryStore";
 import { useCanvasManagerStore } from "../../stores/canvasManagerStore";
-import { rebuildTerminalAtlas } from "../../terminal/webglContextPool";
+import { resetWebGL } from "../../terminal/webglContextPool";
 import { refreshRegisteredTerminalViewports } from "../../terminal/terminalRegistry";
 import {
   formatShortcut,
@@ -403,7 +403,7 @@ function actionCommands(ctx: CommandContext): PaletteCommand[] {
       title: t["palette.cmd.refresh_terminal_rendering"],
       keywords: ["redraw", "atlas", "glyph", "webgl"],
       perform: () => {
-        rebuildTerminalAtlas();
+        resetWebGL(undefined, "manual_refresh_terminal_rendering");
         refreshRegisteredTerminalViewports();
       },
     });

--- a/src/terminal/TerminalTile.tsx
+++ b/src/terminal/TerminalTile.tsx
@@ -56,6 +56,8 @@ import { ActivitySparkline } from "./ActivitySparkline";
 import { TerminalFindOverlay } from "./TerminalFindOverlay";
 import { useTerminalFindStore } from "../stores/terminalFindStore";
 import { recordRenderDiagnostic } from "./renderDiagnostics";
+import { resetWebGL } from "./webglContextPool";
+import { refreshRegisteredTerminalViewports } from "./terminalRegistry";
 
 interface Props {
   lodMode: TerminalMountMode;
@@ -522,6 +524,7 @@ export function TerminalTile({
   const activityHeatmapEnabled = usePreferencesStore(
     (s) => s.activityHeatmapEnabled,
   );
+  const terminalRenderer = usePreferencesStore((s) => s.terminalRenderer);
   const focusLiveTerminal = useCallback(() => {
     const tile = tileRef.current;
     if (!tile || tile.getClientRects().length === 0) {
@@ -1293,6 +1296,21 @@ export function TerminalTile({
                 onClick: () =>
                   setTagManager({ x: contextMenu.x, y: contextMenu.y }),
               },
+              ...(terminalRenderer === "webgl"
+                ? [
+                    { type: "separator" as const },
+                    {
+                      label: t["palette.cmd.refresh_terminal_rendering"],
+                      onClick: () => {
+                        resetWebGL(
+                          terminal.id,
+                          "terminal_context_menu_refresh_rendering",
+                        );
+                        refreshRegisteredTerminalViewports(terminal.id);
+                      },
+                    },
+                  ]
+                : []),
               ...((terminal.type === "claude" || terminal.type === "codex") &&
               liveTerminal.sessionId
                 ? [

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -10,6 +10,7 @@ import {
   releaseWebGL,
   touch as touchWebGL,
   rebuildTerminalAtlas,
+  resetWebGL,
 } from "./webglContextPool";
 import {
   installRenderDiagnosticsListeners,
@@ -1708,8 +1709,10 @@ function installRenderRecoveryListeners() {
       // WebGL canvases lose their framebuffer when the page is genuinely
       // hidden (sleep/wake, minimize, OS Space switch). For light triggers
       // (bare window.focus where the page may have just briefly lost focus)
-      // a refresh is enough — atlas rebuild is GPU-expensive.
-      rebuildTerminalAtlas(undefined, reason);
+      // a refresh is enough. If WebGL's renderer state is corrupted,
+      // clearing the atlas can still leave new glyphs wrong; cycling the
+      // addon matches the user-visible DOM -> WebGL recovery path.
+      resetWebGL(undefined, reason);
     }
   });
 }

--- a/src/terminal/webglContextPool.ts
+++ b/src/terminal/webglContextPool.ts
@@ -133,6 +133,44 @@ export function rebuildTerminalAtlas(
   }
 }
 
+function resetEntryWebGL(entry: PoolEntry, reason: string): boolean {
+  recordWebGLDiagnostic("webgl_reset", entry.terminalId, { reason });
+  const wasFocused = focusedId === entry.terminalId;
+  releaseWebGL(entry.terminalId);
+  const reacquired = acquireWebGL(entry.terminalId, entry.xterm);
+  if (reacquired && wasFocused) {
+    touch(entry.terminalId);
+  }
+  try {
+    entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
+  } catch {
+    // Terminal may be mid-disposal; reset is best-effort recovery.
+  }
+  return reacquired;
+}
+
+export function resetWebGL(terminalId?: string, reason = "unspecified"): void {
+  if (!terminalId) {
+    const currentEntries = [...entries.values()];
+    recordWebGLDiagnostic("webgl_reset_all", undefined, {
+      reason,
+      reset_count: currentEntries.length,
+    });
+    for (const entry of currentEntries) {
+      resetEntryWebGL(entry, reason);
+    }
+    return;
+  }
+
+  const entry = entries.get(terminalId);
+  if (!entry) {
+    recordWebGLDiagnostic("webgl_reset_skipped", terminalId, { reason });
+    return;
+  }
+
+  resetEntryWebGL(entry, reason);
+}
+
 export function acquireWebGL(terminalId: string, xterm: Terminal): boolean {
   if (entries.has(terminalId)) {
     touch(terminalId);

--- a/tests/terminal-runtime-store.test.ts
+++ b/tests/terminal-runtime-store.test.ts
@@ -589,6 +589,24 @@ test("terminal renderer preference can release and reacquire WebGL on a live run
   }
 });
 
+test("resetWebGL recreates the addon and refreshes the terminal viewport", async () => {
+  installRuntimeGlobals();
+  const { acquireWebGL, releaseWebGL, resetWebGL } = await import("../src/terminal/webglContextPool.ts");
+  const { stats, xterm } = createMockXterm();
+
+  try {
+    assert.equal(acquireWebGL("terminal-1", xterm as never), true);
+    assert.equal(stats.loadAddonCalls, 1);
+
+    resetWebGL("terminal-1", "test_reset");
+
+    assert.equal(stats.loadAddonCalls, 2);
+    assert.equal(stats.refreshCalls, 1);
+  } finally {
+    releaseWebGL("terminal-1");
+  }
+});
+
 test("acquireWebGL warns users to switch renderers when WebGL is unavailable", async () => {
   installRuntimeGlobals();
   const { useLocaleStore } = await import("../src/stores/localeStore.ts");


### PR DESCRIPTION
## Summary
- reset the xterm WebGL addon during rendering recovery instead of only clearing the texture atlas
- add a WebGL-only terminal context menu action for refreshing terminal rendering
- keep the command palette refresh path aligned with the stronger reset behavior

## Context
This is a recovery path for the intermittent WebGL glyph corruption we observed. It does not claim to identify the lower-level trigger; the follow-up root-cause investigation is tracked in #172.

## Verification
- pnpm exec tsc --noEmit
- pnpm exec tsx --test tests/terminal-runtime-store.test.ts
