### PR TITLE
chore(wterm): align font, theme, scrollback with xterm path

### DIFF
--- a/src/terminal/WtermTile.tsx
+++ b/src/terminal/WtermTile.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -15,18 +16,55 @@ import type { TerminalData } from "../types";
 import { useResolvedTerminalRuntimeState } from "../stores/terminalRuntimeStateStore";
 import { getTerminalRuntimePreviewAnsi } from "./terminalRuntimeStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
-import { useThemeStore } from "../stores/themeStore";
+import { useThemeStore, XTERM_THEMES } from "../stores/themeStore";
+import { buildFontFamily } from "./fontRegistry";
+import type { CSSProperties } from "react";
+
+const TERMINAL_LINE_HEIGHT = 1.4;
+const SCROLLBACK_LIMIT = 50_000;
 
 let coreLoadPromise: Promise<TerminalCore> | null = null;
 
 function getGhosttyCore(): Promise<TerminalCore> {
   if (!coreLoadPromise) {
-    coreLoadPromise = GhosttyCore.load().catch((err) => {
+    coreLoadPromise = GhosttyCore.load({
+      scrollbackLimit: SCROLLBACK_LIMIT,
+    }).catch((err) => {
       coreLoadPromise = null;
       throw err;
     });
   }
   return coreLoadPromise;
+}
+
+// xterm's ITheme exposes 16 ANSI colors via separate fields. wterm reads
+// them off CSS vars. Bridge the two so the wterm path inherits the same
+// palette we ship for xterm — otherwise wterm falls back to its built-in
+// VS Code blue/purple defaults and TermCanvas turns into two visually
+// disjoint terminals depending on which engine is on.
+function buildPaletteVars(themeName: "dark" | "light"): CSSProperties {
+  const t = XTERM_THEMES[themeName];
+  return {
+    "--term-fg": t.foreground,
+    "--term-bg": t.background,
+    "--term-cursor": t.cursor,
+    "--term-color-0": t.black,
+    "--term-color-1": t.red,
+    "--term-color-2": t.green,
+    "--term-color-3": t.yellow,
+    "--term-color-4": t.blue,
+    "--term-color-5": t.magenta,
+    "--term-color-6": t.cyan,
+    "--term-color-7": t.white,
+    "--term-color-8": t.brightBlack,
+    "--term-color-9": t.brightRed,
+    "--term-color-10": t.brightGreen,
+    "--term-color-11": t.brightYellow,
+    "--term-color-12": t.brightBlue,
+    "--term-color-13": t.brightMagenta,
+    "--term-color-14": t.brightCyan,
+    "--term-color-15": t.brightWhite,
+  } as CSSProperties;
 }
 
 interface Props {
@@ -38,6 +76,7 @@ export function WtermTile({ terminal }: Props) {
   const liveRuntimeState = useResolvedTerminalRuntimeState(terminal);
   const ptyId = liveRuntimeState.ptyId ?? terminal.ptyId ?? null;
   const fontSize = usePreferencesStore((s) => s.terminalFontSize);
+  const fontFamilyId = usePreferencesStore((s) => s.terminalFontFamily);
   const theme = useThemeStore((s) => s.theme);
 
   const [core, setCore] = useState<TerminalCore | null>(null);
@@ -98,6 +137,28 @@ export function WtermTile({ terminal }: Props) {
     [ptyId],
   );
 
+  // Wterm reads font-family/size/line-height/row-height off CSS vars.
+  // Setting them inline overrides the package's built-in defaults
+  // (Menlo/14px/1.2/17px) so cell metrics match what xterm computes from
+  // the same preferences. Row-height has to be an integer pixel value or
+  // wterm's resize math drifts row-by-row.
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const family = buildFontFamily(fontFamilyId);
+    const rowHeight = Math.round(fontSize * TERMINAL_LINE_HEIGHT);
+    return {
+      width: "100%",
+      height: "100%",
+      padding: 0,
+      borderRadius: 0,
+      boxShadow: "none",
+      "--term-font-family": family,
+      "--term-font-size": `${fontSize}px`,
+      "--term-line-height": `${rowHeight}px`,
+      "--term-row-height": `${rowHeight}px`,
+      ...buildPaletteVars(theme),
+    } as CSSProperties;
+  }, [fontFamilyId, fontSize, theme]);
+
   if (coreError) {
     return (
       <div className="flex h-full w-full items-center justify-center px-3 text-center text-[11px] text-[var(--red)]">
@@ -120,18 +181,10 @@ export function WtermTile({ terminal }: Props) {
       core={core}
       autoResize
       cursorBlink
-      theme={theme === "light" ? "light" : undefined}
       onData={handleData}
       onResize={handleResize}
       className="tc-wterm-host"
-      style={{
-        width: "100%",
-        height: "100%",
-        padding: 8,
-        borderRadius: 0,
-        boxShadow: "none",
-        fontSize: `${fontSize}px`,
-      }}
+      style={containerStyle}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Pipes `terminalFontFamily`, `terminalFontSize`, `XTERM_THEMES[theme]`, and 50K scrollback into the wterm path.
- Removes the default 12px padding and shadow on the wterm root so its cell grid aligns with the tile chrome the same way xterm does.

## Why
The first cut shipped wterm with its package defaults — Menlo / 14px / 1.2 line-height / VS Code blue palette / 10K scrollback. Toggling between engines on the same TermCanvas surface looked like two different apps, and TUIs that measure the cell grid (Claude's bordered prompt UI is the obvious one) laid out wrong because the cell width xterm computed didn't match the cell width wterm rendered.

## Implementation notes
- wterm reads font-family / font-size / line-height / row-height off CSS custom properties (`--term-*`). Setting them via inline `style` overrides the package's defaults without touching the imported CSS.
- Row height is locked to `Math.round(fontSize * 1.4)`. wterm's resize math walks integer pixel rows; using a fractional value drifts row-by-row across long buffers.
- `XTERM_THEMES` is xterm's `ITheme` shape (16 ANSI colors plus fg/bg/cursor). Mapped 1:1 onto `--term-color-0..15` + `--term-fg/bg/cursor`.
- `GhosttyCore.load({ scrollbackLimit: 50_000 })` matches xterm's scrollback budget.
- Padding on the wterm root drops to 0 — the tile chrome already owns spacing; padding on the inner element shaves cells off every row.

## Out of scope
This pass is cosmetic + sizing only. The remaining gaps in the wterm engine are unchanged and still tracked separately:
- No mouse reporting (`@wterm/dom` doesn't attach mouse listeners)
- No selection-to-clipboard, find overlay, or serialize
- Wide-char cursor drift (the WASM tracks cell width but the JS layer drops it)

## Test plan
- [ ] Settings → Appearance → Terminal engine → wterm. Same font, same size, same colors, same scrollback feel as the xterm path.
- [ ] Toggle the app theme (dark ↔ light) — wterm picks up the new palette.
- [ ] Run `claude` in a wterm tile — the bordered prompt fits the tile width without wrapping mid-cell.
- [ ] `pnpm typecheck` clean.
- [ ] `pnpm exec vite build` succeeds, ghostty WASM still emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)