### PR TITLE
feat(notifications): system notifications for blocked agent prompts

### DIFF
--- a/electron/blocking-event-bus.ts
+++ b/electron/blocking-event-bus.ts
@@ -1,0 +1,164 @@
+import type {
+  BlockingEvent,
+  BlockingEventKind,
+  BlockingEventResolved,
+} from "../shared/blocking";
+
+// Suppression / re-trigger thresholds. Inlined rather than imported from
+// lifecycleThresholds.ts because they belong to the notification layer,
+// not the telemetry derivation layer.
+const FAST_DECISION_WINDOW_MS = 1_500;
+const SAME_KIND_REPEAT_WINDOW_MS = 5 * 60_000;
+
+type EmitListener = (event: BlockingEvent) => void;
+type ResolveListener = (resolved: BlockingEventResolved) => void;
+
+interface PendingEntry {
+  event: BlockingEvent;
+  // Wall-clock timer that fires the notification 1.5s after `open` —
+  // gives the user a chance to dismiss the prompt themselves before we
+  // bother the OS. Cleared when the block resolves first.
+  notifyTimer: ReturnType<typeof setTimeout> | null;
+  // Whether the notification has actually been published. Distinct from
+  // "active" because we may have an active block that we deliberately
+  // suppressed (window focused, recent re-prompt, etc).
+  notified: boolean;
+}
+
+export class BlockingEventBus {
+  // Active, unresolved blocks — keyed by event id (stable per terminal+kind).
+  private readonly active = new Map<string, PendingEntry>();
+  // Most recent notification publish time per (terminalId|kind), used for
+  // 5-minute repeat suppression. Outlives `active` entries on purpose.
+  private readonly lastNotifiedAt = new Map<string, number>();
+
+  private readonly emitListeners = new Set<EmitListener>();
+  private readonly resolveListeners = new Set<ResolveListener>();
+
+  // Caller decides — usually `mainWindow.isFocused()`. Pulled at the
+  // moment the notify timer fires so a user who refocuses during the
+  // 1.5s grace window is still respected.
+  constructor(
+    private readonly options: {
+      isWindowFocused: () => boolean;
+      now?: () => number;
+    },
+  ) {}
+
+  private get now(): number {
+    return (this.options.now ?? Date.now)();
+  }
+
+  open(input: {
+    kind: BlockingEventKind;
+    terminalId: string;
+    projectName?: string;
+    terminalTitle?: string;
+  }): BlockingEvent {
+    const id = `${input.terminalId}::${input.kind}`;
+    const existing = this.active.get(id);
+    if (existing) {
+      // Already-open block re-opening — just refresh metadata so the
+      // inbox / notification body picks up a renamed terminal, but keep
+      // the original createdAt and the existing notify timer.
+      existing.event.projectName = input.projectName ?? existing.event.projectName;
+      existing.event.terminalTitle =
+        input.terminalTitle ?? existing.event.terminalTitle;
+      return existing.event;
+    }
+
+    const event: BlockingEvent = {
+      id,
+      kind: input.kind,
+      terminalId: input.terminalId,
+      projectName: input.projectName,
+      terminalTitle: input.terminalTitle,
+      createdAt: this.now,
+    };
+
+    const entry: PendingEntry = {
+      event,
+      notifyTimer: null,
+      notified: false,
+    };
+
+    entry.notifyTimer = setTimeout(() => {
+      entry.notifyTimer = null;
+      this.maybePublish(entry);
+    }, FAST_DECISION_WINDOW_MS);
+
+    this.active.set(id, entry);
+    for (const listener of this.emitListeners) listener(event);
+    return event;
+  }
+
+  resolve(input: { kind: BlockingEventKind; terminalId: string }): void {
+    const id = `${input.terminalId}::${input.kind}`;
+    const entry = this.active.get(id);
+    if (!entry) return;
+
+    if (entry.notifyTimer) {
+      clearTimeout(entry.notifyTimer);
+      entry.notifyTimer = null;
+    }
+    this.active.delete(id);
+
+    const resolved: BlockingEventResolved = {
+      id,
+      terminalId: input.terminalId,
+      resolvedAt: this.now,
+    };
+    for (const listener of this.resolveListeners) listener(resolved);
+  }
+
+  // Renderer asks for the snapshot at startup so the toolbar dot picks
+  // up blocks that opened before the renderer subscribed.
+  list(): BlockingEvent[] {
+    return Array.from(this.active.values()).map((e) => e.event);
+  }
+
+  onOpen(listener: EmitListener): () => void {
+    this.emitListeners.add(listener);
+    return () => this.emitListeners.delete(listener);
+  }
+
+  onResolve(listener: ResolveListener): () => void {
+    this.resolveListeners.add(listener);
+    return () => this.resolveListeners.delete(listener);
+  }
+
+  // Decide whether to actually fire the OS notification. Suppression
+  // rules live here, not at the telemetry call site, so all producers
+  // share the same policy.
+  private maybePublish(entry: PendingEntry): void {
+    if (!this.active.has(entry.event.id)) {
+      // Resolved during the grace window — fast-decision suppression.
+      return;
+    }
+
+    if (this.options.isWindowFocused()) {
+      // App is in front; in-app affordances (toolbar dot, future tile
+      // pulse) carry the load. Don't redundantly send to OS notif center.
+      return;
+    }
+
+    const repeatKey = `${entry.event.terminalId}|${entry.event.kind}`;
+    const lastAt = this.lastNotifiedAt.get(repeatKey) ?? 0;
+    if (this.now - lastAt < SAME_KIND_REPEAT_WINDOW_MS) {
+      return;
+    }
+
+    this.lastNotifiedAt.set(repeatKey, this.now);
+    entry.notified = true;
+    for (const listener of this.publishListeners) listener(entry.event);
+  }
+
+  // Separate channel from `onOpen`: `onOpen` always fires (renderer
+  // needs it for the dot); `onPublish` only fires when suppression
+  // actually permits an OS notification.
+  private readonly publishListeners = new Set<EmitListener>();
+  onPublish(listener: EmitListener): () => void {
+    this.publishListeners.add(listener);
+    return () => this.publishListeners.delete(listener);
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -153,6 +153,8 @@ import { createMenu } from "./menu";
 import { isSelectAllShortcutInput } from "./select-all-shortcut";
 import { isReloadShortcutInput } from "./reload-shortcut";
 import { TelemetryService } from "./telemetry-service";
+import { BlockingEventBus } from "./blocking-event-bus";
+import { NotificationService } from "./notification-service";
 import { createRenderDiagnosticsLogger } from "./render-diagnostics";
 import { RenderThrottlingCoordinator } from "./render-throttling-coordinator";
 import { HookReceiver } from "./hook-receiver";
@@ -264,12 +266,50 @@ const fileTreeWatcher = new FileTreeWatcher(HIDDEN_DIRS, (dirPath) => {
   sendToWindow(mainWindow, "fs:dir-changed", dirPath);
 });
 const sessionWatcher = new SessionWatcher();
+// Track turn_state per terminal so we can detect the unknown→awaiting_input
+// transition that gates blocking-event emission. Held outside the
+// telemetry service because the service emits on any change; we only
+// care about edge transitions for blocking events.
+const lastTurnStateByTerminal = new Map<string, string>();
+const blockingEventBus = new BlockingEventBus({
+  isWindowFocused: () => mainWindow?.isFocused() ?? false,
+});
+const notificationService = new NotificationService({
+  getWindow: () => mainWindow,
+});
+blockingEventBus.onPublish((event) => notificationService.showBlocking(event));
+blockingEventBus.onResolve((resolved) =>
+  notificationService.closeBlocking(resolved.id),
+);
+blockingEventBus.onOpen((event) =>
+  sendToWindow(mainWindow, "blocking:opened", event),
+);
+blockingEventBus.onResolve((resolved) =>
+  sendToWindow(mainWindow, "blocking:resolved", resolved),
+);
 const telemetryService = new TelemetryService({
   onSnapshotChanged: (terminalId, snapshot) => {
     sendToWindow(mainWindow, "telemetry:snapshot-changed", {
       terminalId,
       snapshot,
     });
+
+    const prev = lastTurnStateByTerminal.get(terminalId);
+    const curr = snapshot.turn_state;
+    lastTurnStateByTerminal.set(terminalId, curr);
+
+    if (curr === "awaiting_input" && prev !== "awaiting_input") {
+      const repoPath = snapshot.repo_path;
+      const worktreePath = snapshot.worktree_path;
+      blockingEventBus.open({
+        kind: "approval",
+        terminalId,
+        projectName: repoPath ? path.basename(repoPath) : undefined,
+        terminalTitle: worktreePath ? path.basename(worktreePath) : undefined,
+      });
+    } else if (prev === "awaiting_input" && curr !== "awaiting_input") {
+      blockingEventBus.resolve({ kind: "approval", terminalId });
+    }
   },
 });
 const agentService = new AgentService();
@@ -1383,6 +1423,11 @@ function setupIpc() {
 
   ipcMain.handle("hook:get-socket-path", () => hookSocketPath);
   ipcMain.handle("hook:get-health", () => hookReceiver.getHealth());
+
+  ipcMain.handle("blocking:list", () => blockingEventBus.list());
+  ipcMain.handle("blocking:jump", (_event, terminalId: string) => {
+    notificationService.focusWindowAndJump(terminalId);
+  });
 
   ipcMain.handle("sessions:load-replay", async (_event, filePath: string) => {
     return sessionScanner.loadReplay(filePath);

--- a/electron/notification-service.ts
+++ b/electron/notification-service.ts
@@ -1,0 +1,92 @@
+import { app, BrowserWindow, Notification } from "electron";
+import type { BlockingEvent } from "../shared/blocking";
+
+// Single point of contact with the OS notification API. Keeps Electron
+// imports off the bus + telemetry layer so unit tests can stub this
+// service freely.
+
+export interface NotificationServiceDeps {
+  getWindow: () => BrowserWindow | null;
+}
+
+export class NotificationService {
+  // Keep one Notification instance per blocking-event id so we can
+  // close() it when the block resolves; otherwise stale "needs approval"
+  // toasts linger in the OS notification center after the user already
+  // approved.
+  private readonly outstanding = new Map<string, Notification>();
+
+  constructor(private readonly deps: NotificationServiceDeps) {}
+
+  showBlocking(event: BlockingEvent): void {
+    if (!Notification.isSupported()) return;
+
+    const title = formatTitle(event);
+    const body = formatBody(event);
+
+    const existing = this.outstanding.get(event.id);
+    if (existing) {
+      existing.close();
+    }
+
+    const notification = new Notification({
+      title,
+      body,
+      silent: true,
+      // macOS Alert style — stays visible until the user dismisses it.
+      // Falls back to default banner on platforms that don't honor it.
+      timeoutType: "never",
+    });
+
+    notification.on("click", () => {
+      this.focusWindowAndJump(event.terminalId);
+    });
+
+    notification.on("close", () => {
+      this.outstanding.delete(event.id);
+    });
+
+    notification.show();
+    this.outstanding.set(event.id, notification);
+  }
+
+  closeBlocking(eventId: string): void {
+    const existing = this.outstanding.get(eventId);
+    if (!existing) return;
+    existing.close();
+    this.outstanding.delete(eventId);
+  }
+
+  // Public: also called by the IPC handler when the renderer triggers
+  // a jump (toolbar dot click, inbox click).
+  focusWindowAndJump(terminalId: string): void {
+    const win = this.deps.getWindow();
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.show();
+      win.focus();
+    }
+    // macOS only honors steal-focus through app.focus when the app is
+    // in the background; on other platforms it's a noop.
+    if (process.platform === "darwin") {
+      app.focus({ steal: true });
+    }
+    win?.webContents.send("blocking:jump-to-terminal", { terminalId });
+  }
+}
+
+function formatTitle(event: BlockingEvent): string {
+  // {project} · {terminal} — three-part rule with graceful degradation
+  // when either label is missing (fresh terminals before scan completes).
+  const parts: string[] = [];
+  if (event.projectName) parts.push(event.projectName);
+  if (event.terminalTitle) parts.push(event.terminalTitle);
+  return parts.length > 0 ? parts.join(" · ") : "Agent waiting";
+}
+
+function formatBody(event: BlockingEvent): string {
+  switch (event.kind) {
+    case "approval":
+      return "Waiting for your approval";
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,10 @@ import type {
 } from "../shared/render-diagnostics";
 import type { SessionHistoryChangedEvent } from "../shared/sessions";
 import type { TelemetryProvider } from "../shared/telemetry";
+import type {
+  BlockingEvent,
+  BlockingEventResolved,
+} from "../shared/blocking";
 
 type SessionTelemetryProvider = Exclude<TelemetryProvider, "unknown">;
 
@@ -829,6 +833,39 @@ contextBridge.exposeInMainWorld("termcanvas", {
     requestClose: () => ipcRenderer.send("app:request-close"),
     setQuitOnLastWindowClosed: (value: boolean) =>
       ipcRenderer.send("app:set-quit-on-last-window-closed", value),
+  },
+  blocking: {
+    list: () =>
+      ipcRenderer.invoke("blocking:list") as Promise<BlockingEvent[]>,
+    jump: (terminalId: string) =>
+      ipcRenderer.invoke("blocking:jump", terminalId) as Promise<void>,
+    onOpened: (callback: (event: BlockingEvent) => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: BlockingEvent,
+      ) => callback(payload);
+      ipcRenderer.on("blocking:opened", listener);
+      return () => ipcRenderer.removeListener("blocking:opened", listener);
+    },
+    onResolved: (callback: (event: BlockingEventResolved) => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: BlockingEventResolved,
+      ) => callback(payload);
+      ipcRenderer.on("blocking:resolved", listener);
+      return () => ipcRenderer.removeListener("blocking:resolved", listener);
+    },
+    // Main process triggers a jump (e.g. from a notification click).
+    // Renderer listens to actually run the canvas pan + focus.
+    onJumpToTerminal: (callback: (terminalId: string) => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: { terminalId: string },
+      ) => callback(payload.terminalId);
+      ipcRenderer.on("blocking:jump-to-terminal", listener);
+      return () =>
+        ipcRenderer.removeListener("blocking:jump-to-terminal", listener);
+    },
   },
   updater: {
     check: () => ipcRenderer.invoke("updater:check"),

--- a/shared/blocking.ts
+++ b/shared/blocking.ts
@@ -1,0 +1,28 @@
+// Blocking-event types shared between main process and renderer.
+//
+// A "blocking event" is something that has paused agent progress and
+// requires the user to act in the terminal (approve a tool call, answer
+// an elicitation prompt). Currently kind=approval is the only producer;
+// the shape is event-bus-style so future producers (decision points,
+// quota, auth) can plug in without churn.
+
+export type BlockingEventKind = "approval";
+
+export interface BlockingEvent {
+  // Stable per (terminalId + kind) — used to dedupe and to close the
+  // OS notification when the block is resolved.
+  id: string;
+  kind: BlockingEventKind;
+  terminalId: string;
+  // Best-effort context for the notification body. Filled by the main
+  // process from telemetry; renderer treats them as opaque labels.
+  projectName?: string;
+  terminalTitle?: string;
+  createdAt: number;
+}
+
+export interface BlockingEventResolved {
+  id: string;
+  terminalId: string;
+  resolvedAt: number;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { RightPanel } from "./components/RightPanel";
 import { FileEditorDrawer } from "./components/FileEditorDrawer";
 import { PinDetailDrawer } from "./components/PinDetailDrawer";
 import { initUpdaterListeners } from "./stores/updaterStore";
+import { startBlockingBridge } from "./stores/blockingStore";
+import { panToTerminal } from "./utils/panToTerminal";
 import { ComposerBar } from "./components/ComposerBar";
 import { HandoffDragChip } from "./components/HandoffDragChip";
 import { usePreferencesStore, hydrateApiKey } from "./stores/preferencesStore";
@@ -274,6 +276,17 @@ export function App() {
   }, [summaryEnabled]);
 
   useEffect(() => initUpdaterListeners(), []);
+  useEffect(() => startBlockingBridge(), []);
+  // Notification click in main process → renderer pans canvas to terminal.
+  // Kept lightweight (panToTerminal already handles missing terminals)
+  // so a stale notification just no-ops.
+  useEffect(() => {
+    const api = window.termcanvas?.blocking;
+    if (!api) return;
+    return api.onJumpToTerminal((terminalId) => {
+      panToTerminal(terminalId);
+    });
+  }, []);
   useEffect(() => {
     void useSnapshotHistoryStore.getState().refresh();
   }, []);

--- a/src/stores/blockingStore.ts
+++ b/src/stores/blockingStore.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+import type {
+  BlockingEvent,
+  BlockingEventResolved,
+} from "../../shared/blocking";
+
+// Renderer-side mirror of the main-process bus. Exists purely for
+// reactive UI — the truth is still in the main process. We rebuild
+// from `blocking.list()` on mount so a late-subscribing renderer (e.g.
+// reload during dev) catches up with already-open blocks.
+
+interface BlockingStore {
+  events: BlockingEvent[];
+  add: (event: BlockingEvent) => void;
+  remove: (resolved: BlockingEventResolved) => void;
+  reset: (events: BlockingEvent[]) => void;
+  firstTerminalId: () => string | null;
+}
+
+export const useBlockingStore = create<BlockingStore>((set, get) => ({
+  events: [],
+  add: (event) =>
+    set((state) => {
+      // Bus de-dupes by id, but the renderer can also receive a stale
+      // re-open if the user reloads during an active block — mirror the
+      // upsert semantics so we never double-count.
+      const others = state.events.filter((e) => e.id !== event.id);
+      return { events: [...others, event] };
+    }),
+  remove: (resolved) =>
+    set((state) => ({
+      events: state.events.filter((e) => e.id !== resolved.id),
+    })),
+  reset: (events) => set({ events }),
+  firstTerminalId: () => get().events[0]?.terminalId ?? null,
+}));
+
+// Wire main-process events into the store. Returns a disposer; the
+// caller (App.tsx) is responsible for cleanup on unmount, but in
+// practice this lives for the entire renderer lifetime.
+export function startBlockingBridge(): () => void {
+  const api = window.termcanvas?.blocking;
+  if (!api) {
+    return () => {};
+  }
+
+  void api.list().then((events) => {
+    useBlockingStore.getState().reset(events);
+  });
+
+  const offOpen = api.onOpened((event) => {
+    useBlockingStore.getState().add(event);
+  });
+  const offResolve = api.onResolved((resolved) => {
+    useBlockingStore.getState().remove(resolved);
+  });
+
+  return () => {
+    offOpen();
+    offResolve();
+  };
+}

--- a/src/toolbar/Toolbar.tsx
+++ b/src/toolbar/Toolbar.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useThemeStore } from "../stores/themeStore";
 import { useUpdaterStore } from "../stores/updaterStore";
+import { useBlockingStore } from "../stores/blockingStore";
+import { panToTerminal } from "../utils/panToTerminal";
 import { useSettingsModalStore } from "../stores/settingsModalStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { useHubStore } from "../stores/hubStore";
@@ -35,6 +37,10 @@ export function Toolbar() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath);
   const dirty = useWorkspaceStore((s) => s.dirty);
   const updateStatus = useUpdaterStore((s) => s.status);
+  const blockingCount = useBlockingStore((s) => s.events.length);
+  const firstBlockedTerminalId = useBlockingStore((s) =>
+    s.events.length > 0 ? s.events[0].terminalId : null,
+  );
   const showSettings = useSettingsModalStore((s) => s.open);
   const openSettings = useSettingsModalStore((s) => s.openSettings);
   const closeSettings = useSettingsModalStore((s) => s.closeSettings);
@@ -92,6 +98,17 @@ export function Toolbar() {
               status={updateStatus}
               t={t}
               onClick={() => setShowUpdate(true)}
+            />
+          )}
+
+          {blockingCount > 0 && (
+            <BlockingIndicatorButton
+              count={blockingCount}
+              onClick={() => {
+                if (firstBlockedTerminalId) {
+                  panToTerminal(firstBlockedTerminalId);
+                }
+              }}
             />
           )}
 
@@ -216,6 +233,57 @@ function UpdateStatusButton({
         <SpinnerIcon className="motion-safe:animate-spin" />
       )}
     </button>
+  );
+}
+
+function BlockingIndicatorButton({
+  count,
+  onClick,
+}: {
+  count: number;
+  onClick: () => void;
+}) {
+  const label =
+    count === 1
+      ? "1 terminal waiting for you"
+      : `${count} terminals waiting for you`;
+  return (
+    <button
+      type="button"
+      // Re-pop on count change so a new block reads as an event.
+      key={count}
+      className={`${iconButtonClass} tc-enter-pop relative motion-reduce:animate-none`}
+      style={ICON_BUTTON_TRANSITION}
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+    >
+      <BellIcon />
+      <span
+        aria-hidden="true"
+        className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-[var(--red)] ring-2 ring-[var(--bg)]"
+      />
+    </button>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M7 1.5v1M3.5 6a3.5 3.5 0 1 1 7 0c0 2.5 1 3.5 1 3.5h-9s1-1 1-3.5Z"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.5 11.5a1.5 1.5 0 0 0 3 0"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+    </svg>
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1173,6 +1173,19 @@ export interface TermCanvasAPI {
     ) => Promise<ComposerSubmitResult>;
     subscribe: (handler: (event: PinEvent) => void) => () => void;
   };
+  blocking: {
+    list: () => Promise<import("../../shared/blocking").BlockingEvent[]>;
+    jump: (terminalId: string) => Promise<void>;
+    onOpened: (
+      callback: (event: import("../../shared/blocking").BlockingEvent) => void,
+    ) => () => void;
+    onResolved: (
+      callback: (
+        event: import("../../shared/blocking").BlockingEventResolved,
+      ) => void,
+    ) => () => void;
+    onJumpToTerminal: (callback: (terminalId: string) => void) => () => void;
+  };
   updater: {
     check: () => Promise<import("../../shared/updater-types").UpdateCheckOutcome>;
     install: () => void;


### PR DESCRIPTION
Add OS-level notifications when a terminal flips to turn_state=awaiting_input, so users notice agents paused on Claude/Codex permission prompts while the window is in the background.

New BlockingEventBus (main process) emits/resolves events with built-in suppression: 1.5s fast-decision grace window, focused-window suppression, and a 5-minute repeat cap per terminal+kind.

Toolbar grows a bell icon + red dot when there are unresolved blocks; clicking it (or clicking the OS notification) routes through the existing panToTerminal helper to focus the offending tile.

Out of scope (deliberate): tile-pulse border, multi-block inbox panel, settings toggle.

Test plan: see commit message and inline comments. Build smoke is gated on pre-existing @wterm/* module errors on main.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>