### PR TITLE
feat(render): RenderableSurface registry as recovery dispatch hub

### DIFF
--- a/shared/render-surface.ts
+++ b/shared/render-surface.ts
@@ -1,0 +1,63 @@
+// Render-surface contract.
+//
+// A "surface" is anything on screen whose pixels are produced by GPU work
+// that Chromium might pause when the page is occluded — terminals (xterm),
+// the canvas-backed graph layer, code editors (Monaco), the Pet sprite,
+// etc. PR 1 wired recovery only for terminals because that's where the
+// macOS Space-switch bug surfaced first; PR 7 will register the rest.
+//
+// Why a registry instead of growing the recovery callback to know about
+// every surface kind: each surface owns its own paint primitive and each
+// kind's recovery is a slightly different ritual (xterm calls
+// `refresh()`, Monaco calls `editor.render(true)`, raw canvas redraws its
+// scene, etc.). A registry lets recovery dispatch stay a one-liner —
+// `for surface in registry: surface.forceRepaint(...)` — while the
+// per-surface implementation lives next to the surface itself.
+
+export type SurfaceKind = "terminal" | "monaco" | "canvas" | "pet";
+
+export type SurfaceRendererMode = "webgl" | "canvas" | "dom" | "unknown";
+
+export type SurfaceRecoverySeverity = "light" | "heavy";
+
+// Health snapshot returned by a surface for diagnostics + (in PR 5) the
+// paint heartbeat watchdog. `lastPaintAt` is `Date.now()`-based; surfaces
+// stamp it from inside their paint loop or `forceRepaint` callback.
+export interface SurfaceHealth {
+  // Whether this surface is currently considered visible by its owner.
+  // For terminals: focused or recently touched.
+  visible: boolean;
+  // Last paint timestamp (ms since epoch). `null` if the surface has never
+  // painted (just-mounted, off-screen, etc.).
+  lastPaintAt: number | null;
+  // GPU resource state. `true` for WebGL surfaces that have logged a
+  // `webgl_context_lost` event since their last successful repaint.
+  contextLost: boolean;
+  // Active renderer pipeline. Surfaces that swap renderers (xterm
+  // WebGL→Canvas2D fallback) update this on swap.
+  rendererMode: SurfaceRendererMode;
+}
+
+export interface RenderableSurface {
+  readonly id: string;
+  readonly kind: SurfaceKind;
+  // Visibility transition. Surfaces use this to gate their internal paint
+  // loops (e.g. cancel an idle RAF when going hidden) and to align their
+  // `visible` health field. Idempotent — repeated calls with the same
+  // value must be cheap.
+  setVisible(visible: boolean): void;
+  // Synchronously schedule a repaint. `severity = heavy` implies the
+  // framebuffer was almost certainly lost (visibility hidden→visible,
+  // sleep/wake) and the surface should additionally rebuild any GPU
+  // resources (xterm: WebGL atlas; canvas: cached glyphs; etc.).
+  forceRepaint(reason: string, severity: SurfaceRecoverySeverity): void;
+  // Diagnostic snapshot. Called by the paint heartbeat watchdog and the
+  // Help → Report Issue snapshot collector.
+  getHealth(): SurfaceHealth;
+}
+
+export interface SurfaceDispatchResult {
+  total: number;
+  refreshed: number;
+  errors: number;
+}

