### PR TITLE
feat(render): paint heartbeat watchdog (depends on #181)

### DIFF
--- a/src/terminal/paintHeartbeat.ts
+++ b/src/terminal/paintHeartbeat.ts
@@ -1,0 +1,183 @@
+// Paint heartbeat watchdog.
+//
+// `VisibilityObserver` dispatches recovery on *external* signals
+// (visibilitychange, page lifecycle resume, lifecycle IPC, window focus).
+// Those cover the macOS-Space-switch case and most occlusion paths, but
+// not "the surface stopped painting while it's still considered
+// visible". Causes include xterm's IntersectionObserver mistakenly
+// thinking the tile is offscreen, a stuck WebGL pipeline that lost
+// context but didn't fire the loss event, or a renderer-side crash that
+// silently broke RAF.
+//
+// The watchdog ticks every `intervalMs` (default 2 s). On each tick:
+//  1. If `document.visibilityState !== "visible"`, no paints are
+//     expected — skip. (We rely on visibilitychange to trigger recovery
+//     when the page returns to visible.)
+//  2. Walk the surface registry for surfaces whose `health.visible` is
+//     true.
+//  3. If a surface's `lastPaintAt` is older than `stallThresholdMs`
+//     (default 5 s), or it has never painted despite being visible for
+//     longer than that, dispatch through the observer with
+//     `"paint_heartbeat_stall"` at `"heavy"` severity.
+//
+// We dispatch through the observer (not the surface registry directly)
+// so the dedup logic and the diagnostic stream stay shared with the
+// other recovery sources. Same dispatch path = same fix landing in one
+// place.
+
+import type { RenderableSurface } from "../../shared/render-surface";
+import type { VisibilityObserver } from "./visibilityObserver";
+
+export interface PaintHeartbeatDeps {
+  observer: VisibilityObserver;
+  listSurfaces: () => RenderableSurface[];
+  documentVisible: () => boolean;
+  now?: () => number;
+  recordDiagnostic?: (event: { kind: string; data?: Record<string, unknown> }) => void;
+  intervalMs?: number;
+  stallThresholdMs?: number;
+  cooldownMs?: number;
+  setIntervalFn?: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearIntervalFn?: (id: ReturnType<typeof setInterval>) => void;
+}
+
+const DEFAULT_INTERVAL_MS = 2_000;
+const DEFAULT_STALL_THRESHOLD_MS = 5_000;
+// Don't fire two heartbeat dispatches closer than this. The
+// VisibilityObserver has its own 200 ms dedup, but heartbeat ticks are
+// 2 s apart so per-source rate limiting is needed to avoid pile-on while
+// the recovery is still in flight.
+const DEFAULT_COOLDOWN_MS = 10_000;
+
+export class PaintHeartbeatWatchdog {
+  private readonly observer: VisibilityObserver;
+  private readonly listSurfaces: () => RenderableSurface[];
+  private readonly documentVisible: () => boolean;
+  private readonly now: () => number;
+  private readonly recordDiagnostic?: PaintHeartbeatDeps["recordDiagnostic"];
+  private readonly intervalMs: number;
+  private readonly stallThresholdMs: number;
+  private readonly cooldownMs: number;
+  private readonly setIntervalFn: NonNullable<PaintHeartbeatDeps["setIntervalFn"]>;
+  private readonly clearIntervalFn: NonNullable<PaintHeartbeatDeps["clearIntervalFn"]>;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  // First time each surface id was observed visible without a recent
+  // paint. Used to detect "never painted yet" stalls without a separate
+  // mountedAt field on the surface.
+  private firstVisibleSeenAt = new Map<string, number>();
+  private lastDispatchAt = 0;
+
+  constructor(deps: PaintHeartbeatDeps) {
+    this.observer = deps.observer;
+    this.listSurfaces = deps.listSurfaces;
+    this.documentVisible = deps.documentVisible;
+    this.now = deps.now ?? Date.now;
+    this.recordDiagnostic = deps.recordDiagnostic;
+    this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.stallThresholdMs = deps.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS;
+    this.cooldownMs = deps.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+    this.setIntervalFn = deps.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+    this.clearIntervalFn = deps.clearIntervalFn ?? ((id) => clearInterval(id));
+  }
+
+  start(): void {
+    if (this.timer !== null) return;
+    this.timer = this.setIntervalFn(() => this.tick(), this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      this.clearIntervalFn(this.timer);
+      this.timer = null;
+    }
+    this.firstVisibleSeenAt.clear();
+  }
+
+  // Visible for tests.
+  tick(): void {
+    if (!this.documentVisible()) {
+      // No paints expected; clear "first visible" tracking so the next
+      // visible→hidden→visible cycle doesn't immediately fire a stall
+      // based on a stale clock from before the page was hidden.
+      this.firstVisibleSeenAt.clear();
+      return;
+    }
+
+    const now = this.now();
+    const stalled: Array<{
+      id: string;
+      kind: string;
+      reason: "no_paint_yet" | "paint_stale";
+      ageMs: number;
+    }> = [];
+
+    for (const surface of this.listSurfaces()) {
+      let health;
+      try {
+        health = surface.getHealth();
+      } catch {
+        continue;
+      }
+      if (!health.visible) {
+        this.firstVisibleSeenAt.delete(surface.id);
+        continue;
+      }
+
+      if (health.lastPaintAt !== null) {
+        const age = now - health.lastPaintAt;
+        if (age >= this.stallThresholdMs) {
+          stalled.push({
+            id: surface.id,
+            kind: surface.kind,
+            reason: "paint_stale",
+            ageMs: age,
+          });
+        }
+        // Once a surface has actually painted, we no longer need to
+        // track "first visible".
+        this.firstVisibleSeenAt.delete(surface.id);
+        continue;
+      }
+
+      // Never painted: track when we first noticed it visible. If still
+      // unpainted past the stall threshold, treat as stalled.
+      const firstSeen =
+        this.firstVisibleSeenAt.get(surface.id) ??
+        (this.firstVisibleSeenAt.set(surface.id, now), now);
+      const age = now - firstSeen;
+      if (age >= this.stallThresholdMs) {
+        stalled.push({
+          id: surface.id,
+          kind: surface.kind,
+          reason: "no_paint_yet",
+          ageMs: age,
+        });
+      }
+    }
+
+    if (stalled.length === 0) return;
+
+    if (now - this.lastDispatchAt < this.cooldownMs) {
+      this.recordDiagnostic?.({
+        kind: "paint_heartbeat_stall_skipped_cooldown",
+        data: {
+          stalled_count: stalled.length,
+          ms_since_last_dispatch: now - this.lastDispatchAt,
+        },
+      });
+      return;
+    }
+
+    this.lastDispatchAt = now;
+    this.recordDiagnostic?.({
+      kind: "paint_heartbeat_stall_detected",
+      data: {
+        stalled_count: stalled.length,
+        stalled,
+      },
+    });
+
+    this.observer.dispatch("paint_heartbeat_stall", "heavy");
+  }
+}

--- a/src/terminal/terminalRuntimeStore.ts
+++ b/src/terminal/terminalRuntimeStore.ts
@@ -21,7 +21,9 @@ import {
   registerSurface,
   unregisterSurface,
   dispatchSurfaceRecovery,
+  listSurfaces,
 } from "./surfaceRegistry";
+import { PaintHeartbeatWatchdog } from "./paintHeartbeat";
 import {
   createTerminalSurface,
   type TerminalSurfaceHandle,
@@ -1776,6 +1778,19 @@ function installRenderRecoveryListeners() {
     // how many surfaces participated and how many failed.
     dispatchSurfaceRecovery(reason, severity);
   });
+
+  // Heartbeat watchdog catches the "page is visible but no paint
+  // happened in 5 s" case the visibility-event signals can't see
+  // (xterm IntersectionObserver false negative, stuck WebGL pipeline
+  // that didn't fire context-loss, silent renderer breakage).
+  const heartbeat = new PaintHeartbeatWatchdog({
+    observer,
+    listSurfaces,
+    documentVisible: () => document.visibilityState === "visible",
+    recordDiagnostic: (event) =>
+      recordRenderDiagnostic({ kind: event.kind, data: event.data }),
+  });
+  heartbeat.start();
 }
 
 function startTerminalRuntime(runtime: ManagedTerminalRuntime) {

--- a/tests/paint-heartbeat.test.ts
+++ b/tests/paint-heartbeat.test.ts
@@ -1,0 +1,285 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PaintHeartbeatWatchdog } from "../src/terminal/paintHeartbeat.ts";
+import type {
+  RenderableSurface,
+  SurfaceHealth,
+} from "../shared/render-surface.ts";
+import { VisibilityObserver } from "../src/terminal/visibilityObserver.ts";
+
+interface FakeSurface extends RenderableSurface {
+  setHealth(next: Partial<SurfaceHealth>): void;
+}
+
+function makeSurface(id: string, initial: SurfaceHealth): FakeSurface {
+  let health = { ...initial };
+  return {
+    id,
+    kind: "terminal",
+    setVisible() {},
+    forceRepaint() {
+      health = { ...health, lastPaintAt: Date.now() };
+    },
+    getHealth() {
+      return { ...health };
+    },
+    setHealth(next) {
+      health = { ...health, ...next };
+    },
+  };
+}
+
+interface Harness {
+  observer: VisibilityObserver;
+  observerDispatched: Array<{ reason: string; severity: string }>;
+  diagnostics: Array<{ kind: string; data?: Record<string, unknown> }>;
+  watchdog: PaintHeartbeatWatchdog;
+  documentVisibleRef: { value: boolean };
+  nowRef: { value: number };
+  surfaces: FakeSurface[];
+}
+
+function makeHarness(opts?: {
+  intervalMs?: number;
+  stallThresholdMs?: number;
+  cooldownMs?: number;
+}): Harness {
+  const observerDispatched: Harness["observerDispatched"] = [];
+  const diagnostics: Harness["diagnostics"] = [];
+  const documentVisibleRef = { value: true };
+  const nowRef = { value: 1_000_000 };
+  const surfaces: FakeSurface[] = [];
+
+  const observer = new VisibilityObserver({
+    now: () => nowRef.value,
+    dedupWindowMs: 0,
+  });
+  observer.onRecovery((event) => {
+    observerDispatched.push({ reason: event.reason, severity: event.severity });
+  });
+
+  const watchdog = new PaintHeartbeatWatchdog({
+    observer,
+    listSurfaces: () => surfaces,
+    documentVisible: () => documentVisibleRef.value,
+    now: () => nowRef.value,
+    recordDiagnostic: (event) => diagnostics.push(event),
+    intervalMs: opts?.intervalMs ?? 2000,
+    stallThresholdMs: opts?.stallThresholdMs ?? 5000,
+    cooldownMs: opts?.cooldownMs ?? 10000,
+    setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+    clearIntervalFn: () => {},
+  });
+
+  return {
+    observer,
+    observerDispatched,
+    diagnostics,
+    watchdog,
+    documentVisibleRef,
+    nowRef,
+    surfaces,
+  };
+}
+
+test("no dispatch when no surfaces are registered", () => {
+  const h = makeHarness();
+  h.watchdog.tick();
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("no dispatch when document is hidden — no paints expected", () => {
+  const h = makeHarness();
+  h.documentVisibleRef.value = false;
+
+  h.surfaces.push(
+    makeSurface("a", {
+      visible: true,
+      lastPaintAt: h.nowRef.value - 60_000, // very stale
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick();
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("dispatches paint_heartbeat_stall when a visible surface's lastPaintAt is older than threshold", () => {
+  const h = makeHarness({ stallThresholdMs: 5000 });
+
+  h.surfaces.push(
+    makeSurface("stuck", {
+      visible: true,
+      lastPaintAt: h.nowRef.value - 6000,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick();
+  assert.deepEqual(h.observerDispatched, [
+    { reason: "paint_heartbeat_stall", severity: "heavy" },
+  ]);
+  const detected = h.diagnostics.find(
+    (d) => d.kind === "paint_heartbeat_stall_detected",
+  );
+  assert.ok(detected);
+  assert.equal(
+    (detected!.data!.stalled as Array<{ id: string }>)[0]!.id,
+    "stuck",
+  );
+});
+
+test("does not dispatch when surface paints are recent", () => {
+  const h = makeHarness({ stallThresholdMs: 5000 });
+  h.surfaces.push(
+    makeSurface("ok", {
+      visible: true,
+      lastPaintAt: h.nowRef.value - 1000,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+  h.watchdog.tick();
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("hidden surfaces are skipped even when their lastPaintAt is stale", () => {
+  const h = makeHarness({ stallThresholdMs: 5000 });
+  h.surfaces.push(
+    makeSurface("offscreen", {
+      visible: false,
+      lastPaintAt: h.nowRef.value - 60_000,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+  h.watchdog.tick();
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("never-painted surface dispatches once the visible window exceeds threshold", () => {
+  const h = makeHarness({ stallThresholdMs: 5000, cooldownMs: 0 });
+  h.surfaces.push(
+    makeSurface("fresh", {
+      visible: true,
+      lastPaintAt: null,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick(); // first tick: starts tracking
+  assert.deepEqual(h.observerDispatched, []);
+
+  h.nowRef.value += 6000;
+  h.watchdog.tick(); // second tick: 6 s past first-seen, stalled
+  assert.deepEqual(h.observerDispatched, [
+    { reason: "paint_heartbeat_stall", severity: "heavy" },
+  ]);
+});
+
+test("cooldown prevents rapid re-dispatch even if stall persists", () => {
+  const h = makeHarness({ stallThresholdMs: 5000, cooldownMs: 10000 });
+  h.surfaces.push(
+    makeSurface("stuck", {
+      visible: true,
+      lastPaintAt: h.nowRef.value - 6000,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick();
+  assert.equal(h.observerDispatched.length, 1);
+
+  // 5 s later, surface still stalled — but we're in cooldown.
+  h.nowRef.value += 5000;
+  h.surfaces[0]!.setHealth({ lastPaintAt: h.nowRef.value - 11_000 });
+  h.watchdog.tick();
+  assert.equal(h.observerDispatched.length, 1);
+  assert.ok(
+    h.diagnostics.some(
+      (d) => d.kind === "paint_heartbeat_stall_skipped_cooldown",
+    ),
+  );
+
+  // 11 s after first dispatch, cooldown expires.
+  h.nowRef.value += 6000;
+  h.surfaces[0]!.setHealth({ lastPaintAt: h.nowRef.value - 12_000 });
+  h.watchdog.tick();
+  assert.equal(h.observerDispatched.length, 2);
+});
+
+test("a paint update inside the stall threshold window clears the dispatch trigger", () => {
+  const h = makeHarness({ stallThresholdMs: 5000, cooldownMs: 0 });
+  h.surfaces.push(
+    makeSurface("recovers", {
+      visible: true,
+      lastPaintAt: null,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick(); // first-seen tracked
+  h.nowRef.value += 4000;
+  h.surfaces[0]!.setHealth({ lastPaintAt: h.nowRef.value }); // surface paints
+  h.nowRef.value += 100;
+  h.watchdog.tick();
+
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("transition document hidden → visible clears stale first-seen tracking", () => {
+  const h = makeHarness({ stallThresholdMs: 5000, cooldownMs: 0 });
+  h.surfaces.push(
+    makeSurface("a", {
+      visible: true,
+      lastPaintAt: null,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick(); // begin tracking first-seen at T
+
+  h.documentVisibleRef.value = false;
+  h.nowRef.value += 60_000;
+  h.watchdog.tick(); // hidden → resets tracking
+
+  h.documentVisibleRef.value = true;
+  h.watchdog.tick(); // tracking restarts at this moment, no stall yet
+  assert.deepEqual(h.observerDispatched, []);
+
+  h.nowRef.value += 4000;
+  h.watchdog.tick(); // 4 s after restart, still under threshold
+  assert.deepEqual(h.observerDispatched, []);
+});
+
+test("a misbehaving getHealth on one surface doesn't kill the tick for others", () => {
+  const h = makeHarness({ stallThresholdMs: 5000 });
+  const broken: RenderableSurface = {
+    id: "broken",
+    kind: "terminal",
+    setVisible() {},
+    forceRepaint() {},
+    getHealth() {
+      throw new Error("nope");
+    },
+  };
+  h.surfaces.push(broken as FakeSurface);
+  h.surfaces.push(
+    makeSurface("stuck", {
+      visible: true,
+      lastPaintAt: h.nowRef.value - 6000,
+      contextLost: false,
+      rendererMode: "webgl",
+    }),
+  );
+
+  h.watchdog.tick();
+  assert.equal(h.observerDispatched.length, 1);
+});


### PR DESCRIPTION
## Why

Render-recovery v2 PR 5. Stacks on PR #181 (surface registry).

\`VisibilityObserver\` covers external occlusion signals — visibilitychange, page lifecycle resume, lifecycle IPC, window focus. None of those fire when a surface **silently stops painting while still visible**. Causes seen in the wild: xterm IntersectionObserver false negative on tile resize, WebGL pipeline stuck without firing context-loss, renderer-side error that broke the RAF chain.

## What

\`PaintHeartbeatWatchdog\` ticks every 2 s. On each tick:
1. If \`document.visibilityState !== \"visible\"\`, skip — and clear any \"first-seen\" tracking so a later hidden→visible doesn't false-positive on a clock that ran during the hidden period.
2. Walk the surface registry. For each surface with \`health.visible === true\`:
   - \`lastPaintAt !== null && now - lastPaintAt >= 5 s\` → stalled (paint_stale).
   - \`lastPaintAt === null\` and surface has been visible for >5 s → stalled (no_paint_yet).
3. If any stalled and we're past the 10 s cooldown, dispatch \`observer.dispatch(\"paint_heartbeat_stall\", \"heavy\")\`.

The observer routes through the existing recovery callback (PR #181's \`dispatchSurfaceRecovery\`) so the watchdog gets the same WebGL-reset + atlas-rebuild treatment as a Space-switch.

The 10 s cooldown is intentional — VisibilityObserver's own dedup is 200 ms (designed for the visibilitychange + window.focus + IPC trio firing within the same OS event), too tight for a 2 s tick cadence.

## Files

- \`src/terminal/paintHeartbeat.ts\` — \`PaintHeartbeatWatchdog\` class
- \`src/terminal/terminalRuntimeStore.ts\` — start the watchdog inside \`installRenderRecoveryListeners\`
- \`tests/paint-heartbeat.test.ts\` — 10 tests

## Verification

- \`tsc --noEmit\` clean
- \`tsx --test tests/paint-heartbeat.test.ts\` → 10/10 pass

## macOS QA (cannot run here)

- [ ] Idle terminal Space switch + return → ledger contains either a normal \`visibility_change_to_visible\` recovery (fast path) **or** a \`paint_heartbeat_stall\` if visibility never fired. Either is acceptable.
- [ ] During heavy continuous painting (running \`yes\`), tick log should never report \`paint_heartbeat_stall_detected\`.
- [ ] After a forced WebGL context-loss (DevTools \`getContext('webgl').getExtension('WEBGL_lose_context').loseContext()\`), heartbeat should detect the stall and trigger recovery within ~7 s (5 s threshold + up to 2 s for next tick).

## Risks

- **Cooldown tuning**: 10 s is a guess. If stalls cluster within 10 s and recovery hasn't actually worked, we drop subsequent diagnostics events (\`paint_heartbeat_stall_skipped_cooldown\` is recorded). Reasonable balance; tweakable from the call site.
- **\`visible: true\` is approximate**: PR 3 gates surface visibility on \`live && attached && visibleHint\`, not on the actual IntersectionObserver. An attached-but-offscreen terminal will report visible and a stall will fire. Acceptable because we still gate the whole tick on \`document.visibilityState === \"visible\"\`, and for fully-occluded windows that's false.
- **Stacks on PR #181**: cannot merge until that lands. PR base set accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)