### PR TITLE
fix(wterm): exclude @wterm/* from Vite dep pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -184,6 +184,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "src"),
     },
   },
+  // Pre-bundling @wterm/* would move the modules into .vite/deps, breaking
+  // the `new URL("../wasm/...", import.meta.url)` lookup the ghostty core
+  // uses to find its WASM blob. Keep them as-is so the relative URL stays
+  // valid against node_modules.
+  optimizeDeps: {
+    exclude: ["@wterm/core", "@wterm/dom", "@wterm/ghostty", "@wterm/react"],
+  },
   base: "./",
   // Hydra writes worktrees, dispatch state, and result.json under
   // .hydra/ + .worktrees/ at runtime. The dev server's chokidar


### PR DESCRIPTION
## Summary
- Adds `optimizeDeps.exclude: ["@wterm/core", "@wterm/dom", "@wterm/ghostty", "@wterm/react"]` to `vite.config.ts`.
- Fixes the runtime crash when toggling the experimental wterm engine in dev mode.

## Repro before fix
1. Settings → Appearance → Terminal engine → switch to wterm.
2. The tile shows: `wterm core failed: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 64 6f @+0`.

`3c 21 64 6f` is `<!do` — the dev server returned `index.html` (SPA fallback) instead of the WASM binary, so `WebAssembly.instantiate` parsed the HTML byte-stream and rejected the magic word.

## Why it happens
Vite's dep optimization rewrites `@wterm/ghostty` into `.vite/deps/...`. The package's WASM loader does:

```js
new URL("../wasm/ghostty-vt.wasm", import.meta.url)
```

When the module lives in `.vite/deps/`, that relative URL no longer points to `node_modules/@wterm/ghostty/wasm/ghostty-vt.wasm`. The dev server can't find it, falls through to its SPA fallback, and serves the renderer HTML.

Production builds were already fine — Vite's static analysis catches the `new URL(import.meta.url)` pattern at build time and emits the `.wasm` as a hashed asset.

## Why exclude all four
`@wterm/dom` and `@wterm/react` import `@wterm/ghostty`/`@wterm/core` transitively. If only ghostty is excluded, dev mode can still pre-bundle the dependents and lose the relative path. Excluding the whole namespace keeps the resolution graph consistent.

## Test plan
- [ ] `pnpm dev`, flip the engine to wterm — wterm core loads, no WASM magic-word error.
- [ ] `pnpm typecheck` clean.
- [ ] `pnpm exec vite build` succeeds and emits `ghostty-vt-*.wasm` as an asset (unchanged from before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)