--- a/src/terminal/surfaceRegistry.ts
+++ b/src/terminal/surfaceRegistry.ts
@@ -1,0 +1,121 @@
+// Renderer-process registry of every `RenderableSurface` that wants to
+// participate in render recovery (and, in PR 5, the paint heartbeat
+// watchdog).
+//
+// Surfaces register on mount, unregister on unmount. The recovery
+// listener in `terminalRuntimeStore.installRenderRecoveryListeners` calls
+// `dispatchSurfaceRecovery` instead of walking the terminal-only
+// runtimeRegistry — that lets non-terminal GPU surfaces (Monaco, the
+// canvas graph layer, the Pet) get the same recovery treatment without
+// terminalRuntimeStore needing to know about them.
+
+import type {
+  RenderableSurface,
+  SurfaceDispatchResult,
+  SurfaceHealth,
+  SurfaceKind,
+  SurfaceRecoverySeverity,
+} from "../../shared/render-surface";
+import { recordRenderDiagnostic } from "./renderDiagnostics";
+
+const surfaces = new Map<string, RenderableSurface>();
+
+export function registerSurface(surface: RenderableSurface): () => void {
+  if (surfaces.has(surface.id)) {
+    // A double-register usually indicates a forgotten unregister on the
+    // previous mount. Replace silently — keeping the new surface — and
+    // record so the divergence is visible in diagnostics.
+    recordRenderDiagnostic({
+      kind: "surface_register_replaced",
+      data: { surface_id: surface.id, surface_kind: surface.kind },
+    });
+  }
+  surfaces.set(surface.id, surface);
+  recordRenderDiagnostic({
+    kind: "surface_register",
+    data: {
+      surface_id: surface.id,
+      surface_kind: surface.kind,
+      registry_size: surfaces.size,
+    },
+  });
+  return () => unregisterSurface(surface.id);
+}
+
+export function unregisterSurface(id: string): void {
+  if (!surfaces.delete(id)) return;
+  recordRenderDiagnostic({
+    kind: "surface_unregister",
+    data: { surface_id: id, registry_size: surfaces.size },
+  });
+}
+
+export function getSurface(id: string): RenderableSurface | null {
+  return surfaces.get(id) ?? null;
+}
+
+export function listSurfaces(): RenderableSurface[] {
+  return [...surfaces.values()];
+}
+
+export function listSurfacesByKind(kind: SurfaceKind): RenderableSurface[] {
+  const out: RenderableSurface[] = [];
+  for (const surface of surfaces.values()) {
+    if (surface.kind === kind) out.push(surface);
+  }
+  return out;
+}
+
+export function getSurfaceHealth(id: string): SurfaceHealth | null {
+  const surface = surfaces.get(id);
+  if (!surface) return null;
+  try {
+    return surface.getHealth();
+  } catch {
+    return null;
+  }
+}
+
+// Recovery entry point for `VisibilityObserver.onRecovery`. Walks every
+// registered surface, calls `forceRepaint`, and tallies result counters.
+// Surface-level errors are caught so one bad surface can't block recovery
+// for the rest.
+export function dispatchSurfaceRecovery(
+  reason: string,
+  severity: SurfaceRecoverySeverity,
+): SurfaceDispatchResult {
+  let refreshed = 0;
+  let errors = 0;
+  const total = surfaces.size;
+
+  for (const surface of surfaces.values()) {
+    try {
+      surface.forceRepaint(reason, severity);
+      refreshed += 1;
+    } catch (error) {
+      errors += 1;
+      recordRenderDiagnostic({
+        kind: "surface_force_repaint_failed",
+        data: {
+          surface_id: surface.id,
+          surface_kind: surface.kind,
+          reason,
+          severity,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  recordRenderDiagnostic({
+    kind: "surface_recovery_dispatched",
+    data: { reason, severity, total, refreshed, errors },
+  });
+
+  return { total, refreshed, errors };
+}
+
+// Test-only: clear the registry between cases.
+export function __resetSurfaceRegistryForTesting(): void {
+  surfaces.clear();
+}

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -18,6 +18,16 @@ import {
 } from "./renderDiagnostics";
 import { getVisibilityObserver } from "./visibilityObserver";
 import {
+  registerSurface,
+  unregisterSurface,
+  dispatchSurfaceRecovery,
+} from "./surfaceRegistry";
+import {
+  createTerminalSurface,
+  type TerminalSurfaceHandle,
+  type TerminalSurfaceRuntimeView,
+} from "./terminalSurface";
+import {
   registerTerminal,
   serializeTerminal,
   unregisterTerminal,
@@ -148,6 +158,7 @@ interface ManagedTerminalRuntime {
   selectionPointerCleanup: (() => void) | null;
   serializeAddon: SerializeAddon | null;
   sessionCancel: (() => void) | null;
+  surfaceHandle: TerminalSurfaceHandle | null;
   started: boolean;
   telemetryTimer: ReturnType<typeof setInterval> | null;
   usesAgentRenderer: boolean;
@@ -1131,6 +1142,51 @@ function registerModifierAwareLinkProvider(
   };
 }
 
+function createTerminalSurfaceRuntimeView(
+  runtime: ManagedTerminalRuntime,
+): TerminalSurfaceRuntimeView {
+  return {
+    id: runtime.meta.terminal.id,
+    isLive: () => !runtime.disposed && runtime.xterm !== null,
+    isAttached: () => runtime.attachedContainer !== null,
+    rendererMode: () => {
+      // Map the runtime's preferred renderer to the surface health enum.
+      // The actual active renderer can diverge (xterm WebGL fallback to
+      // Canvas2D on context loss) — PR 8 will surface that distinction
+      // by reading the WebGL pool. For now use the runtime preference.
+      const mode = runtime.rendererMode;
+      if (mode === "webgl" || mode === "dom") return mode;
+      return "unknown";
+    },
+    refreshXterm: () => {
+      const xterm = runtime.xterm;
+      if (!xterm || runtime.disposed) return false;
+      try {
+        xterm.refresh(0, Math.max(0, xterm.rows - 1));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    onPaint: (callback) => {
+      // xterm's `onRender` fires on every render (initial + on every
+      // `refresh` / pty write). Subscribe lazily — if xterm isn't ready
+      // yet we return a no-op disposer; PR 5's heartbeat will tolerate
+      // null `lastPaintAt` until the first real render.
+      const xterm = runtime.xterm;
+      if (!xterm || typeof xterm.onRender !== "function") return () => {};
+      const disposable = xterm.onRender(() => callback());
+      return () => {
+        try {
+          disposable.dispose();
+        } catch {
+          // best-effort; xterm may already be disposed
+        }
+      };
+    },
+  };
+}
+
 function createTerminalRenderer(
   runtime: ManagedTerminalRuntime,
   container: HTMLDivElement,
@@ -1202,6 +1258,12 @@ function createTerminalRenderer(
   runtime.serializeAddon = serializeAddon;
   runtime.searchAddon = searchAddon;
   syncRuntimeRenderer(runtime);
+
+  if (!runtime.surfaceHandle) {
+    const view = createTerminalSurfaceRuntimeView(runtime);
+    runtime.surfaceHandle = createTerminalSurface(view);
+    registerSurface(runtime.surfaceHandle.surface);
+  }
 
   registerTerminal(runtime.meta.terminal.id, xterm, serializeAddon);
   if (runtime.previewAnsi) {
@@ -1515,6 +1577,7 @@ function buildTerminalRuntime(
     selectionPointerCleanup: null,
     serializeAddon: null,
     sessionCancel: null,
+    surfaceHandle: null,
     started: false,
     telemetryTimer: null,
     usesAgentRenderer: false,
@@ -1704,16 +1767,14 @@ function installRenderRecoveryListeners() {
   });
   observer.install();
   observer.onRecovery(({ reason, severity }) => {
-    refreshAllTerminalRenderers(reason);
-    if (severity === "heavy") {
-      // WebGL canvases lose their framebuffer when the page is genuinely
-      // hidden (sleep/wake, minimize, OS Space switch). For light triggers
-      // (bare window.focus where the page may have just briefly lost focus)
-      // a refresh is enough. If WebGL's renderer state is corrupted,
-      // clearing the atlas can still leave new glyphs wrong; cycling the
-      // addon matches the user-visible DOM -> WebGL recovery path.
-      resetWebGL(undefined, reason);
-    }
+    // Recovery now routes through the surface registry instead of walking
+    // `runtimeRegistry` directly. Each registered surface implements its
+    // own paint primitive — terminals refresh xterm + cycle WebGL on
+    // heavy, the canvas graph layer redraws its scene, Monaco calls
+    // `editor.render(true)`, etc. (Non-terminal surfaces are wired in
+    // PR 7.) Recording the result counters here makes diagnostics show
+    // how many surfaces participated and how many failed.
+    dispatchSurfaceRecovery(reason, severity);
   });
 }
 
@@ -2086,6 +2147,7 @@ export function focusTerminalRuntime(terminalId: string): boolean {
 
   recordRuntimeDiagnostic(runtime, "terminal_runtime_focus");
   runtime.xterm.focus();
+  runtime.surfaceHandle?.setVisibleHint(true);
   return true;
 }
 
@@ -2096,6 +2158,9 @@ export function blurTerminalRuntime(terminalId: string): boolean {
   }
 
   runtime.xterm.blur();
+  // Don't flip surface visibility on blur — a terminal can be visible
+  // (rendered in its tile) without being keyboard-focused. PR 7 will
+  // wire visibility transitions from the actual mount/unmount path.
   return true;
 }
 
@@ -2196,6 +2261,12 @@ export function destroyTerminalRuntime(
     void window.termcanvas.terminal.destroy(ptyId).catch((error) => {
       console.error(`[terminalRuntime] failed to destroy PTY ${ptyId}:`, error);
     });
+  }
+
+  if (runtime.surfaceHandle) {
+    unregisterSurface(terminalId);
+    runtime.surfaceHandle.dispose();
+    runtime.surfaceHandle = null;
   }
 
   runtimeRegistry.delete(terminalId);

--- a/src/terminal/terminalSurface.ts
+++ b/src/terminal/terminalSurface.ts
@@ -1,0 +1,110 @@
+// Per-terminal `RenderableSurface` adapter.
+//
+// Wraps a `ManagedTerminalRuntime` so the surface registry can drive
+// recovery (and, in PR 5, the paint heartbeat watchdog) without having
+// to know anything about xterm internals. Each runtime owns exactly one
+// surface across its lifetime: attached on `startTerminalRuntime`,
+// detached on `destroyTerminalRuntime`.
+
+import type {
+  RenderableSurface,
+  SurfaceHealth,
+  SurfaceRecoverySeverity,
+  SurfaceRendererMode,
+} from "../../shared/render-surface";
+import { recordRenderDiagnostic } from "./renderDiagnostics";
+import { resetWebGL } from "./webglContextPool";
+
+export interface TerminalSurfaceRuntimeView {
+  readonly id: string;
+  // True when the xterm instance is mounted and the runtime hasn't been
+  // disposed. Used as the floor of `health.visible`.
+  isLive(): boolean;
+  // Whether the runtime currently has an attached container — i.e. is
+  // expected to be painting in the live tile (vs parked offscreen).
+  isAttached(): boolean;
+  rendererMode(): SurfaceRendererMode;
+  // Force xterm to repaint. Returns false if the runtime is mid-disposal.
+  refreshXterm(): boolean;
+  // Subscribe to xterm's onRender event, used for paint heartbeat. Must
+  // return a dispose fn. Implementations may return a no-op disposer if
+  // the underlying xterm hasn't been constructed yet.
+  onPaint(callback: () => void): () => void;
+}
+
+export interface TerminalSurfaceHandle {
+  surface: RenderableSurface;
+  setVisibleHint(visible: boolean): void;
+  markContextLost(): void;
+  dispose(): void;
+}
+
+export function createTerminalSurface(
+  view: TerminalSurfaceRuntimeView,
+): TerminalSurfaceHandle {
+  let visibleHint = true;
+  let lastPaintAt: number | null = null;
+  let contextLost = false;
+
+  const paintDispose = view.onPaint(() => {
+    lastPaintAt = Date.now();
+    if (contextLost) {
+      // A successful paint after a context-loss event proves the surface
+      // recovered. Clear the flag so health stops reporting stale loss.
+      contextLost = false;
+    }
+  });
+
+  const surface: RenderableSurface = {
+    id: view.id,
+    kind: "terminal",
+    setVisible(visible: boolean): void {
+      if (visibleHint === visible) return;
+      visibleHint = visible;
+      recordRenderDiagnostic({
+        kind: "terminal_surface_visibility",
+        terminalId: view.id,
+        data: { visible },
+      });
+    },
+    forceRepaint(reason: string, severity: SurfaceRecoverySeverity): void {
+      const refreshed = view.refreshXterm();
+      recordRenderDiagnostic({
+        kind: "terminal_surface_force_repaint",
+        terminalId: view.id,
+        data: { reason, severity, refreshed },
+      });
+      if (severity === "heavy") {
+        // The framebuffer was almost certainly lost (visibility transition,
+        // sleep/wake). Cycling the WebGL addon mirrors the previous
+        // recovery path and rebuilds the texture atlas.
+        resetWebGL(view.id, reason);
+      }
+    },
+    getHealth(): SurfaceHealth {
+      return {
+        visible: visibleHint && view.isLive() && view.isAttached(),
+        lastPaintAt,
+        contextLost,
+        rendererMode: view.rendererMode(),
+      };
+    },
+  };
+
+  return {
+    surface,
+    setVisibleHint(visible: boolean): void {
+      surface.setVisible(visible);
+    },
+    markContextLost(): void {
+      contextLost = true;
+    },
+    dispose(): void {
+      try {
+        paintDispose();
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}

--- a/tests/surface-registry.test.ts
+++ b/tests/surface-registry.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  __resetSurfaceRegistryForTesting,
+  dispatchSurfaceRecovery,
+  getSurface,
+  getSurfaceHealth,
+  listSurfaces,
+  listSurfacesByKind,
+  registerSurface,
+  unregisterSurface,
+} from "../src/terminal/surfaceRegistry.ts";
+import type {
+  RenderableSurface,
+  SurfaceHealth,
+  SurfaceKind,
+  SurfaceRecoverySeverity,
+} from "../shared/render-surface.ts";
+
+interface FakeSurfaceController {
+  surface: RenderableSurface;
+  visibleCalls: boolean[];
+  repaintCalls: Array<{ reason: string; severity: SurfaceRecoverySeverity }>;
+  health: SurfaceHealth;
+}
+
+function makeFake(
+  id: string,
+  kind: SurfaceKind = "terminal",
+  health: Partial<SurfaceHealth> = {},
+): FakeSurfaceController {
+  const visibleCalls: boolean[] = [];
+  const repaintCalls: FakeSurfaceController["repaintCalls"] = [];
+  const fullHealth: SurfaceHealth = {
+    visible: true,
+    lastPaintAt: null,
+    contextLost: false,
+    rendererMode: "webgl",
+    ...health,
+  };
+  const surface: RenderableSurface = {
+    id,
+    kind,
+    setVisible(v) {
+      visibleCalls.push(v);
+    },
+    forceRepaint(reason, severity) {
+      repaintCalls.push({ reason, severity });
+    },
+    getHealth() {
+      return fullHealth;
+    },
+  };
+  return { surface, visibleCalls, repaintCalls, health: fullHealth };
+}
+
+test("registerSurface adds to list and returns dispose fn", () => {
+  __resetSurfaceRegistryForTesting();
+  const a = makeFake("a");
+  const dispose = registerSurface(a.surface);
+
+  assert.equal(listSurfaces().length, 1);
+  assert.equal(getSurface("a"), a.surface);
+  assert.deepEqual(listSurfacesByKind("terminal"), [a.surface]);
+  assert.deepEqual(listSurfacesByKind("monaco"), []);
+
+  dispose();
+  assert.equal(listSurfaces().length, 0);
+  assert.equal(getSurface("a"), null);
+});
+
+test("registerSurface replaces silently on duplicate id", () => {
+  __resetSurfaceRegistryForTesting();
+  const a1 = makeFake("a");
+  const a2 = makeFake("a");
+  registerSurface(a1.surface);
+  registerSurface(a2.surface);
+
+  assert.equal(listSurfaces().length, 1);
+  assert.equal(getSurface("a"), a2.surface);
+});
+
+test("dispatchSurfaceRecovery walks every surface and tallies counters", () => {
+  __resetSurfaceRegistryForTesting();
+  const a = makeFake("a");
+  const b = makeFake("b", "monaco");
+  registerSurface(a.surface);
+  registerSurface(b.surface);
+
+  const result = dispatchSurfaceRecovery("test", "heavy");
+
+  assert.deepEqual(result, { total: 2, refreshed: 2, errors: 0 });
+  assert.deepEqual(a.repaintCalls, [{ reason: "test", severity: "heavy" }]);
+  assert.deepEqual(b.repaintCalls, [{ reason: "test", severity: "heavy" }]);
+});
+
+test("dispatchSurfaceRecovery isolates a throwing surface from the rest", () => {
+  __resetSurfaceRegistryForTesting();
+  const a = makeFake("a");
+  const broken: RenderableSurface = {
+    id: "broken",
+    kind: "terminal",
+    setVisible() {},
+    forceRepaint() {
+      throw new Error("boom");
+    },
+    getHealth() {
+      return {
+        visible: false,
+        lastPaintAt: null,
+        contextLost: true,
+        rendererMode: "unknown",
+      };
+    },
+  };
+  const c = makeFake("c");
+  registerSurface(a.surface);
+  registerSurface(broken);
+  registerSurface(c.surface);
+
+  const result = dispatchSurfaceRecovery("test", "light");
+
+  assert.equal(result.total, 3);
+  assert.equal(result.refreshed, 2);
+  assert.equal(result.errors, 1);
+  assert.deepEqual(a.repaintCalls, [{ reason: "test", severity: "light" }]);
+  assert.deepEqual(c.repaintCalls, [{ reason: "test", severity: "light" }]);
+});
+
+test("getSurfaceHealth returns null for unknown ids and the result for known", () => {
+  __resetSurfaceRegistryForTesting();
+  const a = makeFake("a", "terminal", { visible: true, contextLost: true });
+  registerSurface(a.surface);
+
+  assert.equal(getSurfaceHealth("missing"), null);
+  assert.deepEqual(getSurfaceHealth("a"), a.health);
+});
+
+test("unregisterSurface removes it from listSurfacesByKind", () => {
+  __resetSurfaceRegistryForTesting();
+  const a = makeFake("a", "terminal");
+  const b = makeFake("b", "terminal");
+  const c = makeFake("c", "monaco");
+  registerSurface(a.surface);
+  registerSurface(b.surface);
+  registerSurface(c.surface);
+
+  unregisterSurface("a");
+
+  assert.deepEqual(
+    listSurfacesByKind("terminal").map((s) => s.id),
+    ["b"],
+  );
+  assert.deepEqual(
+    listSurfacesByKind("monaco").map((s) => s.id),
+    ["c"],
+  );
+});

--- a/tests/terminal-surface.test.ts
+++ b/tests/terminal-surface.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createTerminalSurface, type TerminalSurfaceRuntimeView } from "../src/terminal/terminalSurface.ts";
+
+interface FakeRuntime {
+  id: string;
+  live: boolean;
+  attached: boolean;
+  rendererMode: "webgl" | "canvas" | "dom" | "unknown";
+  refreshCalls: number;
+  refreshShouldFail: boolean;
+  paintCallbacks: Array<() => void>;
+}
+
+function makeView(runtime: FakeRuntime): TerminalSurfaceRuntimeView {
+  return {
+    id: runtime.id,
+    isLive: () => runtime.live,
+    isAttached: () => runtime.attached,
+    rendererMode: () => runtime.rendererMode,
+    refreshXterm: () => {
+      runtime.refreshCalls += 1;
+      return !runtime.refreshShouldFail;
+    },
+    onPaint: (cb) => {
+      runtime.paintCallbacks.push(cb);
+      return () => {
+        runtime.paintCallbacks = runtime.paintCallbacks.filter((c) => c !== cb);
+      };
+    },
+  };
+}
+
+function fakeRuntime(): FakeRuntime {
+  return {
+    id: "term-1",
+    live: true,
+    attached: true,
+    rendererMode: "webgl",
+    refreshCalls: 0,
+    refreshShouldFail: false,
+    paintCallbacks: [],
+  };
+}
+
+test("forceRepaint refreshes xterm and only resets WebGL on heavy", () => {
+  const runtime = fakeRuntime();
+  const handle = createTerminalSurface(makeView(runtime));
+
+  handle.surface.forceRepaint("test_light", "light");
+  assert.equal(runtime.refreshCalls, 1);
+
+  handle.surface.forceRepaint("test_heavy", "heavy");
+  assert.equal(runtime.refreshCalls, 2);
+  // (We can't easily assert the WebGL reset path without the real
+  // webglContextPool — that's covered by the existing
+  // terminal-runtime-store.test.ts integration test. Here we cover the
+  // refresh tally.)
+});
+
+test("getHealth gates visible on live + attached + visibleHint", () => {
+  const runtime = fakeRuntime();
+  const handle = createTerminalSurface(makeView(runtime));
+
+  // Default: visibleHint is true; runtime is live + attached.
+  assert.equal(handle.surface.getHealth().visible, true);
+
+  // Detach the runtime.
+  runtime.attached = false;
+  assert.equal(handle.surface.getHealth().visible, false);
+
+  // Re-attach but set hint to false.
+  runtime.attached = true;
+  handle.setVisibleHint(false);
+  assert.equal(handle.surface.getHealth().visible, false);
+
+  // Re-enable hint.
+  handle.setVisibleHint(true);
+  assert.equal(handle.surface.getHealth().visible, true);
+
+  // Mark not-live (disposed).
+  runtime.live = false;
+  assert.equal(handle.surface.getHealth().visible, false);
+});
+
+test("paint callbacks bump lastPaintAt and clear contextLost", () => {
+  const runtime = fakeRuntime();
+  const handle = createTerminalSurface(makeView(runtime));
+
+  // Initial state.
+  assert.equal(handle.surface.getHealth().lastPaintAt, null);
+
+  handle.markContextLost();
+  assert.equal(handle.surface.getHealth().contextLost, true);
+
+  // Trigger a paint via the subscribed onPaint callback.
+  for (const cb of runtime.paintCallbacks) cb();
+
+  const health = handle.surface.getHealth();
+  assert.ok(
+    health.lastPaintAt !== null && health.lastPaintAt > 0,
+    "lastPaintAt should be set after a paint event",
+  );
+  // A successful paint after a context-loss event clears the flag.
+  assert.equal(health.contextLost, false);
+});
+
+test("rendererMode reflects what the runtime currently reports", () => {
+  const runtime = fakeRuntime();
+  const handle = createTerminalSurface(makeView(runtime));
+
+  assert.equal(handle.surface.getHealth().rendererMode, "webgl");
+
+  runtime.rendererMode = "canvas";
+  assert.equal(handle.surface.getHealth().rendererMode, "canvas");
+});
+
+test("dispose tears down the paint subscription", () => {
+  const runtime = fakeRuntime();
+  const handle = createTerminalSurface(makeView(runtime));
+
+  assert.equal(runtime.paintCallbacks.length, 1);
+
+  handle.dispose();
+
+  assert.equal(runtime.paintCallbacks.length, 0);
+});


### PR DESCRIPTION
## Why

PR 1 (#162) centralized recovery triggers in \`VisibilityObserver\`, but the listener still walked \`runtimeRegistry\` directly — only terminals participated. Monaco / canvas-backed graph layer / Pet are also GPU surfaces that lose framebuffers on \`visibility hidden→visible\`, sleep/wake, and the macOS Space-switch IPC. They had no path back.

This is render-recovery v2 PR 3, the foundation for PR 5 (paint heartbeat) and PR 7 (non-terminal surfaces). Independent of PR 6 (#180).

## What

- \`shared/render-surface.ts\` — \`RenderableSurface\` interface (\`setVisible\`, \`forceRepaint(reason, severity)\`, \`getHealth\`) + \`SurfaceHealth\` shape (\`visible\`, \`lastPaintAt\`, \`contextLost\`, \`rendererMode\`).
- \`src/terminal/surfaceRegistry.ts\` — registry with \`registerSurface\` / \`unregisterSurface\` / \`dispatchSurfaceRecovery(reason, severity)\`.
- \`src/terminal/terminalSurface.ts\` — per-terminal adapter. \`forceRepaint\` does what the old recovery listener did (xterm refresh + WebGL reset on heavy). \`getHealth\` gates \`visible\` on \`live && attached && visibleHint\`.
- \`terminalRuntimeStore\` — surface adapter created at the end of \`createTerminalRenderer\` (when xterm is ready), disposed in \`destroyTerminalRuntime\`. Recovery listener now does \`dispatchSurfaceRecovery(reason, severity)\` instead of walking \`runtimeRegistry\`.

\`xterm.onRender\` feeds \`lastPaintAt\` automatically, so PR 5's heartbeat will read accurate paint timestamps without any new instrumentation in the runtime.

## Files

- \`shared/render-surface.ts\` — new
- \`src/terminal/surfaceRegistry.ts\` — new
- \`src/terminal/terminalSurface.ts\` — new
- \`src/terminal/terminalRuntimeStore.ts\` — wire surface lifecycle + switch recovery dispatch
- \`tests/surface-registry.test.ts\` — 6 tests (registration, dispatch tally, error isolation, duplicate replace, kind filter)
- \`tests/terminal-surface.test.ts\` — 5 tests (visibility gating, paint subscription, contextLost flag, rendererMode passthrough, dispose)

## Verification

- \`tsc --noEmit\` clean
- \`tsx --test tests/surface-registry.test.ts tests/terminal-surface.test.ts\` → 11/11 pass

## macOS QA (cannot run here)

- [ ] After Space switch, a registered terminal surface still recovers (pre-existing behavior preserved).
- [ ] With diagnostics enabled, ledger shows \`surface_recovery_dispatched\` events with \`{total, refreshed, errors}\` after each visibility transition.
- [ ] No regression in the \"Cmd+Tab dedup\" QA from PR #162 — \`visibility_observer_skipped\` still fires for coalesced events.

## Risks

- \`refreshAllTerminalRenderers\` is no longer called from the recovery listener (it's still exported for any external caller; \`grep\` finds none in this PR's tree). If something downstream depends on it being called on visibility changes, that path breaks. The new surface dispatch covers the same work.
- The terminal adapter's \`contextLost\` flag is wired but not yet populated — webglContextPool's \`onContextLoss\` doesn't push to surfaces in this PR. PR 8 will close that loop. Field stays \`false\` until then; documented in code.
- Surface visibility is gated on \`attachedContainer !== null\`, not on the actual \`IntersectionObserver\`. Off-screen-but-attached terminals still report \`visible: true\`. Acceptable for PR 3; the heartbeat (PR 5) tolerates it because it only fires on \`document.visibilityState === \"visible\"\` anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)